### PR TITLE
feat: ✨ add task/project creation dialogs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "@tailwindcss/vite": "^4.1.0",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -3385,6 +3386,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/vite": "^4.1.0",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './App';
 import * as projectsApi from './api/generated/endpoints/projects/projects';
+import * as tasksApi from './api/generated/endpoints/tasks/tasks';
 import * as authApi from './api/generated/endpoints/auth/auth';
 import { useAuthStore } from './stores/authStore';
+import { useUiStore } from './stores/uiStore';
 
 // Mock EventSource for SSE
 class MockEventSource {
@@ -18,11 +21,13 @@ vi.stubGlobal('EventSource', MockEventSource);
 
 vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
+  useCreateProject: vi.fn(),
 }));
 
 vi.mock('./api/generated/endpoints/tasks/tasks', () => ({
   useListTasks: vi.fn(),
   useUpdateTask: vi.fn(),
+  useCreateTask: vi.fn(),
   getListTasksQueryKey: vi.fn(() => ['/api/tasks']),
 }));
 
@@ -82,6 +87,22 @@ describe('App', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof authApi.useRegister>);
+    // Mock useCreateProject
+    vi.mocked(projectsApi.useCreateProject).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useCreateProject>);
+    // Mock useCreateTask
+    vi.mocked(tasksApi.useCreateTask).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof tasksApi.useCreateTask>);
+    // Reset ui store
+    useUiStore.setState({
+      isTaskModalOpen: false,
+      defaultStatus: null,
+      isProjectModalOpen: false,
+    });
   });
 
   describe('when not authenticated', () => {
@@ -172,6 +193,30 @@ describe('App', () => {
 
       expect(screen.getByText('Test User')).toBeInTheDocument();
       expect(screen.getByText('Logout')).toBeInTheDocument();
+    });
+
+    it('renders new project button', () => {
+      vi.mocked(projectsApi.useListProjects).mockReturnValue({
+        data: [],
+        isLoading: false,
+      } as ReturnType<typeof projectsApi.useListProjects>);
+
+      renderWithProviders(<AppRoutes />);
+
+      expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+    });
+
+    it('opens project modal on new project button click', async () => {
+      const user = userEvent.setup();
+      vi.mocked(projectsApi.useListProjects).mockReturnValue({
+        data: [],
+        isLoading: false,
+      } as ReturnType<typeof projectsApi.useListProjects>);
+
+      renderWithProviders(<AppRoutes />);
+      await user.click(screen.getByRole('button', { name: /new project/i }));
+
+      expect(useUiStore.getState().isProjectModalOpen).toBe(true);
     });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,13 @@ import { useLogout, useMe } from './api/generated/endpoints/auth/auth';
 import { useListProjects } from './api/generated/endpoints/projects/projects';
 import { KanbanBoard } from './components/KanbanBoard';
 import { LoginPage } from './components/LoginPage';
+import { ProjectCreateDialog } from './components/ProjectCreateDialog';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { RegisterPage } from './components/RegisterPage';
+import { TaskCreateDialog } from './components/TaskCreateDialog';
 import { connectEventSource } from './hooks/useEventSource';
 import { useAuthStore } from './stores/authStore';
+import { useUiStore } from './stores/uiStore';
 
 function KanbanApp() {
   const queryClient = useQueryClient();
@@ -17,6 +20,7 @@ function KanbanApp() {
   const user = useAuthStore((state) => state.user);
   const logout = useLogout();
   const setUser = useAuthStore((state) => state.setUser);
+  const openProjectModal = useUiStore((s) => s.openProjectModal);
 
   // Connect to SSE for real-time updates (queryClient is stable from provider)
   useEffect(() => {
@@ -58,6 +62,12 @@ function KanbanApp() {
                 </option>
               ))}
             </select>
+            <button
+              onClick={openProjectModal}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+            >
+              New Project
+            </button>
 
             <div className="flex items-center gap-2 border-l pl-4">
               <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
@@ -81,6 +91,8 @@ function KanbanApp() {
           </div>
         )}
       </main>
+      <ProjectCreateDialog />
+      {selectedProjectId && <TaskCreateDialog projectId={selectedProjectId} />}
     </div>
   );
 }

--- a/frontend/src/components/KanbanColumn.test.tsx
+++ b/frontend/src/components/KanbanColumn.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { KanbanColumn } from './KanbanColumn';
 import type { Task } from '../api/generated/model';
 import { TaskStatus, TaskPriority } from '../api/generated/model';
+import { useUiStore } from '../stores/uiStore';
 
 const createMockTask = (overrides: Partial<Task> = {}): Task => ({
   id: 'task-1',
@@ -68,5 +70,22 @@ describe('KanbanColumn', () => {
     render(<KanbanColumn status={TaskStatus.todo} tasks={[]} />);
 
     expect(screen.getByTestId('column-empty')).toBeInTheDocument();
+  });
+
+  it('renders add task button', () => {
+    render(<KanbanColumn status={TaskStatus.todo} tasks={[]} />);
+
+    expect(screen.getByRole('button', { name: /add task/i })).toBeInTheDocument();
+  });
+
+  it('opens task modal with column status on add task click', async () => {
+    const user = userEvent.setup();
+    const openTaskModal = vi.fn();
+    useUiStore.setState({ openTaskModal });
+
+    render(<KanbanColumn status={TaskStatus.in_progress} tasks={[]} />);
+    await user.click(screen.getByRole('button', { name: /add task/i }));
+
+    expect(openTaskModal).toHaveBeenCalledWith(TaskStatus.in_progress);
   });
 });

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,6 +1,7 @@
 import { useDroppable } from '@dnd-kit/core';
 import type { Task } from '../api/generated/model';
 import { TaskStatus } from '../api/generated/model';
+import { useUiStore } from '../stores/uiStore';
 import { TaskCard } from './TaskCard';
 
 interface KanbanColumnProps {
@@ -18,6 +19,7 @@ const statusLabels: Record<TaskStatus, string> = {
 };
 
 export function KanbanColumn({ status, tasks, activeTaskId }: KanbanColumnProps) {
+  const openTaskModal = useUiStore((s) => s.openTaskModal);
   const { setNodeRef, isOver } = useDroppable({
     id: status,
   });
@@ -47,6 +49,14 @@ export function KanbanColumn({ status, tasks, activeTaskId }: KanbanColumnProps)
             <TaskCard key={task.id} task={task} isDragging={activeTaskId === task.id} />
           ))
         )}
