### PR TITLE
feat: ✨ add task detail/edit modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ProjectCreateDialog } from './components/ProjectCreateDialog';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { RegisterPage } from './components/RegisterPage';
 import { TaskCreateDialog } from './components/TaskCreateDialog';
+import { TaskDetailModal } from './components/TaskDetailModal';
 import { connectEventSource } from './hooks/useEventSource';
 import { useAuthStore } from './stores/authStore';
 import { useUiStore } from './stores/uiStore';
@@ -95,6 +96,7 @@ function KanbanApp() {
       </main>
       <ProjectCreateDialog />
       {selectedProjectId && <TaskCreateDialog projectId={selectedProjectId} />}
+      <TaskDetailModal />
     </div>
   );
 }

--- a/frontend/src/components/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { Task } from '../api/generated/model';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';

--- a/frontend/src/components/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Task } from '../api/generated/model';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useUiStore } from '../stores/uiStore';
 import { TaskCard } from './TaskCard';
 
 const createMockTask = (overrides: Partial<Task> = {}): Task => ({
@@ -18,6 +20,13 @@ const createMockTask = (overrides: Partial<Task> = {}): Task => ({
 });
 
 describe('TaskCard', () => {
+  beforeEach(() => {
+    useUiStore.setState({
+      selectedTaskId: null,
+      isTaskDetailOpen: false,
+    });
+  });
+
   it('renders task title', () => {
     const task = createMockTask({ title: 'My Task Title' });
     render(<TaskCard task={task} />);
@@ -76,5 +85,24 @@ describe('TaskCard', () => {
 
     const badge = screen.getByText('low');
     expect(badge).toHaveClass('bg-gray-100');
+  });
+
+  it('opens task detail on click', async () => {
+    const user = userEvent.setup();
+    const task = createMockTask({ id: 'task-42' });
+    render(<TaskCard task={task} />);
+
+    await user.click(screen.getByText('Test Task'));
+
+    expect(useUiStore.getState().selectedTaskId).toBe('task-42');
+    expect(useUiStore.getState().isTaskDetailOpen).toBe(true);
+  });
+
+  it('has pointer cursor', () => {
+    const task = createMockTask();
+    render(<TaskCard task={task} />);
+
+    const card = screen.getByText('Test Task').closest('[data-testid="task-card"]');
+    expect(card).toHaveClass('cursor-pointer');
   });
 });

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -47,13 +47,22 @@ export function TaskCard({ task, isDragging }: TaskCardProps) {
   };
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: dnd-kit requires div with ref/listeners spread
     <div
       ref={setNodeRef}
       style={style}
       {...listeners}
       {...attributes}
+      role="button"
+      tabIndex={0}
       onPointerDown={handlePointerDown}
       onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openTaskDetail(task.id);
+        }
+      }}
       data-testid="task-card"
       className={`cursor-pointer rounded-lg border border-gray-200 bg-white p-3 shadow-sm ${
         isDragging ? 'opacity-50' : ''

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,11 +1,15 @@
 import { useDraggable } from '@dnd-kit/core';
+import { useRef } from 'react';
 import type { Task } from '../api/generated/model';
 import { TaskPriority } from '../api/generated/model';
+import { useUiStore } from '../stores/uiStore';
 
 interface TaskCardProps {
   task: Task;
   isDragging?: boolean;
 }
+
+const CLICK_THRESHOLD = 5;
 
 const priorityStyles: Record<TaskPriority, string> = {
   [TaskPriority.urgent]: 'bg-red-100 text-red-800',
@@ -19,6 +23,8 @@ export function TaskCard({ task, isDragging }: TaskCardProps) {
     id: task.id,
     data: { task },
   });
+  const openTaskDetail = useUiStore((s) => s.openTaskDetail);
+  const pointerStart = useRef<{ x: number; y: number } | null>(null);
 
   const style = transform
     ? {
@@ -26,13 +32,30 @@ export function TaskCard({ task, isDragging }: TaskCardProps) {
       }
     : undefined;
 
+  const handlePointerDown = (e: React.PointerEvent) => {
+    pointerStart.current = { x: e.clientX, y: e.clientY };
+    listeners?.onPointerDown?.(e);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (pointerStart.current) {
+      const dx = e.clientX - pointerStart.current.x;
+      const dy = e.clientY - pointerStart.current.y;
+      if (Math.sqrt(dx * dx + dy * dy) > CLICK_THRESHOLD) return;
+    }
+    openTaskDetail(task.id);
+  };
+
   return (
     <div
       ref={setNodeRef}
       style={style}
       {...listeners}
       {...attributes}
-      className={`cursor-grab rounded-lg border border-gray-200 bg-white p-3 shadow-sm ${
+      onPointerDown={handlePointerDown}
+      onClick={handleClick}
+      data-testid="task-card"
+      className={`cursor-pointer rounded-lg border border-gray-200 bg-white p-3 shadow-sm ${
         isDragging ? 'opacity-50' : ''
       }`}
     >

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -81,16 +81,18 @@ describe('TaskDetailModal', () => {
     expect(screen.getByText('Test description')).toBeInTheDocument();
   });
 
-  it('displays task status', () => {
+  it('displays task status as select', () => {
     useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
     renderWithProviders(<TaskDetailModal />);
-    expect(screen.getByText('todo')).toBeInTheDocument();
+    const statusSelect = screen.getByLabelText(/status/i) as HTMLSelectElement;
+    expect(statusSelect.value).toBe('todo');
   });
 
-  it('displays task priority', () => {
+  it('displays task priority as select', () => {
     useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
     renderWithProviders(<TaskDetailModal />);
-    expect(screen.getByText('medium')).toBeInTheDocument();
+    const prioritySelect = screen.getByLabelText(/priority/i) as HTMLSelectElement;
+    expect(prioritySelect.value).toBe('medium');
   });
 
   it('shows loading state', () => {
@@ -135,5 +137,130 @@ describe('TaskDetailModal', () => {
     useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
     renderWithProviders(<TaskDetailModal />);
     expect(screen.getByText(/no description/i)).toBeInTheDocument();
+  });
+
+  describe('inline editing', () => {
+    it('enters title edit mode on click', async () => {
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByText('Test Task'));
+
+      expect(screen.getByDisplayValue('Test Task')).toBeInTheDocument();
+    });
+
+    it('saves title on blur', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByText('Test Task'));
+      const input = screen.getByDisplayValue('Test Task');
+      await user.clear(input);
+      await user.type(input, 'Updated Title');
+      await user.tab();
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { title: 'Updated Title' },
+      });
+    });
+
+    it('does not save empty title', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByText('Test Task'));
+      const input = screen.getByDisplayValue('Test Task');
+      await user.clear(input);
+      await user.tab();
+
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('enters description edit mode on click', async () => {
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByText('Test description'));
+
+      expect(screen.getByDisplayValue('Test description')).toBeInTheDocument();
+    });
+
+    it('saves description on blur', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByText('Test description'));
+      const textarea = screen.getByDisplayValue('Test description');
+      await user.clear(textarea);
+      await user.type(textarea, 'Updated description');
+      await user.tab();
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { description: 'Updated description' },
+      });
+    });
+
+    it('updates status via select', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.selectOptions(screen.getByLabelText(/status/i), 'in_progress');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { status: 'in_progress' },
+      });
+    });
+
+    it('updates priority via select', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.selectOptions(screen.getByLabelText(/priority/i), 'high');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { priority: 'high' },
+      });
+    });
   });
 });

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
+import type { Task } from '../api/generated/model';
+import { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useUiStore } from '../stores/uiStore';
+import { TaskDetailModal } from './TaskDetailModal';
+
+vi.mock('../api/generated/endpoints/tasks/tasks', () => ({
+  useGetTask: vi.fn(),
+  useUpdateTask: vi.fn(),
+  useDeleteTask: vi.fn(),
+}));
+
+const mockTask: Task = {
+  id: 'task-1',
+  project_id: 'project-1',
+  title: 'Test Task',
+  description: 'Test description',
+  status: TaskStatus.todo,
+  priority: TaskPriority.medium,
+  position: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('TaskDetailModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: mockTask,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof tasksApi.useGetTask>);
+    vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+      isPending: false,
+    } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+    vi.mocked(tasksApi.useDeleteTask).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+      isPending: false,
+    } as unknown as ReturnType<typeof tasksApi.useDeleteTask>);
+    useUiStore.setState({
+      selectedTaskId: null,
+      isTaskDetailOpen: false,
+    });
+  });
+
+  it('does not render when modal is closed', () => {
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders when modal is open', () => {
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('displays task title', () => {
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText('Test Task')).toBeInTheDocument();
+  });
+
+  it('displays task description', () => {
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('displays task status', () => {
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText('todo')).toBeInTheDocument();
+  });
+
+  it('displays task priority', () => {
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText('medium')).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as unknown as ReturnType<typeof tasksApi.useGetTask>);
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('closes on ESC key', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+
+    await user.keyboard('{Escape}');
+
+    expect(useUiStore.getState().isTaskDetailOpen).toBe(false);
+    expect(useUiStore.getState().selectedTaskId).toBeNull();
+  });
+
+  it('closes on backdrop click', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+
+    const backdrop = screen.getByRole('dialog');
+    await user.click(backdrop);
+
+    expect(useUiStore.getState().isTaskDetailOpen).toBe(false);
+  });
+
+  it('displays empty description placeholder when no description', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: { ...mockTask, description: undefined },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof tasksApi.useGetTask>);
+    useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+    renderWithProviders(<TaskDetailModal />);
+    expect(screen.getByText(/no description/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -263,4 +263,58 @@ describe('TaskDetailModal', () => {
       });
     });
   });
