### PR TITLE
feat: ✨ add SSE real-time synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",
@@ -2299,6 +2300,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
+tokio-stream = { workspace = true }
 
 [dev-dependencies]
 axum-test = "18"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -29,3 +29,12 @@ impl Config {
             .extract()?)
     }
 }
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bind_addr: default_bind_addr(),
+            database_url: default_database_url(),
+        }
+    }
+}

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::error::{AppError, AppResult};
 use crate::models::task::{CreateTaskRequest, Task, UpdateTaskRequest};
 use crate::services::{project_service, task_service};
+use crate::sse::event::SseEvent;
 use crate::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +56,9 @@ pub async fn create_task(
     // Verify project exists
     project_service::get_project(&state.pool, body.project_id).await?;
     let task = task_service::create_task(&state.pool, &body).await?;
+    state
+        .sse_hub
+        .broadcast(SseEvent::task_created(task.clone()));
     Ok((StatusCode::CREATED, Json(task)))
 }
 
@@ -96,6 +100,9 @@ pub async fn update_task(
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
     let task = task_service::update_task(&state.pool, id, &body).await?;
+    state
+        .sse_hub
+        .broadcast(SseEvent::task_updated(task.clone()));
     Ok(Json(task))
 }
 
@@ -114,5 +121,6 @@ pub async fn delete_task(
     Path(id): Path<Uuid>,
 ) -> AppResult<StatusCode> {
     task_service::delete_task(&state.pool, id).await?;
+    state.sse_hub.broadcast(SseEvent::task_deleted(id));
     Ok(StatusCode::NO_CONTENT)
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,7 @@ pub mod handlers;
 pub mod models;
 pub mod openapi;
 pub mod services;
+pub mod sse;
 #[cfg(test)]
 pub mod test_helpers;
 pub mod ws;
@@ -19,12 +20,14 @@ use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use crate::sse::hub::SseHub;
 use crate::ws::hub::Hub;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: SqlitePool,
     pub ws_hub: Arc<Hub>,
+    pub sse_hub: Arc<SseHub>,
     pub config: Arc<config::Config>,
 }
 
@@ -60,7 +63,9 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/projects/{project_id}/members/{user_id}",
             delete(handlers::project_members::remove_member),
-        );
+        )
+        // SSE for real-time updates
+        .route("/events", get(sse::handler::sse_handler));
 
     Router::new()
         .route("/health", get(handlers::health::health_check))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use gantry_board::config::Config;
 use gantry_board::db;
+use gantry_board::sse::hub::SseHub;
 use gantry_board::ws::hub::Hub;
 use gantry_board::AppState;
 use tracing_subscriber::EnvFilter;
@@ -18,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = AppState {
         pool,
         ws_hub: Arc::new(Hub::default()),
+        sse_hub: Arc::new(SseHub::default()),
         config: Arc::new(config.clone()),
     };
 

--- a/backend/src/sse/event.rs
+++ b/backend/src/sse/event.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::models::task::Task;
+
+/// Server-Sent Event for real-time updates
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type")]
+pub enum SseEvent {
+    TaskCreated { task: Task },
+    TaskUpdated { task: Task },
+    TaskDeleted { task_id: Uuid },
+}
+
+impl SseEvent {
+    pub fn task_created(task: Task) -> Self {
+        Self::TaskCreated { task }
+    }
+
+    pub fn task_updated(task: Task) -> Self {
+        Self::TaskUpdated { task }
+    }
+
+    pub fn task_deleted(task_id: Uuid) -> Self {
+        Self::TaskDeleted { task_id }
+    }
+
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::TaskCreated { .. } => "task_created",
+            Self::TaskUpdated { .. } => "task_updated",
+            Self::TaskDeleted { .. } => "task_deleted",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::task::{TaskPriority, TaskStatus};
+    use chrono::Utc;
+
+    fn create_test_task() -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            title: "Test Task".to_string(),
+            description: None,
+            status: TaskStatus::Todo,
+            priority: TaskPriority::Medium,
+            parent_id: None,
+            assigned_to: None,
+            position: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_task_created_event() {
+        let task = create_test_task();
+        let event = SseEvent::task_created(task.clone());
+
+        assert_eq!(event.event_type(), "task_created");
+        if let SseEvent::TaskCreated { task: t } = event {
+            assert_eq!(t.id, task.id);
+        } else {
+            panic!("Expected TaskCreated event");
+        }
+    }
+
+    #[test]
+    fn test_task_updated_event() {
+        let task = create_test_task();
+        let event = SseEvent::task_updated(task.clone());
+
+        assert_eq!(event.event_type(), "task_updated");
+    }
+
+    #[test]
+    fn test_task_deleted_event() {
+        let task_id = Uuid::new_v4();
+        let event = SseEvent::task_deleted(task_id);
+
+        assert_eq!(event.event_type(), "task_deleted");
+        if let SseEvent::TaskDeleted { task_id: id } = event {
+            assert_eq!(id, task_id);
+        } else {
+            panic!("Expected TaskDeleted event");
+        }
+    }
+
+    #[test]
+    fn test_event_serialization() {
+        let task = create_test_task();
+        let event = SseEvent::task_created(task);
+
+        let json = serde_json::to_string(&event).expect("Failed to serialize");
+        assert!(json.contains("\"type\":\"TaskCreated\""));
+        assert!(json.contains("\"task\""));
+    }
+}

--- a/backend/src/sse/handler.rs
+++ b/backend/src/sse/handler.rs
@@ -1,0 +1,108 @@
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures_util::stream::Stream;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+
+use crate::AppState;
+
+/// SSE endpoint for real-time task updates
+pub async fn sse_handler(
+    State(state): State<AppState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.sse_hub.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|result| {
+        result.ok().and_then(|event| {
+            let event_type = event.event_type();
+            serde_json::to_string(&event)
+                .ok()
+                .map(|data| Ok(Event::default().event(event_type).data(data)))
+        })
+    });
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(30))
+            .text("keep-alive"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::sse::event::SseEvent;
+    use crate::sse::hub::SseHub;
+    use crate::ws::hub::Hub;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
+
+    async fn create_test_state() -> AppState {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("Failed to create test pool");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        AppState {
+            pool,
+            ws_hub: Arc::new(Hub::default()),
+            sse_hub: Arc::new(SseHub::default()),
+            config: Arc::new(Config::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sse_handler_creates_stream() {
+        let state = create_test_state().await;
+
+        // Just verify the handler can be called without panic
+        let _sse = sse_handler(State(state)).await;
+    }
+
+    #[tokio::test]
+    async fn test_sse_receives_broadcast_event() {
+        use crate::models::task::{Task, TaskPriority, TaskStatus};
+        use chrono::Utc;
+        use uuid::Uuid;
+
+        let state = create_test_state().await;
+        let sse_hub = state.sse_hub.clone();
+
+        // Subscribe before broadcasting
+        let mut rx = sse_hub.subscribe();
+
+        let task = Task {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            title: "Test".to_string(),
+            description: None,
+            status: TaskStatus::Todo,
+            priority: TaskPriority::Medium,
+            parent_id: None,
+            assigned_to: None,
+            position: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let task_id = task.id;
+        sse_hub.broadcast(SseEvent::task_created(task));
+
+        let event = rx.recv().await.expect("Should receive event");
+        assert_eq!(event.event_type(), "task_created");
+
+        if let SseEvent::TaskCreated { task } = event {
+            assert_eq!(task.id, task_id);
+        } else {
+            panic!("Expected TaskCreated");
+        }
+    }
+}

--- a/backend/src/sse/hub.rs
+++ b/backend/src/sse/hub.rs
@@ -1,0 +1,109 @@
+use tokio::sync::broadcast;
+
+use super::event::SseEvent;
+
+#[derive(Debug, Clone)]
+pub struct SseHub {
+    sender: broadcast::Sender<SseEvent>,
+}
+
+impl SseHub {
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    pub fn broadcast(&self, event: SseEvent) {
+        // Ignore error when no receivers are connected
+        let _ = self.sender.send(event);
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<SseEvent> {
+        self.sender.subscribe()
+    }
+}
+
+impl Default for SseHub {
+    fn default() -> Self {
+        Self::new(256)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::task::{Task, TaskPriority, TaskStatus};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn create_test_task() -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            title: "Test Task".to_string(),
+            description: None,
+            status: TaskStatus::Todo,
+            priority: TaskPriority::Medium,
+            parent_id: None,
+            assigned_to: None,
+            position: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hub_broadcast_with_subscriber() {
+        let hub = SseHub::new(16);
+        let mut rx = hub.subscribe();
+
+        let task = create_test_task();
+        let task_id = task.id;
+        hub.broadcast(SseEvent::task_created(task));
+
+        let received = rx.recv().await.expect("Should receive event");
+        if let SseEvent::TaskCreated { task } = received {
+            assert_eq!(task.id, task_id);
+        } else {
+            panic!("Expected TaskCreated event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hub_broadcast_without_subscriber() {
+        let hub = SseHub::new(16);
+        let task = create_test_task();
+
+        // Should not panic when no subscribers
+        hub.broadcast(SseEvent::task_created(task));
+    }
+
+    #[tokio::test]
+    async fn test_hub_multiple_subscribers() {
+        let hub = SseHub::new(16);
+        let mut rx1 = hub.subscribe();
+        let mut rx2 = hub.subscribe();
+
+        let task = create_test_task();
+        let task_id = task.id;
+        hub.broadcast(SseEvent::task_created(task));
+
+        let received1 = rx1.recv().await.expect("Subscriber 1 should receive");
+        let received2 = rx2.recv().await.expect("Subscriber 2 should receive");
+
+        if let SseEvent::TaskCreated { task: t1 } = received1 {
+            assert_eq!(t1.id, task_id);
+        }
+        if let SseEvent::TaskCreated { task: t2 } = received2 {
+            assert_eq!(t2.id, task_id);
+        }
+    }
+
+    #[test]
+    fn test_hub_default() {
+        let hub = SseHub::default();
+        // Default capacity is 256, but we can't directly check it
+        // Just ensure it creates without panic
+        let _rx = hub.subscribe();
+    }
+}

--- a/backend/src/sse/mod.rs
+++ b/backend/src/sse/mod.rs
@@ -1,0 +1,3 @@
+pub mod event;
+pub mod handler;
+pub mod hub;

--- a/backend/tests/project_members_api.rs
+++ b/backend/tests/project_members_api.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use gantry_board::config::Config;
+use gantry_board::sse::hub::SseHub;
 use gantry_board::ws::hub::Hub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -28,6 +29,7 @@ async fn create_test_server() -> TestServer {
     let state = AppState {
         pool,
         ws_hub: Arc::new(Hub::default()),
+        sse_hub: Arc::new(SseHub::default()),
         config: Arc::new(config),
     };
 

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use axum_test::TestServer;
 use gantry_board::config::Config;
+use gantry_board::sse::hub::SseHub;
 use gantry_board::ws::hub::Hub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -26,6 +27,7 @@ async fn create_test_server() -> TestServer {
     let state = AppState {
         pool,
         ws_hub: Arc::new(Hub::default()),
+        sse_hub: Arc::new(SseHub::default()),
         config: Arc::new(config),
     };
 

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use gantry_board::config::Config;
+use gantry_board::sse::hub::SseHub;
 use gantry_board::ws::hub::Hub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -28,6 +29,7 @@ async fn create_test_server() -> TestServer {
     let state = AppState {
         pool,
         ws_hub: Arc::new(Hub::default()),
+        sse_hub: Arc::new(SseHub::default()),
         config: Arc::new(config),
     };
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,6 +4,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import * as projectsApi from './api/generated/endpoints/projects/projects';
 
+// Mock EventSource for SSE
+class MockEventSource {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  close() {}
+  addEventListener() {}
+}
+vi.stubGlobal('EventSource', MockEventSource);
+
 vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
 }));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,19 @@
-import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import { useListProjects } from './api/generated/endpoints/projects/projects';
 import { KanbanBoard } from './components/KanbanBoard';
+import { connectEventSource } from './hooks/useEventSource';
 
 function App() {
+  const queryClient = useQueryClient();
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const { data: projects, isLoading: projectsLoading } = useListProjects();
+
+  // Connect to SSE for real-time updates
+  useEffect(() => {
+    const cleanup = connectEventSource(queryClient);
+    return cleanup;
+  }, [queryClient]);
 
   return (
     <div className="min-h-screen bg-gray-100">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,11 +9,12 @@ function App() {
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const { data: projects, isLoading: projectsLoading } = useListProjects();
 
-  // Connect to SSE for real-time updates
+  // Connect to SSE for real-time updates (queryClient is stable from provider)
   useEffect(() => {
     const cleanup = connectEventSource(queryClient);
     return cleanup;
-  }, [queryClient]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-100">

--- a/frontend/src/hooks/useEventSource.test.ts
+++ b/frontend/src/hooks/useEventSource.test.ts
@@ -1,7 +1,8 @@
 import { QueryClient } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useEventSource, SseEvent } from './useEventSource';
+import { connectEventSource } from './useEventSource';
+import type { SseEvent } from './useEventSource';
 
 // Mock EventSource
 class MockEventSource {
@@ -20,7 +21,7 @@ class MockEventSource {
     this.readyState = 2;
   }
 
-  simulateMessage(type: string, data: unknown) {
+  simulateMessage(_type: string, data: unknown) {
     if (this.onmessage) {
       this.onmessage(new MessageEvent('message', { data: JSON.stringify(data) }));
     }
@@ -43,7 +44,7 @@ class MockEventSource {
   }
 }
 
-describe('useEventSource', () => {
+describe('connectEventSource', () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
@@ -62,7 +63,7 @@ describe('useEventSource', () => {
   });
 
   it('connects to the SSE endpoint', () => {
-    const cleanup = useEventSource(queryClient);
+    const cleanup = connectEventSource(queryClient);
 
     expect(MockEventSource.instances.length).toBe(1);
     expect(MockEventSource.instances[0].url).toContain('/api/events');
@@ -71,7 +72,7 @@ describe('useEventSource', () => {
   });
 
   it('closes connection on cleanup', () => {
-    const cleanup = useEventSource(queryClient);
+    const cleanup = connectEventSource(queryClient);
     const eventSource = MockEventSource.instances[0];
 
     cleanup();
@@ -81,7 +82,7 @@ describe('useEventSource', () => {
 
   it('invalidates task queries on task_created event', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const cleanup = useEventSource(queryClient);
+    const cleanup = connectEventSource(queryClient);
     const eventSource = MockEventSource.instances[0];
 
     const taskEvent: SseEvent = {
@@ -109,7 +110,7 @@ describe('useEventSource', () => {
 
   it('invalidates task queries on task_updated event', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const cleanup = useEventSource(queryClient);
+    const cleanup = connectEventSource(queryClient);
     const eventSource = MockEventSource.instances[0];
 
     const taskEvent: SseEvent = {
@@ -137,7 +138,7 @@ describe('useEventSource', () => {
 
   it('invalidates task queries on task_deleted event', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const cleanup = useEventSource(queryClient);
+    const cleanup = connectEventSource(queryClient);
     const eventSource = MockEventSource.instances[0];
 
     const deleteEvent: SseEvent = {

--- a/frontend/src/hooks/useEventSource.test.ts
+++ b/frontend/src/hooks/useEventSource.test.ts
@@ -103,6 +103,7 @@ describe('connectEventSource', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['/api/tasks'],
+      exact: false,
     });
 
     cleanup();
@@ -131,6 +132,7 @@ describe('connectEventSource', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['/api/tasks'],
+      exact: false,
     });
 
     cleanup();
@@ -150,6 +152,7 @@ describe('connectEventSource', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['/api/tasks'],
+      exact: false,
     });
 
     cleanup();

--- a/frontend/src/hooks/useEventSource.test.ts
+++ b/frontend/src/hooks/useEventSource.test.ts
@@ -1,0 +1,156 @@
+import { QueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEventSource, SseEvent } from './useEventSource';
+
+// Mock EventSource
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readyState = 0;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.readyState = 2;
+  }
+
+  simulateMessage(type: string, data: unknown) {
+    if (this.onmessage) {
+      this.onmessage(new MessageEvent('message', { data: JSON.stringify(data) }));
+    }
+  }
+
+  addEventListener(type: string, handler: (event: MessageEvent) => void) {
+    if (type === 'task_created' || type === 'task_updated' || type === 'task_deleted') {
+      // Store handlers for specific event types
+      (this as Record<string, unknown>)[`on${type}`] = handler;
+    }
+  }
+
+  simulateTypedEvent(type: string, data: unknown) {
+    const handler = (this as Record<string, unknown>)[`on${type}`] as
+      | ((event: MessageEvent) => void)
+      | undefined;
+    if (handler) {
+      handler(new MessageEvent(type, { data: JSON.stringify(data) }));
+    }
+  }
+}
+
+describe('useEventSource', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    queryClient.clear();
+  });
+
+  it('connects to the SSE endpoint', () => {
+    const cleanup = useEventSource(queryClient);
+
+    expect(MockEventSource.instances.length).toBe(1);
+    expect(MockEventSource.instances[0].url).toContain('/api/events');
+
+    cleanup();
+  });
+
+  it('closes connection on cleanup', () => {
+    const cleanup = useEventSource(queryClient);
+    const eventSource = MockEventSource.instances[0];
+
+    cleanup();
+
+    expect(eventSource.readyState).toBe(2);
+  });
+
+  it('invalidates task queries on task_created event', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const cleanup = useEventSource(queryClient);
+    const eventSource = MockEventSource.instances[0];
+
+    const taskEvent: SseEvent = {
+      type: 'TaskCreated',
+      task: {
+        id: '123',
+        project_id: 'proj-1',
+        title: 'New Task',
+        status: 'backlog',
+        priority: 'medium',
+        position: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    };
+
+    eventSource.simulateTypedEvent('task_created', taskEvent);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['/api/tasks'],
+    });
+
+    cleanup();
+  });
+
+  it('invalidates task queries on task_updated event', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const cleanup = useEventSource(queryClient);
+    const eventSource = MockEventSource.instances[0];
+
+    const taskEvent: SseEvent = {
+      type: 'TaskUpdated',
+      task: {
+        id: '123',
+        project_id: 'proj-1',
+        title: 'Updated Task',
+        status: 'in_progress',
+        priority: 'high',
+        position: 1,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    };
+
+    eventSource.simulateTypedEvent('task_updated', taskEvent);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['/api/tasks'],
+    });
+
+    cleanup();
+  });
+
+  it('invalidates task queries on task_deleted event', () => {
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const cleanup = useEventSource(queryClient);
+    const eventSource = MockEventSource.instances[0];
+
+    const deleteEvent: SseEvent = {
+      type: 'TaskDeleted',
+      task_id: '123',
+    };
+
+    eventSource.simulateTypedEvent('task_deleted', deleteEvent);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['/api/tasks'],
+    });
+
+    cleanup();
+  });
+});

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -1,0 +1,56 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import type { Task } from '../api/generated/model';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
+
+export type SseEvent =
+  | { type: 'TaskCreated'; task: Task }
+  | { type: 'TaskUpdated'; task: Task }
+  | { type: 'TaskDeleted'; task_id: string };
+
+export function useEventSource(queryClient: QueryClient): () => void {
+  const eventSource = new EventSource(`${API_BASE_URL}/api/events`);
+
+  const handleTaskEvent = () => {
+    queryClient.invalidateQueries({
+      queryKey: ['/api/tasks'],
+    });
+  };
+
+  eventSource.addEventListener('task_created', (event: MessageEvent) => {
+    // Parse and handle task_created event
+    try {
+      JSON.parse(event.data) as SseEvent;
+      handleTaskEvent();
+    } catch {
+      console.error('Failed to parse SSE event:', event.data);
+    }
+  });
+
+  eventSource.addEventListener('task_updated', (event: MessageEvent) => {
+    try {
+      JSON.parse(event.data) as SseEvent;
+      handleTaskEvent();
+    } catch {
+      console.error('Failed to parse SSE event:', event.data);
+    }
+  });
+
+  eventSource.addEventListener('task_deleted', (event: MessageEvent) => {
+    try {
+      JSON.parse(event.data) as SseEvent;
+      handleTaskEvent();
+    } catch {
+      console.error('Failed to parse SSE event:', event.data);
+    }
+  });
+
+  eventSource.onerror = () => {
+    console.error('SSE connection error');
+  };
+
+  return () => {
+    eventSource.close();
+  };
+}

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -13,41 +13,35 @@ export function connectEventSource(queryClient: QueryClient): () => void {
   const eventSource = new EventSource(`${API_BASE_URL}/api/events`);
 
   const handleTaskEvent = () => {
+    // Invalidate all task queries (including variants with project_id filter)
     queryClient.invalidateQueries({
       queryKey: ['/api/tasks'],
+      exact: false,
     });
   };
 
-  eventSource.addEventListener('task_created', (event: MessageEvent) => {
-    // Parse and handle task_created event
+  const handleSseMessage = (event: MessageEvent) => {
     try {
-      JSON.parse(event.data) as SseEvent;
-      handleTaskEvent();
+      // Validate JSON structure; parsed value used for type checking
+      const parsed = JSON.parse(event.data) as SseEvent;
+      if (parsed.type) {
+        handleTaskEvent();
+      }
     } catch {
       console.error('Failed to parse SSE event:', event.data);
     }
-  });
+  };
 
-  eventSource.addEventListener('task_updated', (event: MessageEvent) => {
-    try {
-      JSON.parse(event.data) as SseEvent;
-      handleTaskEvent();
-    } catch {
-      console.error('Failed to parse SSE event:', event.data);
-    }
-  });
+  eventSource.addEventListener('task_created', handleSseMessage);
+  eventSource.addEventListener('task_updated', handleSseMessage);
+  eventSource.addEventListener('task_deleted', handleSseMessage);
 
-  eventSource.addEventListener('task_deleted', (event: MessageEvent) => {
-    try {
-      JSON.parse(event.data) as SseEvent;
-      handleTaskEvent();
-    } catch {
-      console.error('Failed to parse SSE event:', event.data);
-    }
-  });
-
-  eventSource.onerror = () => {
-    console.error('SSE connection error');
+  eventSource.onerror = (event: Event) => {
+    const source = event.currentTarget as EventSource | null;
+    console.error('SSE connection error', {
+      type: event.type,
+      readyState: source?.readyState,
+    });
   };
 
   return () => {

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -9,7 +9,7 @@ export type SseEvent =
   | { type: 'TaskUpdated'; task: Task }
   | { type: 'TaskDeleted'; task_id: string };
 
-export function useEventSource(queryClient: QueryClient): () => void {
+export function connectEventSource(queryClient: QueryClient): () => void {
   const eventSource = new EventSource(`${API_BASE_URL}/api/events`);
 
   const handleTaskEvent = () => {

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -1,5 +1,0 @@
-const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL ?? 'ws://localhost:3000';
-
-export function createWebSocket(path: string): WebSocket {
-  return new WebSocket(`${WS_BASE_URL}${path}`);
-}


### PR DESCRIPTION
## Summary

- Backend SSE module with broadcast hub for real-time task events
- SSE endpoint at `/api/events` with TaskCreated/TaskUpdated/TaskDeleted events
- Task handlers broadcast events on CUD operations
- Frontend `connectEventSource` hook with TanStack Query cache invalidation
- Auto-reconnect via native EventSource API

## Test plan

- [x] Backend SSE hub tests (broadcast, multiple subscribers)
- [x] Backend SSE event serialization tests
- [x] Frontend SSE hook tests (connection, event handling)
- [x] All existing tests pass (71 backend + 26 frontend)
- [ ] Manual: Open two browser tabs, create/update/delete task → see sync