+      </div>
+      <div className="p-2">
+        <button
+          onClick={() => openTaskModal(status)}
+          className="w-full rounded-md py-1.5 text-sm text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+        >
+          + Add Task
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/ProjectCreateDialog.test.tsx
+++ b/frontend/src/components/ProjectCreateDialog.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as projectsApi from '../api/generated/endpoints/projects/projects';
+import { useUiStore } from '../stores/uiStore';
+import { ProjectCreateDialog } from './ProjectCreateDialog';
+
+vi.mock('../api/generated/endpoints/projects/projects', () => ({
+  useCreateProject: vi.fn(),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('ProjectCreateDialog', () => {
+  const mockMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync.mockResolvedValue({});
+    vi.mocked(projectsApi.useCreateProject).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useCreateProject>);
+    useUiStore.setState({
+      isTaskModalOpen: false,
+      defaultStatus: null,
+      isProjectModalOpen: false,
+    });
+  });
+
+  it('does not render when modal is closed', () => {
+    renderWithProviders(<ProjectCreateDialog />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders form when modal is open', () => {
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+  });
+
+  it('submits form with correct data', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    await user.type(screen.getByLabelText(/name/i), 'My Project');
+    await user.type(screen.getByLabelText(/description/i), 'Project desc');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      data: {
+        name: 'My Project',
+        description: 'Project desc',
+      },
+    });
+  });
+
+  it('closes modal after successful submission', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    await user.type(screen.getByLabelText(/name/i), 'My Project');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(useUiStore.getState().isProjectModalOpen).toBe(false);
+  });
+
+  it('closes modal on cancel', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(useUiStore.getState().isProjectModalOpen).toBe(false);
+  });
+
+  it('does not submit when name is empty', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('resets form when reopened', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectModalOpen: true });
+    renderWithProviders(<ProjectCreateDialog />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Some name');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    act(() => {
+      useUiStore.setState({ isProjectModalOpen: true });
+    });
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue('');
+  });
+});

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -1,3 +1,88 @@
+import { useEffect, useState } from 'react';
+import { useCreateProject } from '../api/generated/endpoints/projects/projects';
+import { useUiStore } from '../stores/uiStore';
+
 export function ProjectCreateDialog() {
-  return null;
+  const isOpen = useUiStore((s) => s.isProjectModalOpen);
+  const closeProjectModal = useUiStore((s) => s.closeProjectModal);
+  const createProject = useCreateProject();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setName('');
+      setDescription('');
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    await createProject.mutateAsync({
+      data: {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      },
+    });
+    closeProjectModal();
+  };
+
+  return (
+    <div role="dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold">Create Project</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">
+              Name
+            </label>
+            <input
+              id="project-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              autoFocus
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="project-description"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Description
+            </label>
+            <textarea
+              id="project-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={closeProjectModal}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={createProject.isPending}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              Create
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCreateProject } from '../api/generated/endpoints/projects/projects';
 import { useUiStore } from '../stores/uiStore';
 
