### PR TITLE
fix: 🔒️ restrict auth_disabled to debug builds only

### DIFF
--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -7,6 +7,9 @@ if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
   . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 
+# Ensure cargo is in PATH (installed globally via rustup)
+export PATH="$HOME/.cargo/bin:$PATH"
+
 cd "$(git rev-parse --show-toplevel)"
 
 INPUT=$(cat)
@@ -72,12 +75,7 @@ if [[ -n "$SIZE_WARN" ]]; then
 fi
 
 # --- 3. Full quality check ---
-if command -v devbox > /dev/null 2>&1 && [[ -f devbox.json ]]; then
-  CHECK_CMD="devbox run -- task check"
-else
-  CHECK_CMD="task check"
-fi
-if ! $CHECK_CMD 2>&1; then
+if ! task check 2>&1; then
   echo '{"decision":"block","reason":"Quality checks failed. Run `task check` to see details."}'
   exit 2
 fi

--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,1 +1,13 @@
+# Gantry Board - direnv configuration
+# Copy this file to .envrc and run `direnv allow`
+#   cp .envrc.sample .envrc && direnv allow
+
 eval "$(devbox generate direnv --print-envrc)"
+
+# Cargo / Rust toolchain
+path_add PATH "$HOME/.cargo/bin"
+
+# Use mold linker if available
+if has mold; then
+  export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,26 +47,32 @@ tasks:
   # ── Backend (Rust) ────────────────────────────
   backend:fmt:
     desc: Format Rust code
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo fmt
 
   backend:fmt:check:
     desc: Check Rust formatting
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo fmt --check
 
   backend:lint:
     desc: Run clippy
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo clippy --all-targets -- -D warnings
 
   backend:build:
     desc: Build Rust backend
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo build
 
   backend:test:
     desc: Run Rust tests
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo test
 
   backend:run:
     desc: Run backend server
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo run
     env:
       RUST_LOG: info
@@ -139,6 +145,7 @@ tasks:
   # ── API (OpenAPI / orval) ─────────────────────
   api:export:
     desc: Export OpenAPI spec from Rust tests
