### PR TITLE
feat: ✨ add AgentExecutor trait and agent types (#25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +304,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -606,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +771,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argon2",
+ "async-trait",
  "axum",
  "axum-extra",
  "axum-test",
@@ -760,13 +780,16 @@ dependencies = [
  "figment",
  "futures-util",
  "garde",
+ "git2",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -833,6 +856,21 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -1148,6 +1186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1219,20 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -1199,6 +1261,38 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1399,6 +1493,24 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -1776,6 +1888,19 @@ dependencies = [
  "mime",
  "rand 0.9.2",
  "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2241,6 +2366,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2524,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ axum-extra = { version = "0.10", features = ["cookie"] }
 
 # Git
 git2 = "0.20"
+
+# Agent
+async-trait = "0.1"
+tokio-util = { version = "0.7", features = ["rt"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -34,6 +34,8 @@ argon2 = { workspace = true }
 rand = { workspace = true }
 axum-extra = { workspace = true }
 git2 = { workspace = true }
+async-trait = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 axum-test = "18"

--- a/backend/src/agent/executor.rs
+++ b/backend/src/agent/executor.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::error::AppResult;
+use crate::models::agent_session::AgentType;
+
+/// Configuration for launching an agent process.
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    pub agent_type: AgentType,
+    pub session_id: Uuid,
+    pub task_id: Uuid,
+    pub working_dir: PathBuf,
+    pub prompt: String,
+}
+
+/// Events emitted by a running agent process.
+#[derive(Debug, Clone)]
+pub enum AgentOutputEvent {
+    Output { text: String },
+    Completed,
+    Failed { error: String },
+}
+
+/// Handle to a running agent process.
+pub struct AgentHandle {
+    pub cancel: CancellationToken,
+    pub output_rx: mpsc::Receiver<AgentOutputEvent>,
+    pub join_handle: tokio::task::JoinHandle<AppResult<()>>,
+}
+
+/// Trait for agent execution backends.
+#[async_trait::async_trait]
+pub trait AgentExecutor: Send + Sync {
+    /// Start an agent process with the given configuration.
+    async fn start(&self, config: AgentConfig) -> AppResult<AgentHandle>;
+}

--- a/backend/src/agent/mod.rs
+++ b/backend/src/agent/mod.rs
@@ -1,0 +1,1 @@
+pub mod executor;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod auth;
 pub mod config;
 pub mod db;


### PR DESCRIPTION
## Summary
- Add `AgentExecutor` trait, `AgentConfig`, `AgentOutputEvent`, and `AgentHandle` type definitions
- Add `async-trait` and `tokio-util` workspace dependencies
- Partial implementation of #25 (trait definition only; Claude Code CLI implementation in a separate PR)

## Changes
- `backend/src/agent/mod.rs` — new agent module
- `backend/src/agent/executor.rs` — trait + type definitions
- `backend/src/lib.rs` — register `pub mod agent;`
- `Cargo.toml` / `backend/Cargo.toml` — add dependencies

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` — zero warnings
- [x] Type definitions only, no tests needed

Closes partially #25