@@ -16,24 +16,52 @@ function ProjectCreateForm() {
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeProjectModal();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeProjectModal]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
+    setError(null);
 
-    await createProject.mutateAsync({
-      data: {
-        name: name.trim(),
-        description: description.trim() || undefined,
-      },
-    });
-    closeProjectModal();
+    try {
+      await createProject.mutateAsync({
+        data: {
+          name: name.trim(),
+          description: description.trim() || undefined,
+        },
+      });
+      closeProjectModal();
+    } catch {
+      setError('Failed to create project. Please try again.');
+    }
   };
 
   return (
-    <div role="dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <h2 className="mb-4 text-lg font-semibold">Create Project</h2>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="project-create-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={closeProjectModal}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="project-create-title" className="mb-4 text-lg font-semibold">
+          Create Project
+        </h2>
+        {error && (
+          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -1,23 +1,21 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useCreateProject } from '../api/generated/endpoints/projects/projects';
 import { useUiStore } from '../stores/uiStore';
 
 export function ProjectCreateDialog() {
   const isOpen = useUiStore((s) => s.isProjectModalOpen);
+
+  if (!isOpen) return null;
+
+  return <ProjectCreateForm />;
+}
+
+function ProjectCreateForm() {
   const closeProjectModal = useUiStore((s) => s.closeProjectModal);
   const createProject = useCreateProject();
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-
-  useEffect(() => {
-    if (isOpen) {
-      setName('');
-      setDescription('');
-    }
-  }, [isOpen]);
-
-  if (!isOpen) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -1,0 +1,3 @@
+export function ProjectCreateDialog() {
+  return null;
+}

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -59,9 +59,7 @@ function ProjectCreateForm() {
         <h2 id="project-create-title" className="mb-4 text-lg font-semibold">
           Create Project
         </h2>
-        {error && (
-          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>
-        )}
+        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/components/TaskCreateDialog.test.tsx
+++ b/frontend/src/components/TaskCreateDialog.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskStatus } from '../api/generated/model';
+import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
+import { useUiStore } from '../stores/uiStore';
+import { TaskCreateDialog } from './TaskCreateDialog';
+
+vi.mock('../api/generated/endpoints/tasks/tasks', () => ({
+  useCreateTask: vi.fn(),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('TaskCreateDialog', () => {
+  const mockMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync.mockResolvedValue({});
+    vi.mocked(tasksApi.useCreateTask).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof tasksApi.useCreateTask>);
+    useUiStore.setState({
+      isTaskModalOpen: false,
+      defaultStatus: null,
+      isProjectModalOpen: false,
+    });
+  });
+
+  it('does not render when modal is closed', () => {
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders form when modal is open', () => {
+    useUiStore.setState({ isTaskModalOpen: true });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/status/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/priority/i)).toBeInTheDocument();
+  });
+
+  it('pre-fills status from defaultStatus', () => {
+    useUiStore.setState({ isTaskModalOpen: true, defaultStatus: TaskStatus.in_progress });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    const statusSelect = screen.getByLabelText(/status/i) as HTMLSelectElement;
+    expect(statusSelect.value).toBe('in_progress');
+  });
+
+  it('defaults status to backlog when no defaultStatus', () => {
+    useUiStore.setState({ isTaskModalOpen: true, defaultStatus: null });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    const statusSelect = screen.getByLabelText(/status/i) as HTMLSelectElement;
+    expect(statusSelect.value).toBe('backlog');
+  });
+
+  it('submits form with correct data', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isTaskModalOpen: true, defaultStatus: TaskStatus.todo });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    await user.type(screen.getByLabelText(/title/i), 'New Task');
+    await user.type(screen.getByLabelText(/description/i), 'Task description');
+    await user.selectOptions(screen.getByLabelText(/priority/i), 'high');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      data: {
+        project_id: 'proj-1',
+        title: 'New Task',
+        description: 'Task description',
+        status: 'todo',
+        priority: 'high',
+      },
+    });
+  });
+
+  it('closes modal after successful submission', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isTaskModalOpen: true });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    await user.type(screen.getByLabelText(/title/i), 'New Task');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(useUiStore.getState().isTaskModalOpen).toBe(false);
+  });
+
+  it('closes modal on cancel', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isTaskModalOpen: true });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(useUiStore.getState().isTaskModalOpen).toBe(false);
+  });
+
+  it('does not submit when title is empty', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isTaskModalOpen: true });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('resets form when reopened', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isTaskModalOpen: true });
+    renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+    await user.type(screen.getByLabelText(/title/i), 'Some title');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    // Reopen
+    useUiStore.setState({ isTaskModalOpen: true });
+
+    expect(screen.getByLabelText(/title/i)).toHaveValue('');
+  });
+});

--- a/frontend/src/components/TaskCreateDialog.test.tsx
+++ b/frontend/src/components/TaskCreateDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -131,7 +131,9 @@ describe('TaskCreateDialog', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }));
 
     // Reopen
-    useUiStore.setState({ isTaskModalOpen: true });
+    act(() => {
+      useUiStore.setState({ isTaskModalOpen: true });
+    });
 
     expect(screen.getByLabelText(/title/i)).toHaveValue('');
   });

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -76,9 +76,7 @@ function TaskCreateForm({
         <h2 id="task-create-title" className="mb-4 text-lg font-semibold">
           Create Task
         </h2>
-        {error && (
-          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>
-        )}
+        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,3 +1,133 @@
-export function TaskCreateDialog(_props: { projectId: string }) {
-  return null;
+import { useEffect, useState } from 'react';
+import { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useCreateTask } from '../api/generated/endpoints/tasks/tasks';
+import { useUiStore } from '../stores/uiStore';
+
+interface TaskCreateDialogProps {
+  projectId: string;
+}
+
+export function TaskCreateDialog({ projectId }: TaskCreateDialogProps) {
+  const isOpen = useUiStore((s) => s.isTaskModalOpen);
+  const defaultStatus = useUiStore((s) => s.defaultStatus);
+  const closeTaskModal = useUiStore((s) => s.closeTaskModal);
+  const createTask = useCreateTask();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<TaskStatus>(TaskStatus.backlog);
+  const [priority, setPriority] = useState<TaskPriority>(TaskPriority.medium);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle('');
+      setDescription('');
+      setStatus(defaultStatus ?? TaskStatus.backlog);
+      setPriority(TaskPriority.medium);
+    }
+  }, [isOpen, defaultStatus]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    await createTask.mutateAsync({
+      data: {
+        project_id: projectId,
+        title: title.trim(),
+        description: description.trim() || undefined,
+        status,
+        priority,
+      },
+    });
+    closeTaskModal();
+  };
+
+  return (
+    <div role="dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-4 text-lg font-semibold">Create Task</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
+              Title
+            </label>
+            <input
+              id="task-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              autoFocus
+            />
+          </div>
+          <div>
+            <label htmlFor="task-description" className="block text-sm font-medium text-gray-700">
+              Description
+            </label>
+            <textarea
+              id="task-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
+                Status
+              </label>
+              <select
+                id="task-status"
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TaskStatus)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value={TaskStatus.backlog}>Backlog</option>
+                <option value={TaskStatus.todo}>To Do</option>
+                <option value={TaskStatus.in_progress}>In Progress</option>
+                <option value={TaskStatus.in_review}>In Review</option>
+                <option value={TaskStatus.done}>Done</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
+                Priority
+              </label>
+              <select
+                id="task-priority"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as TaskPriority)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value={TaskPriority.low}>Low</option>
+                <option value={TaskPriority.medium}>Medium</option>
+                <option value={TaskPriority.high}>High</option>
+                <option value={TaskPriority.urgent}>Urgent</option>
+              </select>
+            </div>
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={closeTaskModal}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={createTask.isPending}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              Create
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,0 +1,3 @@
+export function TaskCreateDialog(_props: { projectId: string }) {
+  return null;
+}

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useCreateTask } from '../api/generated/endpoints/tasks/tasks';
 import { useUiStore } from '../stores/uiStore';
