### PR TITLE
feat: ✨ add rate limiting to auth endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +616,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "typetag",
  "uuid",
 ]
@@ -667,10 +681,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -679,6 +705,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -749,6 +785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,12 +828,13 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "utoipa",
@@ -853,9 +896,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -874,6 +919,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,7 +974,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -889,6 +982,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -993,6 +1091,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1003,6 +1102,19 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1384,6 +1496,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1721,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1778,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1689,6 +1839,21 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1766,6 +1931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,7 +1992,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1887,7 +2061,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.9.2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2103,6 +2277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,7 +2336,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2237,7 +2420,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2276,7 +2459,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2302,7 +2485,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2380,11 +2563,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2571,6 +2774,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,9 +2810,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2617,6 +2852,23 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tonic",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -2699,7 +2951,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2977,6 +3229,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3259,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3282,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }
 
+# Rate limiting
+tower_governor = "0.8"
+
 # Authentication
 argon2 = "0.5"
 rand = "0.8"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,6 +36,7 @@ axum-extra = { workspace = true }
 git2 = { workspace = true }
 async-trait = { workspace = true }
 tokio-util = { workspace = true }
+tower_governor = "0.8.0"
 
 [dev-dependencies]
 axum-test = "18"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,7 +36,7 @@ axum-extra = { workspace = true }
 git2 = { workspace = true }
 async-trait = { workspace = true }
 tokio-util = { workspace = true }
-tower_governor = "0.8.0"
+tower_governor = { workspace = true }
 
 [dev-dependencies]
 axum-test = "18"

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,17 +35,18 @@ pub struct AppState {
 }
 
 pub fn app(state: AppState) -> Router {
-    // Rate limit: login — 5 attempts per 15 min per IP (1 token / 180s, burst 5)
+    // Rate limit: login — 5 attempts per 15 min per IP.
+    // per_second(N) sets the replenishment *interval* to N seconds (NOT N req/sec).
     let login_governor = GovernorConfigBuilder::default()
-        .per_second(180)
-        .burst_size(5)
+        .per_second(180) // 1 token every 180s
+        .burst_size(5) // bucket capacity
         .finish()
         .expect("valid governor config");
 
-    // Rate limit: register — 3 attempts per hour per IP (1 token / 1200s, burst 3)
+    // Rate limit: register — 3 attempts per hour per IP.
     let register_governor = GovernorConfigBuilder::default()
-        .per_second(1200)
-        .burst_size(3)
+        .per_second(1200) // 1 token every 1200s
+        .burst_size(3) // bucket capacity
         .finish()
         .expect("valid governor config");
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,6 +16,8 @@ use std::sync::Arc;
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
 use sqlx::SqlitePool;
+use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::GovernorLayer;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
@@ -33,10 +35,30 @@ pub struct AppState {
 }
 
 pub fn app(state: AppState) -> Router {
+    // Rate limit: login — 5 attempts per 15 min per IP (1 token / 180s, burst 5)
+    let login_governor = GovernorConfigBuilder::default()
+        .per_second(180)
+        .burst_size(5)
+        .finish()
+        .expect("valid governor config");
+
+    // Rate limit: register — 3 attempts per hour per IP (1 token / 1200s, burst 3)
+    let register_governor = GovernorConfigBuilder::default()
+        .per_second(1200)
+        .burst_size(3)
+        .finish()
+        .expect("valid governor config");
+
     let api_routes = Router::new()
-        // Auth endpoints
-        .route("/auth/register", post(handlers::auth::register))
-        .route("/auth/login", post(handlers::auth::login))
+        // Auth endpoints (rate-limited)
+        .route(
+            "/auth/register",
+            post(handlers::auth::register).layer(GovernorLayer::new(register_governor)),
+        )
+        .route(
+            "/auth/login",
+            post(handlers::auth::login).layer(GovernorLayer::new(login_governor)),
+        )
         .route("/auth/logout", post(handlers::auth::logout))
         .route("/auth/me", get(handlers::auth::me))
         // Task endpoints

--- a/backend/tests/agent_sessions_api.rs
+++ b/backend/tests/agent_sessions_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
@@ -55,7 +56,7 @@ async fn create_test_server() -> (TempDir, TestServer) {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     let server = TestServer::new(app).expect("Failed to create test server");
     (tmp, server)
 }

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -303,3 +303,46 @@ async fn test_logout_without_auth() {
 
     response.assert_status(StatusCode::UNAUTHORIZED);
 }
+
+#[tokio::test]
+async fn test_login_rate_limit_returns_429_after_burst() {
+    let server = create_test_server().await;
+
+    let body = json!({
+        "email": "nobody@example.com",
+        "password": "doesnotmatter123"
+    });
+
+    // Exhaust burst_size (5) for login
+    for _ in 0..5 {
+        server.post("/api/auth/login").json(&body).await;
+    }
+
+    // 6th request should be rate-limited
+    let response = server.post("/api/auth/login").json(&body).await;
+    response.assert_status(StatusCode::TOO_MANY_REQUESTS);
+}
+
+#[tokio::test]
+async fn test_register_rate_limit_returns_429_after_burst() {
+    let server = create_test_server().await;
+
+    // Exhaust burst_size (3) for register — use different emails so the first ones succeed
+    for i in 0..3 {
+        let body = json!({
+            "email": format!("user{}@example.com", i),
+            "name": "Test User",
+            "password": "Tr0ub4dor&3-correct-horse"
+        });
+        server.post("/api/auth/register").json(&body).await;
+    }
+
+    // 4th request should be rate-limited
+    let body = json!({
+        "email": "user3@example.com",
+        "name": "Test User",
+        "password": "Tr0ub4dor&3-correct-horse"
+    });
+    let response = server.post("/api/auth/register").json(&body).await;
+    response.assert_status(StatusCode::TOO_MANY_REQUESTS);
+}

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
@@ -43,7 +44,7 @@ async fn create_test_server() -> TestServer {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     TestServer::new(app).expect("Failed to create test server")
 }
 

--- a/backend/tests/authorization_api.rs
+++ b/backend/tests/authorization_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
@@ -43,7 +44,7 @@ async fn create_test_server() -> TestServer {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     TestServer::new(app).expect("Failed to create test server")
 }
 

--- a/backend/tests/project_members_api.rs
+++ b/backend/tests/project_members_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
@@ -44,7 +45,7 @@ async fn create_test_server() -> TestServer {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     TestServer::new(app).expect("Failed to create test server")
 }
 

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum_test::TestServer;
@@ -42,7 +43,7 @@ async fn create_test_server() -> TestServer {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     TestServer::new(app).expect("Failed to create test server")
 }
 

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
@@ -44,7 +45,7 @@ async fn create_test_server() -> TestServer {
         orchestrator,
     };
 
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
     TestServer::new(app).expect("Failed to create test server")
 }
 


### PR DESCRIPTION
## Summary
- Add `tower-governor` for IP-based rate limiting on auth endpoints
- Login: 5 attempts per 15 min per IP (burst 5, replenish 1/180s)
- Register: 3 attempts per hour per IP (burst 3, replenish 1/1200s)

## Test plan
- [x] `cargo check` — compiles successfully
- [x] `cargo test --lib` — all 128 tests pass

Closes #13