### PR TITLE
feat: ✨ add git worktree service (#24)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 argon2 = "0.5"
 rand = "0.8"
 axum-extra = { version = "0.10", features = ["cookie"] }
+
+# Git
+git2 = "0.20"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,6 +33,8 @@ tokio-stream = { workspace = true }
 argon2 = { workspace = true }
 rand = { workspace = true }
 axum-extra = { workspace = true }
+git2 = { workspace = true }
 
 [dev-dependencies]
 axum-test = "18"
+tempfile = "3"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -22,6 +22,10 @@ pub struct Config {
     /// Use secure cookies (HTTPS only) - should be true in production
     #[serde(default)]
     pub cookie_secure: bool,
+
+    /// Path to the git repository for worktree management
+    #[serde(default)]
+    pub repository_path: Option<String>,
 }
 
 fn default_bind_addr() -> String {
@@ -56,6 +60,7 @@ impl Default for Config {
             #[cfg(debug_assertions)]
             auth_disabled: false,
             cookie_secure: false,
+            repository_path: None,
         }
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -34,6 +34,9 @@ pub enum AppError {
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    #[error("git error: {0}")]
+    Git(#[from] git2::Error),
+
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }
@@ -72,6 +75,13 @@ impl IntoResponse for AppError {
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "database error".to_string(),
                 )
+            }
+            AppError::Git(err) => {
+                if err.code() == git2::ErrorCode::NotFound {
+                    return AppError::NotFound(err.message().to_string()).into_response();
+                }
+                tracing::error!(%err, "git error");
+                (StatusCode::INTERNAL_SERVER_ERROR, "git error".to_string())
             }
             AppError::Anyhow(err) => {
                 tracing::error!(%err, "internal server error");

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -76,13 +76,22 @@ impl IntoResponse for AppError {
                     "database error".to_string(),
                 )
             }
-            AppError::Git(err) => {
-                if err.code() == git2::ErrorCode::NotFound {
-                    return AppError::NotFound(err.message().to_string()).into_response();
+            AppError::Git(err) => match err.code() {
+                git2::ErrorCode::NotFound => {
+                    tracing::info!(%err, "git not found");
+                    return AppError::NotFound("resource not found".to_string()).into_response();
                 }
-                tracing::error!(%err, "git error");
-                (StatusCode::INTERNAL_SERVER_ERROR, "git error".to_string())
-            }
+                git2::ErrorCode::Exists => {
+                    return AppError::Conflict(err.message().to_string()).into_response();
+                }
+                git2::ErrorCode::InvalidSpec | git2::ErrorCode::Invalid => {
+                    return AppError::Validation(err.message().to_string()).into_response();
+                }
+                _ => {
+                    tracing::error!(%err, "git error");
+                    (StatusCode::INTERNAL_SERVER_ERROR, "git error".to_string())
+                }
+            },
             AppError::Anyhow(err) => {
                 tracing::error!(%err, "internal server error");
                 (

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -4,3 +4,4 @@ pub mod project_service;
 pub mod session_service;
 pub mod task_service;
 pub mod user_service;
+pub mod worktree_service;

--- a/backend/src/services/worktree_service.rs
+++ b/backend/src/services/worktree_service.rs
@@ -1,8 +1,25 @@
 use std::path::{Path, PathBuf};
 
 use git2::{BranchType, Repository, WorktreeAddOptions, WorktreePruneOptions};
+use tracing::warn;
 
 use crate::error::{AppError, AppResult};
+
+fn validate_worktree_name(name: &str) -> AppResult<()> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+        || name == "."
+        || name == ".."
+        || name.starts_with('-')
+    {
+        return Err(AppError::Validation(format!(
+            "invalid worktree name: {name}"
+        )));
+    }
+    Ok(())
+}
 
 /// Information about a git worktree.
 #[derive(Debug, Clone)]
@@ -15,21 +32,24 @@ pub struct WorktreeInfo {
 
 /// Create a new worktree with a branch forked from HEAD.
 pub fn create_worktree(repo_path: &Path, name: &str) -> AppResult<WorktreeInfo> {
+    validate_worktree_name(name)?;
     let repo = Repository::open(repo_path)?;
 
     let head = repo.head()?;
     let commit = head.peel_to_commit()?;
-    let branch = repo.branch(name, &commit, false)?;
+    let mut branch = repo.branch(name, &commit, false)?;
 
     let wt_path = repo_path
         .parent()
         .ok_or_else(|| AppError::Internal("repository has no parent directory".to_string()))?
         .join(name);
 
-    let branch_ref = branch.into_reference();
     let mut opts = WorktreeAddOptions::new();
-    opts.reference(Some(&branch_ref));
-    repo.worktree(name, &wt_path, Some(&opts))?;
+    opts.reference(Some(branch.get()));
+    if let Err(e) = repo.worktree(name, &wt_path, Some(&opts)) {
+        let _ = branch.delete();
+        return Err(e.into());
+    }
 
     Ok(WorktreeInfo {
         name: name.to_string(),
@@ -46,9 +66,8 @@ pub fn list_worktrees(repo_path: &Path) -> AppResult<Vec<WorktreeInfo>> {
 
     let mut result = Vec::new();
     for name in worktrees.iter().flatten() {
-        if let Ok(info) = build_worktree_info(&repo, name) {
-            result.push(info);
-        }
+        let info = build_worktree_info(&repo, name)?;
+        result.push(info);
     }
     Ok(result)
 }
@@ -71,7 +90,9 @@ pub fn delete_worktree(repo_path: &Path, name: &str) -> AppResult<()> {
 
     // Clean up the branch
     if let Ok(mut branch) = repo.find_branch(name, BranchType::Local) {
-        let _ = branch.delete();
+        if let Err(e) = branch.delete() {
+            warn!(%e, name, "failed to delete branch after worktree removal");
+        }
     }
 
     Ok(())
@@ -224,5 +245,16 @@ mod tests {
 
         assert!(get_worktree(&repo_path, "del-wt").is_err());
         assert!(!wt_path.exists());
+    }
+
+    #[test]
+    fn test_create_worktree_rejects_path_traversal() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        assert!(create_worktree(&repo_path, "../escape").is_err());
+        assert!(create_worktree(&repo_path, "a/b").is_err());
+        assert!(create_worktree(&repo_path, "..").is_err());
+        assert!(create_worktree(&repo_path, ".").is_err());
+        assert!(create_worktree(&repo_path, "").is_err());
     }
 }

--- a/backend/src/services/worktree_service.rs
+++ b/backend/src/services/worktree_service.rs
@@ -1,0 +1,155 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::AppResult;
+
+/// Information about a git worktree.
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub is_valid: bool,
+}
+
+/// Create a new worktree with a branch forked from HEAD.
+pub fn create_worktree(_repo_path: &Path, _name: &str) -> AppResult<WorktreeInfo> {
+    todo!()
+}
+
+/// List all worktrees in the repository.
+pub fn list_worktrees(_repo_path: &Path) -> AppResult<Vec<WorktreeInfo>> {
+    todo!()
+}
+
+/// Get information about a specific worktree by name.
+pub fn get_worktree(_repo_path: &Path, _name: &str) -> AppResult<WorktreeInfo> {
+    todo!()
+}
+
+/// Delete a worktree and its working directory.
+pub fn delete_worktree(_repo_path: &Path, _name: &str) -> AppResult<()> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Creates a temporary git repository with one initial commit.
+    fn setup_test_repo() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let repo = git2::Repository::init(dir.path()).expect("Failed to init repo");
+
+        let sig =
+            git2::Signature::now("Test", "test@example.com").expect("Failed to create signature");
+        let tree_id = repo
+            .index()
+            .expect("Failed to get index")
+            .write_tree()
+            .expect("Failed to write tree");
+        let tree = repo.find_tree(tree_id).expect("Failed to find tree");
+        repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+            .expect("Failed to create initial commit");
+
+        let path = dir.path().to_path_buf();
+        (dir, path)
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_create_worktree_returns_info() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        let info = create_worktree(&repo_path, "test-wt").expect("Failed to create worktree");
+
+        assert_eq!(info.name, "test-wt");
+        assert_eq!(info.branch, Some("test-wt".to_string()));
+        assert!(info.is_valid);
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_create_worktree_directory_exists() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        let info = create_worktree(&repo_path, "test-wt").expect("Failed to create worktree");
+
+        assert!(info.path.exists());
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_create_duplicate_worktree_returns_error() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        create_worktree(&repo_path, "dup-wt").expect("First create should succeed");
+        let result = create_worktree(&repo_path, "dup-wt");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_list_worktrees_empty() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        let list = list_worktrees(&repo_path).expect("Failed to list worktrees");
+
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_list_worktrees_returns_created() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        create_worktree(&repo_path, "wt-a").expect("Failed to create wt-a");
+        create_worktree(&repo_path, "wt-b").expect("Failed to create wt-b");
+
+        let list = list_worktrees(&repo_path).expect("Failed to list worktrees");
+
+        assert_eq!(list.len(), 2);
+        let names: Vec<&str> = list.iter().map(|w| w.name.as_str()).collect();
+        assert!(names.contains(&"wt-a"));
+        assert!(names.contains(&"wt-b"));
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_get_worktree_returns_existing() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        create_worktree(&repo_path, "my-wt").expect("Failed to create worktree");
+
+        let info = get_worktree(&repo_path, "my-wt").expect("Failed to get worktree");
+
+        assert_eq!(info.name, "my-wt");
+        assert!(info.is_valid);
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_get_worktree_not_found() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        let result = get_worktree(&repo_path, "nonexistent");
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[ignore = "TDD: pending implementation"]
+    fn test_delete_worktree_removes_it() {
+        let (_dir, repo_path) = setup_test_repo();
+
+        let info = create_worktree(&repo_path, "del-wt").expect("Failed to create worktree");
+        let wt_path = info.path.clone();
+
+        delete_worktree(&repo_path, "del-wt").expect("Failed to delete worktree");
+
+        assert!(get_worktree(&repo_path, "del-wt").is_err());
+        assert!(!wt_path.exists());
+    }
+}

--- a/backend/src/services/worktree_service.rs
+++ b/backend/src/services/worktree_service.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use crate::error::AppResult;
+use git2::{BranchType, Repository, WorktreeAddOptions, WorktreePruneOptions};
+
+use crate::error::{AppError, AppResult};
 
 /// Information about a git worktree.
 #[derive(Debug, Clone)]
@@ -12,23 +14,91 @@ pub struct WorktreeInfo {
 }
 
 /// Create a new worktree with a branch forked from HEAD.
-pub fn create_worktree(_repo_path: &Path, _name: &str) -> AppResult<WorktreeInfo> {
-    todo!()
+pub fn create_worktree(repo_path: &Path, name: &str) -> AppResult<WorktreeInfo> {
+    let repo = Repository::open(repo_path)?;
+
+    let head = repo.head()?;
+    let commit = head.peel_to_commit()?;
+    let branch = repo.branch(name, &commit, false)?;
+
+    let wt_path = repo_path
+        .parent()
+        .ok_or_else(|| AppError::Internal("repository has no parent directory".to_string()))?
+        .join(name);
+
+    let branch_ref = branch.into_reference();
+    let mut opts = WorktreeAddOptions::new();
+    opts.reference(Some(&branch_ref));
+    repo.worktree(name, &wt_path, Some(&opts))?;
+
+    Ok(WorktreeInfo {
+        name: name.to_string(),
+        path: wt_path,
+        branch: Some(name.to_string()),
+        is_valid: true,
+    })
 }
 
 /// List all worktrees in the repository.
-pub fn list_worktrees(_repo_path: &Path) -> AppResult<Vec<WorktreeInfo>> {
-    todo!()
+pub fn list_worktrees(repo_path: &Path) -> AppResult<Vec<WorktreeInfo>> {
+    let repo = Repository::open(repo_path)?;
+    let worktrees = repo.worktrees()?;
+
+    let mut result = Vec::new();
+    for name in worktrees.iter().flatten() {
+        if let Ok(info) = build_worktree_info(&repo, name) {
+            result.push(info);
+        }
+    }
+    Ok(result)
 }
 
 /// Get information about a specific worktree by name.
-pub fn get_worktree(_repo_path: &Path, _name: &str) -> AppResult<WorktreeInfo> {
-    todo!()
+pub fn get_worktree(repo_path: &Path, name: &str) -> AppResult<WorktreeInfo> {
+    let repo = Repository::open(repo_path)?;
+    build_worktree_info(&repo, name)
 }
 
 /// Delete a worktree and its working directory.
-pub fn delete_worktree(_repo_path: &Path, _name: &str) -> AppResult<()> {
-    todo!()
+pub fn delete_worktree(repo_path: &Path, name: &str) -> AppResult<()> {
+    let repo = Repository::open(repo_path)?;
+    let wt = repo.find_worktree(name)?;
+
+    let mut opts = WorktreePruneOptions::new();
+    opts.valid(true);
+    opts.working_tree(true);
+    wt.prune(Some(&mut opts))?;
+
+    // Clean up the branch
+    if let Ok(mut branch) = repo.find_branch(name, BranchType::Local) {
+        let _ = branch.delete();
+    }
+
+    Ok(())
+}
+
+fn build_worktree_info(repo: &Repository, name: &str) -> AppResult<WorktreeInfo> {
+    let wt = repo.find_worktree(name)?;
+    let is_valid = wt.validate().is_ok();
+    let wt_path = wt.path().to_path_buf();
+
+    let branch = if is_valid {
+        Repository::open(&wt_path).ok().and_then(|wt_repo| {
+            wt_repo
+                .head()
+                .ok()
+                .and_then(|h| h.shorthand().map(String::from))
+        })
+    } else {
+        None
+    };
+
+    Ok(WorktreeInfo {
+        name: name.to_string(),
+        path: wt_path,
+        branch,
+        is_valid,
+    })
 }
 
 #[cfg(test)]
@@ -38,9 +108,13 @@ mod tests {
     use tempfile::TempDir;
 
     /// Creates a temporary git repository with one initial commit.
+    /// The repo is placed in a `repo` subdirectory so worktrees can be
+    /// created as siblings inside the same TempDir.
     fn setup_test_repo() -> (TempDir, PathBuf) {
         let dir = TempDir::new().expect("Failed to create temp dir");
-        let repo = git2::Repository::init(dir.path()).expect("Failed to init repo");
+        let repo_path = dir.path().join("repo");
+        std::fs::create_dir(&repo_path).expect("Failed to create repo dir");
+        let repo = git2::Repository::init(&repo_path).expect("Failed to init repo");
 
         let sig =
             git2::Signature::now("Test", "test@example.com").expect("Failed to create signature");
@@ -53,12 +127,11 @@ mod tests {
         repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
             .expect("Failed to create initial commit");
 
-        let path = dir.path().to_path_buf();
-        (dir, path)
+        (dir, repo_path)
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_create_worktree_returns_info() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -70,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_create_worktree_directory_exists() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -80,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_create_duplicate_worktree_returns_error() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -91,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_list_worktrees_empty() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -101,7 +174,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_list_worktrees_returns_created() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -117,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_get_worktree_returns_existing() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -130,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_get_worktree_not_found() {
         let (_dir, repo_path) = setup_test_repo();
 
@@ -140,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TDD: pending implementation"]
+
     fn test_delete_worktree_removes_it() {
         let (_dir, repo_path) = setup_test_repo();
 


### PR DESCRIPTION
## Summary
- Add git worktree CRUD service using the git2 crate
- Implement `create_worktree` / `list_worktrees` / `get_worktree` / `delete_worktree`
- Add `repository_path` field to `Config` (env: `GANTRY_REPOSITORY_PATH`)
- Add `AppError::Git` variant for git2 error-to-HTTP response mapping

## Changes
- **New**: `backend/src/services/worktree_service.rs` — worktree service with 8 tests
- `Cargo.toml` — add `git2 = "0.20"` workspace dependency
- `backend/Cargo.toml` — add `git2` + dev-dep `tempfile`
- `backend/src/config.rs` — add `repository_path: Option<String>`
- `backend/src/error.rs` — add `Git(#[from] git2::Error)` variant
- `backend/src/services/mod.rs` — register module

Closes #24

## Test plan
- [x] `cargo test -p gantry-board worktree` — all 8 tests pass
- [x] `cargo test -p gantry-board --lib -- --skip worktree` — all 100 existing tests pass (no regressions)
- [x] `cargo clippy -p gantry-board -- -D warnings` — zero warnings
- [x] `cargo fmt -p gantry-board --check` — clean