+
+  describe('delete', () => {
+    it('shows delete button', () => {
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('shows confirmation dialog when delete is clicked', async () => {
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+
+      expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+    });
+
+    it('cancels deletion when cancel is clicked in confirmation', async () => {
+      const mockDeleteMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useDeleteTask).mockReturnValue({
+        mutateAsync: mockDeleteMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useDeleteTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+      expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+    });
+
+    it('deletes task and closes modal on confirm', async () => {
+      const mockDeleteMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useDeleteTask).mockReturnValue({
+        mutateAsync: mockDeleteMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useDeleteTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.click(screen.getByRole('button', { name: /delete/i }));
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ id: 'task-1' });
+      expect(useUiStore.getState().isTaskDetailOpen).toBe(false);
+    });
+  });
 });

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
+import { useDeleteTask, useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 
@@ -17,8 +17,11 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const { data: task, isLoading } = useGetTask(taskId);
   const updateTask = useUpdateTask();
 
+  const deleteTask = useDeleteTask();
+
   const [editingField, setEditingField] = useState<'title' | 'description' | null>(null);
   const [editValue, setEditValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -53,6 +56,11 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       });
     }
     setEditingField(null);
+  };
+
+  const handleDelete = async () => {
+    await deleteTask.mutateAsync({ id: taskId });
+    closeTaskDetail();
   };
 
   const handleSelectChange = async (field: 'status' | 'priority', value: string) => {
@@ -159,6 +167,38 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   <option value="urgent">Urgent</option>
                 </select>
               </div>
+            </div>
+
+            <div className="border-t pt-4">
+              {showDeleteConfirm ? (
+                <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
+                  <p className="text-sm text-red-700">Are you sure you want to delete this task?</p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowDeleteConfirm(false)}
+                      className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
+                >
+                  Delete
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { useGetTask } from '../api/generated/endpoints/tasks/tasks';
+import { useUiStore } from '../stores/uiStore';
+
+export function TaskDetailModal() {
+  const selectedTaskId = useUiStore((s) => s.selectedTaskId);
+  const isOpen = useUiStore((s) => s.isTaskDetailOpen);
+
+  if (!isOpen || !selectedTaskId) return null;
+
+  return <TaskDetailContent taskId={selectedTaskId} />;
+}
+
+function TaskDetailContent({ taskId }: { taskId: string }) {
+  const closeTaskDetail = useUiStore((s) => s.closeTaskDetail);
+  const { data: task, isLoading } = useGetTask(taskId);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeTaskDetail();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeTaskDetail]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeTaskDetail();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        {isLoading || !task ? (
+          <p className="text-sm text-gray-500">Loading...</p>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-start justify-between">
+              <h2 className="text-lg font-semibold text-gray-900">{task.title}</h2>
+              <button
+                type="button"
+                onClick={closeTaskDetail}
+                className="text-gray-400 hover:text-gray-600"
+                aria-label="Close"
+              >
+                &times;
+              </button>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-medium text-gray-700">Description</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                {task.description || 'No description'}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <h3 className="text-sm font-medium text-gray-700">Status</h3>
+                <p className="mt-1 text-sm text-gray-600">{task.status}</p>
+              </div>
+              <div>
+                <h3 className="text-sm font-medium text-gray-700">Priority</h3>
+                <p className="mt-1 text-sm text-gray-600">{task.priority}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -14,14 +14,14 @@ export function TaskDetailModal() {
 
 function TaskDetailContent({ taskId }: { taskId: string }) {
   const closeTaskDetail = useUiStore((s) => s.closeTaskDetail);
-  const { data: task, isLoading } = useGetTask(taskId);
+  const { data: task, isLoading, isError } = useGetTask(taskId);
   const updateTask = useUpdateTask();
-
   const deleteTask = useDeleteTask();
 
   const [editingField, setEditingField] = useState<'title' | 'description' | null>(null);
   const [editValue, setEditValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -49,44 +49,65 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       return;
     }
     const currentValue = field === 'title' ? task?.title : task?.description;
-    if (trimmed !== (currentValue ?? '')) {
-      await updateTask.mutateAsync({
-        id: taskId,
-        data: { [field]: trimmed },
-      });
+    try {
+      if (trimmed !== (currentValue ?? '')) {
+        await updateTask.mutateAsync({
+          id: taskId,
+          data: { [field]: trimmed },
+        });
+      }
+    } catch {
+      setError(`Failed to update ${field}. Please try again.`);
+    } finally {
+      setEditingField(null);
     }
-    setEditingField(null);
   };
 
   const handleDelete = async () => {
-    await deleteTask.mutateAsync({ id: taskId });
-    closeTaskDetail();
+    try {
+      await deleteTask.mutateAsync({ id: taskId });
+      closeTaskDetail();
+    } catch {
+      setError('Failed to delete task. Please try again.');
+    }
   };
 
-  const handleSelectChange = async (field: 'status' | 'priority', value: string) => {
-    await updateTask.mutateAsync({
-      id: taskId,
-      data: { [field]: value },
-    });
+  const handleSelectChange = async (
+    field: 'status' | 'priority',
+    value: TaskStatus | TaskPriority,
+  ) => {
+    try {
+      await updateTask.mutateAsync({
+        id: taskId,
+        data: { [field]: value },
+      });
+    } catch {
+      setError(`Failed to update ${field}. Please try again.`);
+    }
   };
 
   return (
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby="task-detail-modal-title"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={(e) => {
         if (e.target === e.currentTarget) closeTaskDetail();
       }}
     >
       <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
-        {isLoading || !task ? (
+        {isLoading ? (
           <p className="text-sm text-gray-500">Loading...</p>
+        ) : isError || !task ? (
+          <p className="text-sm text-red-500">Failed to load task.</p>
         ) : (
           <div className="space-y-4">
+            {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
             <div className="flex items-start justify-between">
               {editingField === 'title' ? (
                 <input
+                  id="task-detail-modal-title"
                   type="text"
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
@@ -95,12 +116,14 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   autoFocus
                 />
               ) : (
-                <h2
-                  className="cursor-pointer text-lg font-semibold text-gray-900 hover:bg-gray-100 rounded px-1"
+                <button
+                  id="task-detail-modal-title"
+                  type="button"
+                  className="cursor-pointer rounded px-1 text-left text-lg font-semibold text-gray-900 hover:bg-gray-100"
                   onClick={() => startEditing('title', task.title)}
                 >
                   {task.title}
-                </h2>
+                </button>
               )}
               <button
                 type="button"
@@ -124,18 +147,22 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   autoFocus
                 />
               ) : (
-                <p
-                  className="mt-1 cursor-pointer text-sm text-gray-600 hover:bg-gray-100 rounded px-1"
+                <button
+                  type="button"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
                   onClick={() => startEditing('description', task.description ?? '')}
                 >
                   {task.description || 'No description'}
-                </p>
+                </button>
               )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="task-detail-status" className="block text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="task-detail-status"
+                  className="block text-sm font-medium text-gray-700"
+                >
                   Status
                 </label>
                 <select
@@ -152,7 +179,10 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                 </select>
               </div>
               <div>
-                <label htmlFor="task-detail-priority" className="block text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="task-detail-priority"
+                  className="block text-sm font-medium text-gray-700"
+                >
                   Priority
                 </label>
                 <select

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
-import { useGetTask } from '../api/generated/endpoints/tasks/tasks';
+import { useEffect, useState } from 'react';
+import { useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
+import type { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 
 export function TaskDetailModal() {
@@ -14,14 +15,52 @@ export function TaskDetailModal() {
 function TaskDetailContent({ taskId }: { taskId: string }) {
   const closeTaskDetail = useUiStore((s) => s.closeTaskDetail);
   const { data: task, isLoading } = useGetTask(taskId);
+  const updateTask = useUpdateTask();
+
+  const [editingField, setEditingField] = useState<'title' | 'description' | null>(null);
+  const [editValue, setEditValue] = useState('');
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeTaskDetail();
+      if (e.key === 'Escape') {
+        if (editingField) {
+          setEditingField(null);
+        } else {
+          closeTaskDetail();
+        }
+      }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeTaskDetail]);
+  }, [closeTaskDetail, editingField]);
+
+  const startEditing = (field: 'title' | 'description', value: string) => {
+    setEditingField(field);
+    setEditValue(value);
+  };
+
+  const saveField = async (field: 'title' | 'description') => {
+    const trimmed = editValue.trim();
+    if (field === 'title' && !trimmed) {
+      setEditingField(null);
+      return;
+    }
+    const currentValue = field === 'title' ? task?.title : task?.description;
+    if (trimmed !== (currentValue ?? '')) {
+      await updateTask.mutateAsync({
+        id: taskId,
+        data: { [field]: trimmed },
+      });
+    }
+    setEditingField(null);
+  };
+
+  const handleSelectChange = async (field: 'status' | 'priority', value: string) => {
+    await updateTask.mutateAsync({
+      id: taskId,
+      data: { [field]: value },
+    });
+  };
 
   return (
     <div
@@ -38,7 +77,23 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         ) : (
           <div className="space-y-4">
             <div className="flex items-start justify-between">
-              <h2 className="text-lg font-semibold text-gray-900">{task.title}</h2>
+              {editingField === 'title' ? (
+                <input
+                  type="text"
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={() => saveField('title')}
+                  className="flex-1 rounded border border-blue-300 px-2 py-1 text-lg font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                />
+              ) : (
+                <h2
+                  className="cursor-pointer text-lg font-semibold text-gray-900 hover:bg-gray-100 rounded px-1"
+                  onClick={() => startEditing('title', task.title)}
+                >
+                  {task.title}
+                </h2>
+              )}
               <button
                 type="button"
                 onClick={closeTaskDetail}
@@ -51,19 +106,58 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
 
             <div>
               <h3 className="text-sm font-medium text-gray-700">Description</h3>
-              <p className="mt-1 text-sm text-gray-600">
-                {task.description || 'No description'}
-              </p>
+              {editingField === 'description' ? (
+                <textarea
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={() => saveField('description')}
+                  rows={3}
+                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                />
+              ) : (
+                <p
+                  className="mt-1 cursor-pointer text-sm text-gray-600 hover:bg-gray-100 rounded px-1"
+                  onClick={() => startEditing('description', task.description ?? '')}
+                >
+                  {task.description || 'No description'}
+                </p>
+              )}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <h3 className="text-sm font-medium text-gray-700">Status</h3>
-                <p className="mt-1 text-sm text-gray-600">{task.status}</p>
+                <label htmlFor="task-detail-status" className="block text-sm font-medium text-gray-700">
+                  Status
+                </label>
+                <select
+                  id="task-detail-status"
+                  value={task.status}
+                  onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="backlog">Backlog</option>
+                  <option value="todo">To Do</option>
+                  <option value="in_progress">In Progress</option>
+                  <option value="in_review">In Review</option>
+                  <option value="done">Done</option>
+                </select>
               </div>
               <div>
-                <h3 className="text-sm font-medium text-gray-700">Priority</h3>
-                <p className="mt-1 text-sm text-gray-600">{task.priority}</p>
+                <label htmlFor="task-detail-priority" className="block text-sm font-medium text-gray-700">
+                  Priority
+                </label>
+                <select
+                  id="task-detail-priority"
+                  value={task.priority}
+                  onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                  <option value="urgent">Urgent</option>
+                </select>
               </div>
             </div>
           </div>

--- a/frontend/src/stores/uiStore.test.ts
+++ b/frontend/src/stores/uiStore.test.ts
@@ -10,6 +10,8 @@ describe('uiStore', () => {
       isTaskModalOpen: false,
       defaultStatus: null,
       isProjectModalOpen: false,
+      selectedTaskId: null,
+      isTaskDetailOpen: false,
     });
   });
 
@@ -40,6 +42,29 @@ describe('uiStore', () => {
       const state = useUiStore.getState();
       expect(state.isTaskModalOpen).toBe(false);
       expect(state.defaultStatus).toBeNull();
+    });
+  });
+
+  describe('task detail modal', () => {
+    it('has correct initial state', () => {
+      const state = useUiStore.getState();
+      expect(state.selectedTaskId).toBeNull();
+      expect(state.isTaskDetailOpen).toBe(false);
+    });
+
+    it('opens task detail with task id', () => {
+      useUiStore.getState().openTaskDetail('task-123');
+      const state = useUiStore.getState();
+      expect(state.selectedTaskId).toBe('task-123');
+      expect(state.isTaskDetailOpen).toBe(true);
+    });
+
+    it('closes task detail and resets selectedTaskId', () => {
+      useUiStore.getState().openTaskDetail('task-123');
+      useUiStore.getState().closeTaskDetail();
+      const state = useUiStore.getState();
+      expect(state.selectedTaskId).toBeNull();
+      expect(state.isTaskDetailOpen).toBe(false);
     });
   });
 

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -24,8 +24,7 @@ export const useUiStore = create<UiState>((set) => ({
   closeTaskModal: () => set({ isTaskModalOpen: false, defaultStatus: null }),
   selectedTaskId: null,
   isTaskDetailOpen: false,
-  openTaskDetail: (taskId: string) =>
-    set({ selectedTaskId: taskId, isTaskDetailOpen: true }),
+  openTaskDetail: (taskId: string) => set({ selectedTaskId: taskId, isTaskDetailOpen: true }),
   closeTaskDetail: () => set({ selectedTaskId: null, isTaskDetailOpen: false }),
   isProjectModalOpen: false,
   openProjectModal: () => set({ isProjectModalOpen: true }),

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -7,6 +7,10 @@ interface UiState {
   defaultStatus: TaskStatus | null;
   openTaskModal: (status?: TaskStatus) => void;
   closeTaskModal: () => void;
+  selectedTaskId: string | null;
+  isTaskDetailOpen: boolean;
+  openTaskDetail: (taskId: string) => void;
+  closeTaskDetail: () => void;
   isProjectModalOpen: boolean;
   openProjectModal: () => void;
   closeProjectModal: () => void;
@@ -18,6 +22,11 @@ export const useUiStore = create<UiState>((set) => ({
   openTaskModal: (status?: TaskStatus) =>
     set({ isTaskModalOpen: true, defaultStatus: status ?? null }),
   closeTaskModal: () => set({ isTaskModalOpen: false, defaultStatus: null }),
+  selectedTaskId: null,
+  isTaskDetailOpen: false,
+  openTaskDetail: (taskId: string) =>
+    set({ selectedTaskId: taskId, isTaskDetailOpen: true }),
+  closeTaskDetail: () => set({ selectedTaskId: null, isTaskDetailOpen: false }),
   isProjectModalOpen: false,
   openProjectModal: () => set({ isProjectModalOpen: true }),
   closeProjectModal: () => set({ isProjectModalOpen: false }),


### PR DESCRIPTION
## Summary
Add a task detail modal with inline editing and delete functionality, triggered by clicking a task card on the Kanban board.

## Changes
- Add `selectedTaskId` / `isTaskDetailOpen` state to `uiStore`
- Create `TaskDetailModal` component with read-only view, inline editing (title, description, status, priority), and delete with confirmation
- Add click handler to `TaskCard` that distinguishes clicks from drags
- Wire up `TaskDetailModal` in `App.tsx`

## Why
Users need to view, edit, and delete tasks without leaving the Kanban board. This implements the core task management workflow described in #22.

## Test Plan
- [x] uiStore: openTaskDetail/closeTaskDetail state transitions (3 tests)
- [x] TaskDetailModal: display, loading, ESC/backdrop close (10 tests)
- [x] TaskDetailModal: inline editing for title, description, status, priority (7 tests)
- [x] TaskDetailModal: delete with confirmation dialog (4 tests)
- [x] TaskCard: click opens detail, pointer cursor (2 tests)
- [x] All 81 existing tests pass

## Related
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)