### PR TITLE
refactor: ♻️ improve error handling and extract test helpers

### DIFF
--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -12,6 +12,13 @@ pub enum AppError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    /// Wrapper for all `sqlx::Error` values.
+    ///
+    /// We intentionally treat all SQLx errors the same at the HTTP boundary,
+    /// returning `500 Internal Server Error`, except for constraint violations
+    /// (unique/foreign key) which are detected and converted to `Conflict`.
+    /// Higher layers using `fetch_optional` are responsible for translating
+    /// "row not found" conditions into `AppError::NotFound`.
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
 
@@ -31,6 +38,10 @@ impl IntoResponse for AppError {
                 let err_str = err.to_string();
                 if err_str.contains("UNIQUE constraint failed") {
                     return AppError::Conflict("resource already exists".to_string())
+                        .into_response();
+                }
+                if err_str.contains("FOREIGN KEY constraint failed") {
+                    return AppError::Conflict("referenced resource does not exist".to_string())
                         .into_response();
                 }
                 (

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -9,6 +9,12 @@ pub enum AppError {
     #[error("validation error: {0}")]
     Validation(String),
 
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }
@@ -18,6 +24,20 @@ impl IntoResponse for AppError {
         let (status, message) = match &self {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             AppError::Validation(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            AppError::Database(err) => {
+                tracing::error!(%err, "database error");
+                // Check for constraint violations
+                let err_str = err.to_string();
+                if err_str.contains("UNIQUE constraint failed") {
+                    return AppError::Conflict("resource already exists".to_string())
+                        .into_response();
+                }
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "database error".to_string(),
+                )
+            }
             AppError::Internal(err) => {
                 tracing::error!(%err, "internal server error");
                 (

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,8 @@ pub mod handlers;
 pub mod models;
 pub mod openapi;
 pub mod services;
+#[cfg(test)]
+pub mod test_helpers;
 pub mod ws;
 
 use std::sync::Arc;

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -45,8 +45,7 @@ pub async fn add_member(
     .bind(&req.role)
     .bind(now)
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     Ok(ProjectMember {
         project_id,
@@ -71,8 +70,7 @@ pub async fn get_member(
     .bind(project_id.to_string())
     .bind(user_id.to_string())
     .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -96,8 +94,7 @@ pub async fn list_members(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<
     )
     .bind(project_id.to_string())
     .fetch_all(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     rows.into_iter()
         .map(|r| r.try_into())
@@ -124,8 +121,7 @@ pub async fn update_member_role(
     .bind(project_id.to_string())
     .bind(user_id.to_string())
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     Ok(ProjectMember {
         project_id,
@@ -145,8 +141,7 @@ pub async fn remove_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) -
     .bind(project_id.to_string())
     .bind(user_id.to_string())
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound(format!(
@@ -163,21 +158,7 @@ mod tests {
     use super::*;
     use crate::models::project::CreateProjectRequest;
     use crate::services::project_service;
-    use sqlx::sqlite::SqlitePoolOptions;
-
-    async fn setup_test_db() -> SqlitePool {
-        let pool = SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("Failed to create test database");
-
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-            .expect("Failed to run migrations");
-
-        pool
-    }
+    use crate::test_helpers::setup_test_db;
 
     async fn create_test_project(pool: &SqlitePool) -> Uuid {
         let req = CreateProjectRequest {

--- a/backend/src/services/project_service.rs
+++ b/backend/src/services/project_service.rs
@@ -45,8 +45,7 @@ pub async fn create_project(pool: &SqlitePool, req: &CreateProjectRequest) -> Ap
     .bind(now)
     .bind(now)
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     Ok(Project {
         id,
@@ -67,8 +66,7 @@ pub async fn get_project(pool: &SqlitePool, id: Uuid) -> AppResult<Project> {
     )
     .bind(id.to_string())
     .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -85,8 +83,7 @@ pub async fn list_projects(pool: &SqlitePool) -> AppResult<Vec<Project>> {
         "#,
     )
     .fetch_all(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     rows.into_iter()
         .map(|r| r.try_into())
@@ -120,8 +117,7 @@ pub async fn update_project(
     .bind(now)
     .bind(id.to_string())
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     Ok(Project {
         id,
@@ -141,8 +137,7 @@ pub async fn delete_project(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
     )
     .bind(id.to_string())
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound(format!("project {} not found", id)));
@@ -154,21 +149,7 @@ pub async fn delete_project(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::sqlite::SqlitePoolOptions;
-
-    async fn setup_test_db() -> SqlitePool {
-        let pool = SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("Failed to create test database");
-
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-            .expect("Failed to run migrations");
-
-        pool
-    }
+    use crate::test_helpers::setup_test_db;
 
     #[tokio::test]
     async fn test_create_project_saves_to_db_and_returns() {

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -66,7 +66,7 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
     .bind(now)
     .execute(pool)
     .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    ?;
 
     Ok(Task {
         id,
@@ -94,7 +94,7 @@ pub async fn get_task(pool: &SqlitePool, id: Uuid) -> AppResult<Task> {
     .bind(id.to_string())
     .fetch_optional(pool)
     .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    ?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -114,7 +114,7 @@ pub async fn list_tasks(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<Ta
     .bind(project_id.to_string())
     .fetch_all(pool)
     .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    ?;
 
     rows.into_iter()
         .map(|r| r.try_into())
@@ -152,7 +152,7 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     .bind(id.to_string())
     .execute(pool)
     .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    ?;
 
     Ok(Task {
         id,
@@ -178,8 +178,7 @@ pub async fn delete_task(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
     )
     .bind(id.to_string())
     .execute(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.into()))?;
+    .await?;
 
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound(format!("task {} not found", id)));
@@ -193,21 +192,7 @@ mod tests {
     use super::*;
     use crate::models::project::CreateProjectRequest;
     use crate::services::project_service;
-    use sqlx::sqlite::SqlitePoolOptions;
-
-    async fn setup_test_db() -> SqlitePool {
-        let pool = SqlitePoolOptions::new()
-            .connect("sqlite::memory:")
-            .await
-            .expect("Failed to create test database");
-
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-            .expect("Failed to run migrations");
-
-        pool
-    }
+    use crate::test_helpers::setup_test_db;
 
     async fn create_test_project(pool: &SqlitePool) -> Uuid {
         let req = CreateProjectRequest {

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -65,8 +65,7 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
     .bind(now)
     .bind(now)
     .execute(pool)
-    .await
-    ?;
+    .await?;
 
     Ok(Task {
         id,
@@ -93,8 +92,7 @@ pub async fn get_task(pool: &SqlitePool, id: Uuid) -> AppResult<Task> {
     )
     .bind(id.to_string())
     .fetch_optional(pool)
-    .await
-    ?;
+    .await?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -113,8 +111,7 @@ pub async fn list_tasks(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<Ta
     )
     .bind(project_id.to_string())
     .fetch_all(pool)
-    .await
-    ?;
+    .await?;
 
     rows.into_iter()
         .map(|r| r.try_into())
@@ -151,8 +148,7 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     .bind(now)
     .bind(id.to_string())
     .execute(pool)
-    .await
-    ?;
+    .await?;
 
     Ok(Task {
         id,

--- a/backend/src/test_helpers.rs
+++ b/backend/src/test_helpers.rs
@@ -1,0 +1,22 @@
+//! Shared test utilities for service and integration tests.
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::SqlitePool;
+
+/// Creates an in-memory SQLite database with migrations applied.
+///
+/// # Panics
+/// Panics if database creation or migration fails.
+pub async fn setup_test_db() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .expect("Failed to create test database");
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}


### PR DESCRIPTION
## Summary
- Add `Conflict` and `Database` error variants with automatic `From<sqlx::Error>` conversion
- Simplify service error handling by replacing `.map_err(|e| AppError::Internal(e.into()))?` with `?`
- Extract `setup_test_db()` helper to shared `test_helpers` module to reduce code duplication

## Test plan
- [x] All 61 backend tests passing
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied