### PR TITLE
fix: 🐛 harden HTTP security (CORS, SSE auth, cookie)

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -19,8 +19,8 @@ pub struct Config {
     #[serde(default)]
     pub auth_disabled: bool,
 
-    /// Use secure cookies (HTTPS only) - should be true in production
-    #[serde(default)]
+    /// Use secure cookies (HTTPS only) - defaults to true; set to false only for local HTTP dev
+    #[serde(default = "default_cookie_secure")]
     pub cookie_secure: bool,
 
     /// Path to the git repository for worktree management
@@ -42,6 +42,10 @@ fn default_database_url() -> String {
 
 fn default_session_duration_hours() -> u64 {
     168 // 1 week
+}
+
+fn default_cookie_secure() -> bool {
+    true
 }
 
 fn default_session_cleanup_interval_secs() -> u64 {
@@ -67,7 +71,7 @@ impl Default for Config {
             session_duration_hours: default_session_duration_hours(),
             #[cfg(debug_assertions)]
             auth_disabled: false,
-            cookie_secure: false,
+            cookie_secure: default_cookie_secure(),
             repository_path: None,
             session_cleanup_interval_secs: default_session_cleanup_interval_secs(),
         }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,3 +1,4 @@
+use axum::http::HeaderValue;
 use figment::providers::{Env, Format, Toml};
 use figment::Figment;
 use serde::Deserialize;
@@ -60,10 +61,30 @@ impl Config {
     pub fn load() -> Result<Self, Box<figment::Error>> {
         dotenvy::dotenv().ok();
 
-        Ok(Figment::new()
+        let config: Self = Figment::new()
             .merge(Toml::file("config.toml"))
             .merge(Env::prefixed("GANTRY_"))
-            .extract()?)
+            .extract()?;
+
+        config.validate();
+
+        Ok(config)
+    }
+
+    /// Validate config values that cannot be expressed via serde alone.
+    pub fn validate(&self) {
+        if let Some(origin) = &self.cors_origin {
+            origin.parse::<HeaderValue>().unwrap_or_else(|_| {
+                panic!("GANTRY_CORS_ORIGIN is not a valid HTTP header value: {origin:?}")
+            });
+        }
+    }
+
+    /// Parse `cors_origin` into an `HeaderValue`, returning `None` when unset.
+    pub fn cors_origin_header(&self) -> Option<HeaderValue> {
+        self.cors_origin
+            .as_ref()
+            .map(|o| o.parse().expect("cors_origin already validated"))
     }
 }
 
@@ -84,16 +105,17 @@ impl Default for Config {
 }
 
 #[cfg(test)]
-#[cfg(debug_assertions)]
 mod tests {
     use super::*;
 
+    #[cfg(debug_assertions)]
     #[test]
     fn test_auth_disabled_defaults_to_false() {
         let config = Config::default();
         assert!(!config.auth_disabled);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     fn test_auth_disabled_can_be_enabled_in_debug_builds() {
         let config = Config {
@@ -107,5 +129,37 @@ mod tests {
     fn test_session_cleanup_interval_defaults_to_3600() {
         let config = Config::default();
         assert_eq!(config.session_cleanup_interval_secs, 3600);
+    }
+
+    #[test]
+    fn test_cors_origin_header_returns_none_when_unset() {
+        let config = Config::default();
+        assert!(config.cors_origin_header().is_none());
+    }
+
+    #[test]
+    fn test_cors_origin_header_returns_value_when_set() {
+        let config = Config {
+            cors_origin: Some("http://localhost:5173".to_string()),
+            ..Default::default()
+        };
+        let header = config.cors_origin_header().expect("should return header");
+        assert_eq!(header.to_str().unwrap(), "http://localhost:5173");
+    }
+
+    #[test]
+    #[should_panic(expected = "not a valid HTTP header value")]
+    fn test_validate_rejects_invalid_cors_origin() {
+        let config = Config {
+            cors_origin: Some("not a valid \x00 header".to_string()),
+            ..Default::default()
+        };
+        config.validate();
+    }
+
+    #[test]
+    fn test_cookie_secure_defaults_to_true() {
+        let config = Config::default();
+        assert!(config.cookie_secure);
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -30,6 +30,10 @@ pub struct Config {
     /// Interval in seconds between session cleanup runs (default: 3600 = 1 hour)
     #[serde(default = "default_session_cleanup_interval_secs")]
     pub session_cleanup_interval_secs: u64,
+
+    /// Allowed CORS origin (e.g. "http://localhost:5173"). When unset, CORS is permissive.
+    #[serde(default)]
+    pub cors_origin: Option<String>,
 }
 
 fn default_bind_addr() -> String {
@@ -74,6 +78,7 @@ impl Default for Config {
             cookie_secure: default_cookie_secure(),
             repository_path: None,
             session_cleanup_interval_secs: default_session_cleanup_interval_secs(),
+            cors_origin: None,
         }
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,7 +13,7 @@ pub mod test_helpers;
 
 use std::sync::Arc;
 
-use axum::http::{HeaderValue, Method};
+use axum::http::Method;
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
 use sqlx::SqlitePool;
@@ -136,17 +136,17 @@ pub fn app(state: AppState) -> Router {
 }
 
 fn build_cors_layer(config: &config::Config) -> CorsLayer {
-    match &config.cors_origin {
-        Some(origin) => {
-            let origin: HeaderValue = origin
-                .parse()
-                .expect("GANTRY_CORS_ORIGIN must be a valid header value");
-            CorsLayer::new()
-                .allow_origin(AllowOrigin::exact(origin))
-                .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
-                .allow_headers([axum::http::header::CONTENT_TYPE])
-                .allow_credentials(true)
+    match config.cors_origin_header() {
+        Some(origin) => CorsLayer::new()
+            .allow_origin(AllowOrigin::exact(origin))
+            .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
+            .allow_headers([axum::http::header::CONTENT_TYPE])
+            .allow_credentials(true),
+        None => {
+            tracing::warn!(
+                "GANTRY_CORS_ORIGIN is not set — CORS is permissive; set it in production"
+            );
+            CorsLayer::permissive()
         }
-        None => CorsLayer::permissive(),
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,12 +13,13 @@ pub mod test_helpers;
 
 use std::sync::Arc;
 
+use axum::http::{HeaderValue, Method};
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
 use sqlx::SqlitePool;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::GovernorLayer;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -129,7 +130,23 @@ pub fn app(state: AppState) -> Router {
         .merge(
             SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
         )
-        .layer(CorsLayer::permissive())
+        .layer(build_cors_layer(&state.config))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
+}
+
+fn build_cors_layer(config: &config::Config) -> CorsLayer {
+    match &config.cors_origin {
+        Some(origin) => {
+            let origin: HeaderValue = origin
+                .parse()
+                .expect("GANTRY_CORS_ORIGIN must be a valid header value");
+            CorsLayer::new()
+                .allow_origin(AllowOrigin::exact(origin))
+                .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
+                .allow_headers([axum::http::header::CONTENT_TYPE])
+                .allow_credentials(true)
+        }
+        None => CorsLayer::permissive(),
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!("cookie_secure is false — session cookies will be sent over HTTP. Set GANTRY_COOKIE_SECURE=true in production.");
     }
 
+    if config.cors_origin.is_none() {
+        tracing::warn!(
+            "cors_origin is not set — CORS is permissive. Set GANTRY_CORS_ORIGIN in production."
+        );
+    }
+
     let pool = db::init_pool(&config.database_url).await?;
     let sse_hub = Arc::new(SseHub::default());
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -24,6 +24,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!("Authentication is DISABLED. Do not use in production!");
     }
 
+    if !config.cookie_secure {
+        tracing::warn!("cookie_secure is false — session cookies will be sent over HTTP. Set GANTRY_COOKIE_SECURE=true in production.");
+    }
+
     let pool = db::init_pool(&config.database_url).await?;
     let sse_hub = Arc::new(SseHub::default());
 

--- a/backend/src/sse/handler.rs
+++ b/backend/src/sse/handler.rs
@@ -7,10 +7,12 @@ use futures_util::stream::Stream;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 
+use crate::auth::middleware::AuthUser;
 use crate::AppState;
 
 /// SSE endpoint for real-time task updates
 pub async fn sse_handler(
+    _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let rx = state.sse_hub.subscribe();
@@ -35,12 +37,14 @@ mod tests {
     use super::*;
     use crate::agent::executor::NoopExecutor;
     use crate::agent::orchestrator::AgentOrchestrator;
+    use crate::auth::middleware::AuthUser;
     use crate::config::Config;
     use crate::sse::event::SseEvent;
     use crate::sse::hub::SseHub;
     use sqlx::sqlite::SqlitePoolOptions;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     async fn create_test_state() -> AppState {
         let pool = SqlitePoolOptions::new()
@@ -71,9 +75,13 @@ mod tests {
     #[tokio::test]
     async fn test_sse_handler_creates_stream() {
         let state = create_test_state().await;
+        let auth = AuthUser {
+            user_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+        };
 
         // Just verify the handler can be called without panic
-        let _sse = sse_handler(State(state)).await;
+        let _sse = sse_handler(auth, State(state)).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Require `AuthUser` on SSE endpoint (`/api/events`) to prevent unauthenticated access
- Default `cookie_secure` to `true` with startup warning when `false`
- Replace `CorsLayer::permissive()` with configurable `cors_origin` setting (permissive + warning when unset)

## Test plan
- [x] `cargo check` — compiles successfully
- [x] `cargo test --lib` — all 128 tests pass

Closes #14
Closes #15
Closes #20