@@ -10,24 +10,26 @@ interface TaskCreateDialogProps {
 export function TaskCreateDialog({ projectId }: TaskCreateDialogProps) {
   const isOpen = useUiStore((s) => s.isTaskModalOpen);
   const defaultStatus = useUiStore((s) => s.defaultStatus);
+
+  if (!isOpen) return null;
+
+  return <TaskCreateForm projectId={projectId} defaultStatus={defaultStatus} />;
+}
+
+function TaskCreateForm({
+  projectId,
+  defaultStatus,
+}: {
+  projectId: string;
+  defaultStatus: TaskStatus | null;
+}) {
   const closeTaskModal = useUiStore((s) => s.closeTaskModal);
   const createTask = useCreateTask();
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [status, setStatus] = useState<TaskStatus>(TaskStatus.backlog);
+  const [status, setStatus] = useState<TaskStatus>(defaultStatus ?? TaskStatus.backlog);
   const [priority, setPriority] = useState<TaskPriority>(TaskPriority.medium);
-
-  useEffect(() => {
-    if (isOpen) {
-      setTitle('');
-      setDescription('');
-      setStatus(defaultStatus ?? TaskStatus.backlog);
-      setPriority(TaskPriority.medium);
-    }
-  }, [isOpen, defaultStatus]);
-
-  if (!isOpen) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useCreateTask } from '../api/generated/endpoints/tasks/tasks';
 import { useUiStore } from '../stores/uiStore';
@@ -30,27 +30,55 @@ function TaskCreateForm({
   const [description, setDescription] = useState('');
   const [status, setStatus] = useState<TaskStatus>(defaultStatus ?? TaskStatus.backlog);
   const [priority, setPriority] = useState<TaskPriority>(TaskPriority.medium);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeTaskModal();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeTaskModal]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
+    setError(null);
 
-    await createTask.mutateAsync({
-      data: {
-        project_id: projectId,
-        title: title.trim(),
-        description: description.trim() || undefined,
-        status,
-        priority,
-      },
-    });
-    closeTaskModal();
+    try {
+      await createTask.mutateAsync({
+        data: {
+          project_id: projectId,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          status,
+          priority,
+        },
+      });
+      closeTaskModal();
+    } catch {
+      setError('Failed to create task. Please try again.');
+    }
   };
 
   return (
-    <div role="dialog" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <h2 className="mb-4 text-lg font-semibold">Create Task</h2>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="task-create-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={closeTaskModal}
+    >
+      <div
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="task-create-title" className="mb-4 text-lg font-semibold">
+          Create Task
+        </h2>
+        {error && (
+          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">

--- a/frontend/src/stores/uiStore.test.ts
+++ b/frontend/src/stores/uiStore.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { TaskStatus } from '../api/generated/model';
+import { useUiStore } from './uiStore';
+
+describe('uiStore', () => {
+  afterEach(() => {
+    // Reset store to initial state between tests
+    useUiStore.setState({
+      isTaskModalOpen: false,
+      defaultStatus: null,
+      isProjectModalOpen: false,
+    });
+  });
+
+  describe('task modal', () => {
+    it('has correct initial state', () => {
+      const state = useUiStore.getState();
+      expect(state.isTaskModalOpen).toBe(false);
+      expect(state.defaultStatus).toBeNull();
+    });
+
+    it('opens task modal without default status', () => {
+      useUiStore.getState().openTaskModal();
+      const state = useUiStore.getState();
+      expect(state.isTaskModalOpen).toBe(true);
+      expect(state.defaultStatus).toBeNull();
+    });
+
+    it('opens task modal with default status', () => {
+      useUiStore.getState().openTaskModal(TaskStatus.todo);
+      const state = useUiStore.getState();
+      expect(state.isTaskModalOpen).toBe(true);
+      expect(state.defaultStatus).toBe('todo');
+    });
+
+    it('resets defaultStatus when closing task modal', () => {
+      useUiStore.getState().openTaskModal(TaskStatus.in_progress);
+      useUiStore.getState().closeTaskModal();
+      const state = useUiStore.getState();
+      expect(state.isTaskModalOpen).toBe(false);
+      expect(state.defaultStatus).toBeNull();
+    });
+  });
+
+  describe('project modal', () => {
+    it('has correct initial state', () => {
+      const state = useUiStore.getState();
+      expect(state.isProjectModalOpen).toBe(false);
+    });
+
+    it('opens project modal', () => {
+      useUiStore.getState().openProjectModal();
+      expect(useUiStore.getState().isProjectModalOpen).toBe(true);
+    });
+
+    it('closes project modal', () => {
+      useUiStore.getState().openProjectModal();
+      useUiStore.getState().closeProjectModal();
+      expect(useUiStore.getState().isProjectModalOpen).toBe(false);
+    });
+  });
+});

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -1,13 +1,24 @@
 import { create } from 'zustand';
 
+import type { TaskStatus } from '../api/generated/model';
+
 interface UiState {
   isTaskModalOpen: boolean;
-  openTaskModal: () => void;
+  defaultStatus: TaskStatus | null;
+  openTaskModal: (status?: TaskStatus) => void;
   closeTaskModal: () => void;
+  isProjectModalOpen: boolean;
+  openProjectModal: () => void;
+  closeProjectModal: () => void;
 }
 
 export const useUiStore = create<UiState>((set) => ({
   isTaskModalOpen: false,
-  openTaskModal: () => set({ isTaskModalOpen: true }),
-  closeTaskModal: () => set({ isTaskModalOpen: false }),
+  defaultStatus: null,
+  openTaskModal: (status?: TaskStatus) =>
+    set({ isTaskModalOpen: true, defaultStatus: status ?? null }),
+  closeTaskModal: () => set({ isTaskModalOpen: false, defaultStatus: null }),
+  isProjectModalOpen: false,
+  openProjectModal: () => set({ isProjectModalOpen: true }),
+  closeProjectModal: () => set({ isProjectModalOpen: false }),
 }));


### PR DESCRIPTION
## Summary

- Add **TaskCreateDialog** with title, description, status (pre-filled from column), and priority fields
- Add **ProjectCreateDialog** with name and description fields
- Extend **uiStore** with `defaultStatus` parameter and project modal state
- Add "**+ Add Task**" button to each KanbanColumn (opens dialog with column's status pre-selected)
- Add "**New Project**" button to App header

Closes #21

## Test plan

- [x] uiStore: 7 tests (initial state, openTaskModal with/without status, closeTaskModal resets, project modal open/close)
- [x] TaskCreateDialog: 9 tests (render/close, status pre-fill, form submit, cancel, title validation, form reset)
- [x] ProjectCreateDialog: 7 tests (render/close, form submit, cancel, name validation, form reset)
- [x] KanbanColumn: 2 new tests (add task button renders, opens modal with column status)
- [x] App: 2 new tests (new project button renders, opens project modal)
- [x] All 55 frontend tests pass, no regressions