+    dir: "{{.BACKEND_DIR}}"
     cmd: cargo test --test export_openapi -- --nocapture
     generates:
       - openapi.json

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -23,9 +23,9 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // Check if auth is disabled (development mode)
+        // Auth bypass for development — compiled out of release builds
+        #[cfg(debug_assertions)]
         if state.config.auth_disabled {
-            // Return a dummy user for development
             return Ok(AuthUser {
                 user_id: Uuid::nil(),
                 session_id: Uuid::nil(),

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -61,6 +61,7 @@ impl Default for Config {
 }
 
 #[cfg(test)]
+#[cfg(debug_assertions)]
 mod tests {
     use super::*;
 
@@ -72,8 +73,6 @@ mod tests {
 
     #[test]
     fn test_auth_disabled_can_be_enabled_in_debug_builds() {
-        // In release builds, this field is gated by #[cfg(debug_assertions)]
-        // and does not exist. Tests always run in debug mode.
         let config = Config {
             auth_disabled: true,
             ..Default::default()

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -14,7 +14,8 @@ pub struct Config {
     #[serde(default = "default_session_duration_hours")]
     pub session_duration_hours: u64,
 
-    /// Disable authentication (for development only)
+    /// Disable authentication (debug builds only — never available in release)
+    #[cfg(debug_assertions)]
     #[serde(default)]
     pub auth_disabled: bool,
 
@@ -52,8 +53,31 @@ impl Default for Config {
             bind_addr: default_bind_addr(),
             database_url: default_database_url(),
             session_duration_hours: default_session_duration_hours(),
+            #[cfg(debug_assertions)]
             auth_disabled: false,
             cookie_secure: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_disabled_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.auth_disabled);
+    }
+
+    #[test]
+    fn test_auth_disabled_can_be_enabled_in_debug_builds() {
+        // In release builds, this field is gated by #[cfg(debug_assertions)]
+        // and does not exist. Tests always run in debug mode.
+        let config = Config {
+            auth_disabled: true,
+            ..Default::default()
+        };
+        assert!(config.auth_disabled);
     }
 }

--- a/backend/src/handlers/projects.rs
+++ b/backend/src/handlers/projects.rs
@@ -24,9 +24,14 @@ pub async fn list_projects(
     State(state): State<AppState>,
     auth: AuthUser,
 ) -> AppResult<Json<Vec<Project>>> {
-    let projects = if auth.user_id.is_nil() {
-        project_service::list_projects(&state.pool).await?
-    } else {
+    let projects = {
+        #[cfg(debug_assertions)]
+        if auth.user_id.is_nil() {
+            project_service::list_projects(&state.pool).await?
+        } else {
+            project_service::list_projects_for_user(&state.pool, auth.user_id).await?
+        }
+        #[cfg(not(debug_assertions))]
         project_service::list_projects_for_user(&state.pool, auth.user_id).await?
     };
     Ok(Json(projects))
@@ -50,8 +55,18 @@ pub async fn create_project(
         .map_err(|e| AppError::Validation(e.to_string()))?;
     let project = project_service::create_project(&state.pool, &body).await?;
 
-    // Auto-add creator as owner (skip in auth_disabled mode)
-    if !auth.user_id.is_nil() {
+    // Auto-add creator as owner (skip in auth_disabled mode for debug builds)
+    let should_add_owner = {
+        #[cfg(debug_assertions)]
+        {
+            !auth.user_id.is_nil()
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            true
+        }
+    };
+    if should_add_owner {
         member_service::add_member(
             &state.pool,
             project.id,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -13,6 +13,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let config = Config::load()?;
+
+    #[cfg(debug_assertions)]
+    if config.auth_disabled {
+        tracing::warn!("Authentication is DISABLED. Do not use in production!");
+    }
+
     let pool = db::init_pool(&config.database_url).await?;
 
     let state = AppState {

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -181,6 +181,7 @@ mod tests {
         assert!(matches!(result, Err(AppError::Forbidden(_))));
     }
 
+    #[cfg(debug_assertions)]
     #[tokio::test]
     async fn test_require_project_member_skips_for_nil_user() {
         let pool = setup_test_db().await;

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -6,12 +6,13 @@ use crate::models::project::MemberRole;
 
 /// Check if user is a member of the project (any role).
 /// Returns the member's role or Forbidden.
-/// When user_id is nil (auth_disabled mode), returns Owner to grant full access.
 pub async fn require_project_member(
     pool: &SqlitePool,
     user_id: Uuid,
     project_id: Uuid,
 ) -> AppResult<MemberRole> {
+    // Nil UUID bypass for auth_disabled mode — compiled out of release builds
+    #[cfg(debug_assertions)]
     if user_id.is_nil() {
         return Ok(MemberRole::Owner);
     }

--- a/devbox.json
+++ b/devbox.json
@@ -1,26 +1,21 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
   "packages": {
-    "rustup": "latest",
-    "nodejs": "22",
-    "sqlite": "latest",
+    "nodejs":     "22",
+    "sqlite":     "latest",
     "pkg-config": "latest",
-    "gcc": "latest",
-    "curl": "latest",
-    "sccache": "latest",
-    "mold": "latest"
+    "gcc":        "latest",
+    "curl":       "latest",
+    "sccache":    "latest",
+    "mold":       "latest"
   },
   "env": {
-    "RUST_LOG": "info",
+    "RUST_LOG":      "info",
     "RUSTC_WRAPPER": "sccache"
   },
   "shell": {
     "init_hook": [
       "echo 'Setting up Gantry Board development environment...'",
-      "export PATH=\"$HOME/.cargo/bin:$PATH\"",
-      "# Rust toolchain",
-      "rustup default stable 2>/dev/null",
-      "rustup component add clippy rustfmt 2>/dev/null",
       "# Configure mold linker",
       "if command -v mold > /dev/null 2>&1; then export RUSTFLAGS=\"-C link-arg=-fuse-ld=mold\"; fi",
       "# Install cargo tools (first time only)",
@@ -33,7 +28,7 @@
       "echo '  Run \"devbox services up\" to start backend + frontend.'"
     ],
     "scripts": {
-      "dev": "devbox services up",
+      "dev":      "devbox services up",
       "setup-db": "cd backend && sqlx database create && sqlx migrate run",
       "reset-db": "cd backend && sqlx database drop -y && sqlx database create && sqlx migrate run"
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -426,55 +426,6 @@
         }
       }
     },
-    "rustup@latest": {
-      "last_modified": "2026-01-23T17:20:52Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#rustup",
-      "source": "devbox-search",
-      "version": "1.28.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/r0nacc31pp9jglw15wacjp8bzyjhi41b-rustup-1.28.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/r0nacc31pp9jglw15wacjp8bzyjhi41b-rustup-1.28.2"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/jczizx7qz254wi11kj9flx1kyzvpxb3x-rustup-1.28.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/jczizx7qz254wi11kj9flx1kyzvpxb3x-rustup-1.28.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/prxdrp8ffnsrmzfznjgiqvqm8j810c5v-rustup-1.28.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/prxdrp8ffnsrmzfznjgiqvqm8j810c5v-rustup-1.28.2"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/8kys5yhdhiybfw4p4rdyfg7av8rldl6r-rustup-1.28.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/8kys5yhdhiybfw4p4rdyfg7av8rldl6r-rustup-1.28.2"
-        }
-      }
-    },
     "sccache@latest": {
       "last_modified": "2026-01-23T17:20:52Z",
       "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#sccache",


### PR DESCRIPTION
## Summary
- Gate `auth_disabled` flag and all related bypass code with `#[cfg(debug_assertions)]`, ensuring the auth bypass cannot exist in release builds (compile-time guarantee)
- Add startup warning log when `auth_disabled` is enabled
- Migrate rustup from devbox to global install

Closes #12

## Changes
| File | Change |
|------|--------|
| `backend/src/config.rs` | Gate `auth_disabled` field with `#[cfg(debug_assertions)]` + add tests |
| `backend/src/auth/middleware.rs` | Gate auth bypass block with `#[cfg(debug_assertions)]` |
| `backend/src/main.rs` | Add startup warning log |
| `backend/src/services/authorization_service.rs` | Gate `Uuid::nil()` Owner bypass with `#[cfg(debug_assertions)]` (defense in depth) |
| `backend/src/handlers/projects.rs` | Gate `is_nil()` branches with `#[cfg(debug_assertions)]` |
| `devbox.json` / `Taskfile.yml` / `.envrc.sample` | Migrate rustup to global install |

## Test plan
- [x] `task check` passes (fmt, lint, build, test)
- [x] `cargo build --release` compiles successfully (auth_disabled code excluded)
- [x] All 167 backend + 81 frontend tests pass