### PR TITLE
feat: ✨ implement Agent Orchestrator (#26)

### DIFF
--- a/backend/src/agent/executor.rs
+++ b/backend/src/agent/executor.rs
@@ -38,3 +38,20 @@ pub trait AgentExecutor: Send + Sync {
     /// Start an agent process with the given configuration.
     async fn start(&self, config: AgentConfig) -> AppResult<AgentHandle>;
 }
+
+/// No-op executor placeholder. Returns a handle that completes immediately.
+pub struct NoopExecutor;
+
+#[async_trait::async_trait]
+impl AgentExecutor for NoopExecutor {
+    async fn start(&self, _config: AgentConfig) -> AppResult<AgentHandle> {
+        let cancel = CancellationToken::new();
+        let (_tx, rx) = mpsc::channel(1);
+        let join_handle = tokio::spawn(async { Ok(()) });
+        Ok(AgentHandle {
+            cancel,
+            output_rx: rx,
+            join_handle,
+        })
+    }
+}

--- a/backend/src/agent/executor.rs
+++ b/backend/src/agent/executor.rs
@@ -39,15 +39,20 @@ pub trait AgentExecutor: Send + Sync {
     async fn start(&self, config: AgentConfig) -> AppResult<AgentHandle>;
 }
 
-/// No-op executor placeholder. Returns a handle that completes immediately.
+/// No-op executor placeholder. Waits for cancellation, then emits Completed.
 pub struct NoopExecutor;
 
 #[async_trait::async_trait]
 impl AgentExecutor for NoopExecutor {
     async fn start(&self, _config: AgentConfig) -> AppResult<AgentHandle> {
         let cancel = CancellationToken::new();
-        let (_tx, rx) = mpsc::channel(1);
-        let join_handle = tokio::spawn(async { Ok(()) });
+        let (tx, rx) = mpsc::channel(1);
+        let token = cancel.clone();
+        let join_handle = tokio::spawn(async move {
+            token.cancelled().await;
+            let _ = tx.send(AgentOutputEvent::Completed).await;
+            Ok(())
+        });
         Ok(AgentHandle {
             cancel,
             output_rx: rx,

--- a/backend/src/agent/mod.rs
+++ b/backend/src/agent/mod.rs
@@ -1,1 +1,2 @@
 pub mod executor;
+pub mod orchestrator;

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use sqlx::SqlitePool;
 use tokio::sync::Mutex;
+use tracing::warn;
 use uuid::Uuid;
 
-use crate::agent::executor::{AgentConfig, AgentExecutor, AgentHandle};
+use crate::agent::executor::{AgentConfig, AgentExecutor, AgentOutputEvent};
 use crate::error::{AppError, AppResult};
 use crate::models::agent_session::{
     AgentSessionStatus, AgentType, CreateAgentSessionRequest, UpdateAgentSessionRequest,
@@ -15,7 +16,8 @@ use crate::services::{agent_session_service, worktree_service};
 use crate::sse::hub::SseHub;
 
 struct RunningSession {
-    handle: AgentHandle,
+    cancel: tokio_util::sync::CancellationToken,
+    _monitor_handle: tokio::task::JoinHandle<()>,
 }
 
 /// Parameters for starting a new agent session.
@@ -40,7 +42,10 @@ pub struct AgentOrchestrator {
     pool: SqlitePool,
     repo_path: PathBuf,
     _sse_hub: Arc<SseHub>,
-    running: Mutex<HashMap<Uuid, RunningSession>>,
+    /// Per-task lock to prevent concurrent start_session for the same task.
+    task_locks: Mutex<HashMap<Uuid, Arc<Mutex<()>>>>,
+    /// Currently running sessions, keyed by session_id.
+    running: Arc<Mutex<HashMap<Uuid, RunningSession>>>,
 }
 
 impl AgentOrchestrator {
@@ -55,23 +60,36 @@ impl AgentOrchestrator {
             pool,
             repo_path,
             _sse_hub: sse_hub,
-            running: Mutex::new(HashMap::new()),
+            task_locks: Mutex::new(HashMap::new()),
+            running: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
     /// Start a new agent session for a task.
     ///
-    /// 1. Check no active session for this task (duplicate prevention)
-    /// 2. Create DB session (Pending)
-    /// 3. Create git worktree
-    /// 4. Start agent executor
-    /// 5. Update DB session (Running)
-    /// 6. Register in running sessions map
+    /// 1. Acquire per-task lock (atomic duplicate prevention)
+    /// 2. Check no active session for this task
+    /// 3. Create DB session (Pending)
+    /// 4. Create git worktree (via spawn_blocking)
+    /// 5. Start agent executor
+    /// 6. Update DB session (Running)
+    /// 7. Spawn background monitor for output_rx
+    /// 8. Register in running sessions map
     pub async fn start_session(&self, req: StartSessionRequest) -> AppResult<StartSessionResult> {
-        // Step 1: Duplicate prevention
+        // Step 1: Acquire per-task lock
+        let task_lock = {
+            let mut locks = self.task_locks.lock().await;
+            locks
+                .entry(req.task_id)
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = task_lock.lock().await;
+
+        // Step 2: Duplicate prevention (now atomic under task lock)
         self.check_no_active_session(req.task_id).await?;
 
-        // Step 2: Create DB session
+        // Step 3: Create DB session
         let session = agent_session_service::create_agent_session(
             &self.pool,
             req.task_id,
@@ -81,17 +99,24 @@ impl AgentOrchestrator {
         )
         .await?;
 
-        // Step 3: Create worktree
-        let worktree_name = format!("task-{}", req.task_id);
-        let worktree = match worktree_service::create_worktree(&self.repo_path, &worktree_name) {
+        // Step 4: Create worktree (spawn_blocking for synchronous git2 operations)
+        let worktree_name = format!("task-{}-session-{}", req.task_id, session.id);
+        let repo_path = self.repo_path.clone();
+        let wt_name = worktree_name.clone();
+        let worktree = match tokio::task::spawn_blocking(move || {
+            worktree_service::create_worktree(&repo_path, &wt_name)
+        })
+        .await
+        .map_err(|e| AppError::Internal(format!("worktree task panicked: {e}")))?
+        {
             Ok(wt) => wt,
             Err(e) => {
-                let _ = self.mark_session_failed(req.task_id, session.id).await;
+                let _ = self.mark_session_cancelled(req.task_id, session.id).await;
                 return Err(e);
             }
         };
 
-        // Step 4: Start executor
+        // Step 5: Start executor
         let config = AgentConfig {
             agent_type: req.agent_type,
             session_id: session.id,
@@ -103,14 +128,14 @@ impl AgentOrchestrator {
         let handle = match self.executor.start(config).await {
             Ok(h) => h,
             Err(e) => {
-                let _ = worktree_service::delete_worktree(&self.repo_path, &worktree_name);
-                let _ = self.mark_session_failed(req.task_id, session.id).await;
+                let _ = Self::delete_worktree_blocking(&self.repo_path, &worktree_name).await;
+                let _ = self.mark_session_cancelled(req.task_id, session.id).await;
                 return Err(e);
             }
         };
 
-        // Step 5: Update DB session to Running
-        agent_session_service::update_agent_session(
+        // Step 6: Update DB session to Running
+        if let Err(e) = agent_session_service::update_agent_session(
             &self.pool,
             req.task_id,
             session.id,
@@ -118,13 +143,35 @@ impl AgentOrchestrator {
                 status: AgentSessionStatus::Running,
             },
         )
-        .await?;
+        .await
+        {
+            // Rollback: cancel executor + delete worktree + mark cancelled
+            handle.cancel.cancel();
+            let _ = Self::delete_worktree_blocking(&self.repo_path, &worktree_name).await;
+            let _ = self.mark_session_cancelled(req.task_id, session.id).await;
+            return Err(e);
+        }
 
-        // Step 6: Register in running sessions map
+        // Step 7: Spawn background monitor to drain output_rx and update DB on completion
+        let monitor_handle = self.spawn_session_monitor(
+            handle.output_rx,
+            handle.join_handle,
+            handle.cancel.clone(),
+            req.task_id,
+            session.id,
+        );
+
+        // Step 8: Register in running sessions map
         let worktree_path = worktree.path.clone();
         {
             let mut running = self.running.lock().await;
-            running.insert(session.id, RunningSession { handle });
+            running.insert(
+                session.id,
+                RunningSession {
+                    cancel: handle.cancel,
+                    _monitor_handle: monitor_handle,
+                },
+            );
         }
 
         Ok(StartSessionResult {
@@ -135,20 +182,20 @@ impl AgentOrchestrator {
 
     /// Stop a running agent session.
     ///
-    /// 1. Remove from running map
-    /// 2. Cancel the agent process
-    /// 3. Update DB session (Cancelled)
+    /// 1. Cancel the agent process
+    /// 2. Update DB session (Cancelled)
+    /// 3. Remove from running map only after DB update succeeds
     pub async fn stop_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
-        let running_session = {
-            let mut running = self.running.lock().await;
-            running.remove(&session_id)
-        };
+        // Step 1: Check session exists and cancel it (keep in map)
+        {
+            let running = self.running.lock().await;
+            let session = running.get(&session_id).ok_or_else(|| {
+                AppError::NotFound(format!("no running session found: {session_id}"))
+            })?;
+            session.cancel.cancel();
+        }
 
-        let running_session = running_session
-            .ok_or_else(|| AppError::NotFound(format!("no running session found: {session_id}")))?;
-
-        running_session.handle.cancel.cancel();
-
+        // Step 2: Update DB session to Cancelled
         agent_session_service::update_agent_session(
             &self.pool,
             task_id,
@@ -158,6 +205,12 @@ impl AgentOrchestrator {
             },
         )
         .await?;
+
+        // Step 3: Remove from running map after DB success
+        {
+            let mut running = self.running.lock().await;
+            running.remove(&session_id);
+        }
 
         Ok(())
     }
@@ -183,9 +236,8 @@ impl AgentOrchestrator {
         Ok(())
     }
 
-    async fn mark_session_failed(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
-        // Pending -> Failed is not a valid transition in agent_session_service.
-        // We need Pending -> Cancelled instead.
+    async fn mark_session_cancelled(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
+        // Pending -> Failed is not a valid transition; use Pending -> Cancelled.
         agent_session_service::update_agent_session(
             &self.pool,
             task_id,
@@ -196,6 +248,65 @@ impl AgentOrchestrator {
         )
         .await?;
         Ok(())
+    }
+
+    async fn delete_worktree_blocking(repo_path: &Path, name: &str) -> AppResult<()> {
+        let repo = repo_path.to_path_buf();
+        let n = name.to_string();
+        tokio::task::spawn_blocking(move || worktree_service::delete_worktree(&repo, &n))
+            .await
+            .map_err(|e| AppError::Internal(format!("worktree delete task panicked: {e}")))?
+    }
+
+    /// Spawn a background task that drains `output_rx` and updates DB status
+    /// when the agent completes or fails naturally (not via stop_session).
+    fn spawn_session_monitor(
+        &self,
+        mut output_rx: tokio::sync::mpsc::Receiver<AgentOutputEvent>,
+        join_handle: tokio::task::JoinHandle<AppResult<()>>,
+        cancel: tokio_util::sync::CancellationToken,
+        task_id: Uuid,
+        session_id: Uuid,
+    ) -> tokio::task::JoinHandle<()> {
+        let pool = self.pool.clone();
+        let running = Arc::clone(&self.running);
+        tokio::spawn(async move {
+            // Drain output events until the channel closes
+            while let Some(event) = output_rx.recv().await {
+                match event {
+                    AgentOutputEvent::Completed | AgentOutputEvent::Failed { .. } => break,
+                    AgentOutputEvent::Output { .. } => {
+                        // Future: forward to SSE hub
+                    }
+                }
+            }
+
+            // Wait for the executor task to finish
+            let _ = join_handle.await;
+
+            // If cancelled by stop_session, don't update DB (stop_session handles it)
+            if cancel.is_cancelled() {
+                return;
+            }
+
+            // Natural completion: update DB (best-effort)
+            if let Err(e) = agent_session_service::update_agent_session(
+                &pool,
+                task_id,
+                session_id,
+                &UpdateAgentSessionRequest {
+                    status: AgentSessionStatus::Completed,
+                },
+            )
+            .await
+            {
+                warn!("failed to update session {session_id} status: {e}");
+            }
+
+            // Remove from running map
+            let mut map = running.lock().await;
+            map.remove(&session_id);
+        })
     }
 }
 
@@ -433,8 +544,9 @@ mod tests {
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].status, AgentSessionStatus::Cancelled);
 
-        // Verify worktree was cleaned up
-        let worktree_name = format!("task-{task_id}");
+        // Verify worktree was cleaned up (name includes session_id)
+        let session_id = sessions[0].id;
+        let worktree_name = format!("task-{task_id}-session-{session_id}");
         let worktree_result = worktree_service::get_worktree(&repo_path, &worktree_name);
         assert!(worktree_result.is_err());
     }

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -59,16 +59,143 @@ impl AgentOrchestrator {
         }
     }
 
-    pub async fn start_session(&self, _req: StartSessionRequest) -> AppResult<StartSessionResult> {
-        todo!()
+    /// Start a new agent session for a task.
+    ///
+    /// 1. Check no active session for this task (duplicate prevention)
+    /// 2. Create DB session (Pending)
+    /// 3. Create git worktree
+    /// 4. Start agent executor
+    /// 5. Update DB session (Running)
+    /// 6. Register in running sessions map
+    pub async fn start_session(&self, req: StartSessionRequest) -> AppResult<StartSessionResult> {
+        // Step 1: Duplicate prevention
+        self.check_no_active_session(req.task_id).await?;
+
+        // Step 2: Create DB session
+        let session = agent_session_service::create_agent_session(
+            &self.pool,
+            req.task_id,
+            &CreateAgentSessionRequest {
+                agent_type: req.agent_type.clone(),
+            },
+        )
+        .await?;
+
+        // Step 3: Create worktree
+        let worktree_name = format!("task-{}", req.task_id);
+        let worktree = match worktree_service::create_worktree(&self.repo_path, &worktree_name) {
+            Ok(wt) => wt,
+            Err(e) => {
+                let _ = self.mark_session_failed(req.task_id, session.id).await;
+                return Err(e);
+            }
+        };
+
+        // Step 4: Start executor
+        let config = AgentConfig {
+            agent_type: req.agent_type,
+            session_id: session.id,
+            task_id: req.task_id,
+            working_dir: worktree.path.clone(),
+            prompt: req.prompt,
+        };
+
+        let handle = match self.executor.start(config).await {
+            Ok(h) => h,
+            Err(e) => {
+                let _ = worktree_service::delete_worktree(&self.repo_path, &worktree_name);
+                let _ = self.mark_session_failed(req.task_id, session.id).await;
+                return Err(e);
+            }
+        };
+
+        // Step 5: Update DB session to Running
+        agent_session_service::update_agent_session(
+            &self.pool,
+            req.task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await?;
+
+        // Step 6: Register in running sessions map
+        let worktree_path = worktree.path.clone();
+        {
+            let mut running = self.running.lock().await;
+            running.insert(session.id, RunningSession { handle });
+        }
+
+        Ok(StartSessionResult {
+            session_id: session.id,
+            worktree_path,
+        })
     }
 
-    pub async fn stop_session(&self, _task_id: Uuid, _session_id: Uuid) -> AppResult<()> {
-        todo!()
+    /// Stop a running agent session.
+    ///
+    /// 1. Remove from running map
+    /// 2. Cancel the agent process
+    /// 3. Update DB session (Cancelled)
+    pub async fn stop_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
+        let running_session = {
+            let mut running = self.running.lock().await;
+            running.remove(&session_id)
+        };
+
+        let running_session = running_session
+            .ok_or_else(|| AppError::NotFound(format!("no running session found: {session_id}")))?;
+
+        running_session.handle.cancel.cancel();
+
+        agent_session_service::update_agent_session(
+            &self.pool,
+            task_id,
+            session_id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Cancelled,
+            },
+        )
+        .await?;
+
+        Ok(())
     }
 
-    pub async fn is_running(&self, _session_id: Uuid) -> bool {
-        todo!()
+    pub async fn is_running(&self, session_id: Uuid) -> bool {
+        let running = self.running.lock().await;
+        running.contains_key(&session_id)
+    }
+
+    async fn check_no_active_session(&self, task_id: Uuid) -> AppResult<()> {
+        let sessions = agent_session_service::list_agent_sessions(&self.pool, task_id).await?;
+        let has_active = sessions.iter().any(|s| {
+            matches!(
+                s.status,
+                AgentSessionStatus::Pending | AgentSessionStatus::Running
+            )
+        });
+        if has_active {
+            return Err(AppError::Conflict(format!(
+                "task {task_id} already has an active agent session"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn mark_session_failed(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
+        // Pending -> Failed is not a valid transition in agent_session_service.
+        // We need Pending -> Cancelled instead.
+        agent_session_service::update_agent_session(
+            &self.pool,
+            task_id,
+            session_id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Cancelled,
+            },
+        )
+        .await?;
+        Ok(())
     }
 }
 
@@ -280,7 +407,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_start_session_executor_failure_marks_failed() {
+    async fn test_start_session_executor_failure_cleans_up() {
         let pool = setup_test_db().await;
         let (_project_id, task_id) = create_test_task(&pool).await;
         let tmp = tempfile::tempdir().unwrap();
@@ -299,12 +426,12 @@ mod tests {
 
         assert!(result.is_err());
 
-        // Verify DB session is Failed
+        // Verify DB session is Cancelled (Pending → Failed is not a valid transition)
         let sessions = agent_session_service::list_agent_sessions(&pool, task_id)
             .await
             .unwrap();
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].status, AgentSessionStatus::Failed);
+        assert_eq!(sessions[0].status, AgentSessionStatus::Cancelled);
 
         // Verify worktree was cleaned up
         let worktree_name = format!("task-{task_id}");

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -1,0 +1,361 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::agent::executor::{AgentConfig, AgentExecutor, AgentHandle};
+use crate::error::{AppError, AppResult};
+use crate::models::agent_session::{
+    AgentSessionStatus, AgentType, CreateAgentSessionRequest, UpdateAgentSessionRequest,
+};
+use crate::services::{agent_session_service, worktree_service};
+use crate::sse::hub::SseHub;
+
+struct RunningSession {
+    handle: AgentHandle,
+}
+
+/// Parameters for starting a new agent session.
+#[derive(Debug)]
+pub struct StartSessionRequest {
+    pub task_id: Uuid,
+    pub agent_type: AgentType,
+    pub prompt: String,
+}
+
+/// Result of a successful session start.
+#[derive(Debug)]
+pub struct StartSessionResult {
+    pub session_id: Uuid,
+    pub worktree_path: PathBuf,
+}
+
+/// Orchestrates agent session lifecycle:
+/// DB session creation → worktree setup → executor launch → status updates → cleanup.
+pub struct AgentOrchestrator {
+    executor: Arc<dyn AgentExecutor>,
+    pool: SqlitePool,
+    repo_path: PathBuf,
+    _sse_hub: Arc<SseHub>,
+    running: Mutex<HashMap<Uuid, RunningSession>>,
+}
+
+impl AgentOrchestrator {
+    pub fn new(
+        executor: Arc<dyn AgentExecutor>,
+        pool: SqlitePool,
+        repo_path: PathBuf,
+        sse_hub: Arc<SseHub>,
+    ) -> Self {
+        Self {
+            executor,
+            pool,
+            repo_path,
+            _sse_hub: sse_hub,
+            running: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub async fn start_session(&self, _req: StartSessionRequest) -> AppResult<StartSessionResult> {
+        todo!()
+    }
+
+    pub async fn stop_session(&self, _task_id: Uuid, _session_id: Uuid) -> AppResult<()> {
+        todo!()
+    }
+
+    pub async fn is_running(&self, _session_id: Uuid) -> bool {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::executor::{AgentHandle, AgentOutputEvent};
+    use crate::error::AppError;
+    use crate::models::agent_session::AgentType;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::task::CreateTaskRequest;
+    use crate::services::{project_service, task_service};
+    use crate::test_helpers::setup_test_db;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    /// Mock executor that always succeeds.
+    struct MockExecutor {
+        started: Arc<AtomicBool>,
+    }
+
+    impl MockExecutor {
+        fn new() -> Self {
+            Self {
+                started: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AgentExecutor for MockExecutor {
+        async fn start(&self, _config: AgentConfig) -> AppResult<AgentHandle> {
+            self.started.store(true, Ordering::SeqCst);
+            let cancel = CancellationToken::new();
+            let (tx, rx) = mpsc::channel(16);
+            let token = cancel.clone();
+            let join_handle = tokio::spawn(async move {
+                token.cancelled().await;
+                let _ = tx.send(AgentOutputEvent::Completed).await;
+                Ok(())
+            });
+            Ok(AgentHandle {
+                cancel,
+                output_rx: rx,
+                join_handle,
+            })
+        }
+    }
+
+    /// Mock executor that always fails on start.
+    struct FailingExecutor;
+
+    #[async_trait::async_trait]
+    impl AgentExecutor for FailingExecutor {
+        async fn start(&self, _config: AgentConfig) -> AppResult<AgentHandle> {
+            Err(AppError::Internal("executor failed to start".into()))
+        }
+    }
+
+    /// Create a test task in DB and return (project_id, task_id).
+    async fn create_test_task(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+            },
+        )
+        .await
+        .expect("Failed to create project");
+
+        let task = task_service::create_task(
+            pool,
+            &CreateTaskRequest {
+                project_id: project.id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("Failed to create task");
+
+        (project.id, task.id)
+    }
+
+    /// Initialize a bare git repo and return its path.
+    fn init_test_repo(dir: &Path) -> PathBuf {
+        let repo_path = dir.join("repo");
+        let repo = git2::Repository::init(&repo_path).expect("Failed to init repo");
+        // Create an initial commit so HEAD exists
+        let sig = git2::Signature::now("test", "test@test.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        repo_path
+    }
+
+    fn create_orchestrator(
+        executor: Arc<dyn AgentExecutor>,
+        pool: SqlitePool,
+        repo_path: PathBuf,
+    ) -> AgentOrchestrator {
+        let sse_hub = Arc::new(SseHub::new(16));
+        AgentOrchestrator::new(executor, pool, repo_path, sse_hub)
+    }
+
+    #[tokio::test]
+    async fn test_start_session_success() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor.clone(), pool.clone(), repo_path.clone());
+
+        let result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "test prompt".to_string(),
+            })
+            .await;
+
+        let result = result.expect("start_session should succeed");
+        assert!(result.worktree_path.exists());
+        assert!(executor.started.load(Ordering::SeqCst));
+
+        // Verify DB session is Running
+        let sessions = agent_session_service::list_agent_sessions(&pool, task_id)
+            .await
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].status, AgentSessionStatus::Running);
+        assert!(sessions[0].started_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_stop_session_success() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor, pool.clone(), repo_path);
+
+        let start_result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "test".to_string(),
+            })
+            .await
+            .expect("start should succeed");
+
+        let stop_result = orchestrator
+            .stop_session(task_id, start_result.session_id)
+            .await;
+
+        stop_result.expect("stop_session should succeed");
+
+        // Verify DB session is Cancelled
+        let session =
+            agent_session_service::get_agent_session(&pool, task_id, start_result.session_id)
+                .await
+                .unwrap();
+        assert_eq!(session.status, AgentSessionStatus::Cancelled);
+        assert!(session.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_start_session_rejects_duplicate() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor, pool.clone(), repo_path);
+
+        // First start should succeed
+        orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "first".to_string(),
+            })
+            .await
+            .expect("first start should succeed");
+
+        // Second start for same task should fail with Conflict
+        let result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "second".to_string(),
+            })
+            .await;
+
+        assert!(matches!(result, Err(AppError::Conflict(_))));
+    }
+
+    #[tokio::test]
+    async fn test_start_session_executor_failure_marks_failed() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(FailingExecutor);
+        let orchestrator = create_orchestrator(executor, pool.clone(), repo_path.clone());
+
+        let result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "test".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err());
+
+        // Verify DB session is Failed
+        let sessions = agent_session_service::list_agent_sessions(&pool, task_id)
+            .await
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].status, AgentSessionStatus::Failed);
+
+        // Verify worktree was cleaned up
+        let worktree_name = format!("task-{task_id}");
+        let worktree_result = worktree_service::get_worktree(&repo_path, &worktree_name);
+        assert!(worktree_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_stop_session_not_found() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor, pool, repo_path);
+
+        let result = orchestrator.stop_session(task_id, Uuid::new_v4()).await;
+
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_is_running_state() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor, pool, repo_path);
+
+        let random_id = Uuid::new_v4();
+        assert!(!orchestrator.is_running(random_id).await);
+
+        let result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::ClaudeCode,
+                prompt: "test".to_string(),
+            })
+            .await
+            .expect("start should succeed");
+
+        assert!(orchestrator.is_running(result.session_id).await);
+
+        orchestrator
+            .stop_session(task_id, result.session_id)
+            .await
+            .expect("stop should succeed");
+
+        assert!(!orchestrator.is_running(result.session_id).await);
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -21,6 +21,7 @@ use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use crate::agent::orchestrator::AgentOrchestrator;
 use crate::sse::hub::SseHub;
 
 #[derive(Clone)]
@@ -28,6 +29,7 @@ pub struct AppState {
     pub pool: SqlitePool,
     pub sse_hub: Arc<SseHub>,
     pub config: Arc<config::Config>,
+    pub orchestrator: Arc<AgentOrchestrator>,
 }
 
 pub fn app(state: AppState) -> Router {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,8 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::db;
 use gantry_board::sse::hub::SseHub;
@@ -20,11 +23,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let pool = db::init_pool(&config.database_url).await?;
+    let sse_hub = Arc::new(SseHub::default());
+
+    let repo_path = config
+        .repository_path
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let executor = Arc::new(NoopExecutor);
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        executor,
+        pool.clone(),
+        repo_path,
+        Arc::clone(&sse_hub),
+    ));
 
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config.clone()),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/src/sse/handler.rs
+++ b/backend/src/sse/handler.rs
@@ -33,10 +33,13 @@ pub async fn sse_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::executor::NoopExecutor;
+    use crate::agent::orchestrator::AgentOrchestrator;
     use crate::config::Config;
     use crate::sse::event::SseEvent;
     use crate::sse::hub::SseHub;
     use sqlx::sqlite::SqlitePoolOptions;
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     async fn create_test_state() -> AppState {
@@ -50,10 +53,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
+        let sse_hub = Arc::new(SseHub::default());
+        let orchestrator = Arc::new(AgentOrchestrator::new(
+            Arc::new(NoopExecutor),
+            pool.clone(),
+            PathBuf::from("."),
+            Arc::clone(&sse_hub),
+        ));
         AppState {
             pool,
-            sse_hub: Arc::new(SseHub::default()),
+            sse_hub,
             config: Arc::new(Config::default()),
+            orchestrator,
         }
     }
 

--- a/backend/tests/agent_sessions_api.rs
+++ b/backend/tests/agent_sessions_api.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 use uuid::Uuid;
 
 async fn create_test_server() -> TestServer {
@@ -27,10 +30,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 
 async fn create_test_server() -> TestServer {
     let pool = SqlitePoolOptions::new()
@@ -26,10 +29,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/tests/authorization_api.rs
+++ b/backend/tests/authorization_api.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 
 async fn create_test_server() -> TestServer {
     let pool = SqlitePoolOptions::new()
@@ -26,10 +29,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/tests/project_members_api.rs
+++ b/backend/tests/project_members_api.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 use uuid::Uuid;
 
 async fn create_test_server() -> TestServer {
@@ -27,10 +30,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 
 async fn create_test_server() -> TestServer {
     let pool = SqlitePoolOptions::new()
@@ -25,10 +28,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
+use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
 use uuid::Uuid;
 
 async fn create_test_server() -> TestServer {
@@ -27,10 +30,18 @@ async fn create_test_server() -> TestServer {
         ..Default::default()
     };
 
+    let sse_hub = Arc::new(SseHub::default());
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        Arc::new(NoopExecutor),
+        pool.clone(),
+        PathBuf::from("."),
+        Arc::clone(&sse_hub),
+    ));
     let state = AppState {
         pool,
-        sse_hub: Arc::new(SseHub::default()),
+        sse_hub,
         config: Arc::new(config),
+        orchestrator,
     };
 
     let app = gantry_board::app(state);


### PR DESCRIPTION
## Summary
- Implement `AgentOrchestrator` with `start_session` / `stop_session` / `is_running`
- Integrate session management → worktree creation → executor launch flow
- Duplicate prevention with per-task mutex for atomic check-and-create
- Rollback on failure at any step (cancel executor, delete worktree, mark session cancelled)
- Background monitor task drains `output_rx` and auto-updates DB on natural completion
- Wrap synchronous git2 operations in `spawn_blocking`
- Add `orchestrator: Arc<AgentOrchestrator>` to `AppState`
- Add `NoopExecutor` placeholder in `main.rs` (waits for cancellation, emits Completed)

## Changes
- `backend/src/agent/orchestrator.rs` — new orchestrator implementation + 6 unit tests
- `backend/src/agent/executor.rs` — add `NoopExecutor` with proper cancellation behavior
- `backend/src/agent/mod.rs` — register orchestrator module
- `backend/src/lib.rs` — add `orchestrator` field to `AppState`
- `backend/src/main.rs` — construct and inject orchestrator
- `backend/src/sse/handler.rs` + `backend/tests/*.rs` — update test AppState construction

## Test plan
- [x] `test_start_session_success` — DB session Running, worktree created, executor started
- [x] `test_stop_session_success` — cancel called, DB session Cancelled
- [x] `test_start_session_rejects_duplicate` — same task twice → Conflict error
- [x] `test_start_session_executor_failure_cleans_up` — executor failure → Cancelled + worktree deleted
- [x] `test_stop_session_not_found` — unknown session → NotFound error
- [x] `test_is_running_state` — false before start → true after start → false after stop
- [x] All 115 existing tests pass, zero clippy warnings

Closes #26