### PR TITLE
fix: 🐛 spawn background task for periodic session cleanup

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -93,4 +93,10 @@ mod tests {
         };
         assert!(config.auth_disabled);
     }
+
+    #[test]
+    fn test_session_cleanup_interval_defaults_to_3600() {
+        let config = Config::default();
+        assert_eq!(config.session_cleanup_interval_secs, 3600);
+    }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -26,6 +26,10 @@ pub struct Config {
     /// Path to the git repository for worktree management
     #[serde(default)]
     pub repository_path: Option<String>,
+
+    /// Interval in seconds between session cleanup runs (default: 3600 = 1 hour)
+    #[serde(default = "default_session_cleanup_interval_secs")]
+    pub session_cleanup_interval_secs: u64,
 }
 
 fn default_bind_addr() -> String {
@@ -38,6 +42,10 @@ fn default_database_url() -> String {
 
 fn default_session_duration_hours() -> u64 {
     168 // 1 week
+}
+
+fn default_session_cleanup_interval_secs() -> u64 {
+    3600 // 1 hour
 }
 
 impl Config {
@@ -61,6 +69,7 @@ impl Default for Config {
             auth_disabled: false,
             cookie_secure: false,
             repository_path: None,
+            session_cleanup_interval_secs: default_session_cleanup_interval_secs(),
         }
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -51,9 +51,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = gantry_board::app(state);
 
     // Spawn background task for periodic session cleanup
-    let cleanup_interval = Duration::from_secs(config.session_cleanup_interval_secs);
+    let cleanup_interval_secs = config.session_cleanup_interval_secs.max(1);
+    let cleanup_interval = Duration::from_secs(cleanup_interval_secs);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(cleanup_interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         interval.tick().await; // skip the immediate first tick
         loop {
             interval.tick().await;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use gantry_board::agent::claude_code::ClaudeCodeExecutor;
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::db;
+use gantry_board::services::session_service;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use tracing_subscriber::EnvFilter;
@@ -38,14 +40,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&sse_hub),
     ));
 
+    let cleanup_pool = pool.clone();
+
     let state = AppState {
         pool,
         sse_hub,
         config: Arc::new(config.clone()),
         orchestrator,
     };
-
     let app = gantry_board::app(state);
+
+    // Spawn background task for periodic session cleanup
+    let cleanup_interval = Duration::from_secs(config.session_cleanup_interval_secs);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(cleanup_interval);
+        interval.tick().await; // skip the immediate first tick
+        loop {
+            interval.tick().await;
+            match session_service::cleanup_expired_sessions(&cleanup_pool).await {
+                Ok(count) if count > 0 => {
+                    tracing::info!(count, "cleaned up expired sessions");
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to cleanup expired sessions");
+                }
+                _ => {}
+            }
+        }
+    });
 
     let listener = tokio::net::TcpListener::bind(&config.bind_addr).await?;
     tracing::info!("listening on {}", config.bind_addr);


### PR DESCRIPTION
## Summary
- `cleanup_expired_sessions()` was implemented and tested but never called
- Add background task in `main.rs` to periodically invoke it
- Add `session_cleanup_interval_secs` config field (default: 3600s = 1 hour)
- Clamp interval to minimum 1s to prevent panic on zero
- Set `MissedTickBehavior::Delay` to avoid bursty DB load
- Add config default value test

## Test plan
- [x] `cargo check` — compiles successfully
- [x] `cargo test -- session` — all session tests pass
- [x] `test_session_cleanup_interval_defaults_to_3600`

Closes #16