### PR TITLE
refactor: 🔧 support multiple agent executors in orchestrator

### DIFF
--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -39,7 +39,7 @@ pub struct StartSessionResult {
 /// Orchestrates agent session lifecycle:
 /// DB session creation → worktree setup → executor launch → status updates → cleanup.
 pub struct AgentOrchestrator {
-    executor: Arc<dyn AgentExecutor>,
+    executors: HashMap<AgentType, Arc<dyn AgentExecutor>>,
     pool: SqlitePool,
     repo_path: PathBuf,
     sse_hub: Arc<SseHub>,
@@ -51,13 +51,13 @@ pub struct AgentOrchestrator {
 
 impl AgentOrchestrator {
     pub fn new(
-        executor: Arc<dyn AgentExecutor>,
+        executors: HashMap<AgentType, Arc<dyn AgentExecutor>>,
         pool: SqlitePool,
         repo_path: PathBuf,
         sse_hub: Arc<SseHub>,
     ) -> Self {
         Self {
-            executor,
+            executors,
             pool,
             repo_path,
             sse_hub,
@@ -127,7 +127,11 @@ impl AgentOrchestrator {
             allowed_tools: vec![],
         };
 
-        let handle = match self.executor.start(config).await {
+        let executor = self.executors.get(&config.agent_type).ok_or_else(|| {
+            AppError::Validation(format!("unsupported agent type: {:?}", config.agent_type))
+        })?;
+
+        let handle = match executor.start(config).await {
             Ok(h) => h,
             Err(e) => {
                 let _ = Self::delete_worktree_blocking(&self.repo_path, &worktree_name).await;
@@ -439,7 +443,7 @@ mod tests {
         repo_path: PathBuf,
     ) -> AgentOrchestrator {
         let sse_hub = Arc::new(SseHub::new(16));
-        AgentOrchestrator::new(executor, pool, repo_path, sse_hub)
+        create_orchestrator_with_hub(executor, pool, repo_path, sse_hub)
     }
 
     fn create_orchestrator_with_hub(
@@ -448,7 +452,9 @@ mod tests {
         repo_path: PathBuf,
         sse_hub: Arc<SseHub>,
     ) -> AgentOrchestrator {
-        AgentOrchestrator::new(executor, pool, repo_path, sse_hub)
+        let mut executors = HashMap::new();
+        executors.insert(AgentType::ClaudeCode, executor);
+        AgentOrchestrator::new(executors, pool, repo_path, sse_hub)
     }
 
     #[tokio::test]
@@ -727,6 +733,32 @@ mod tests {
         assert!(
             event_types.contains(&"agent_session_status_changed".to_string()),
             "expected agent_session_status_changed event, got: {event_types:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_start_session_unsupported_agent_type() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = init_test_repo(tmp.path());
+
+        // Register only ClaudeCode executor
+        let executor = Arc::new(MockExecutor::new());
+        let orchestrator = create_orchestrator(executor, pool.clone(), repo_path);
+
+        // Request GeminiCli which is not registered
+        let result = orchestrator
+            .start_session(StartSessionRequest {
+                task_id,
+                agent_type: AgentType::GeminiCli,
+                prompt: "test".to_string(),
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(AppError::Validation(_))),
+            "expected Validation error for unsupported agent type, got: {result:?}"
         );
     }
 }

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -69,13 +69,14 @@ impl AgentOrchestrator {
     /// Start a new agent session for a task.
     ///
     /// 1. Acquire per-task lock (atomic duplicate prevention)
-    /// 2. Check no active session for this task
-    /// 3. Create DB session (Pending)
-    /// 4. Create git worktree (via spawn_blocking)
-    /// 5. Start agent executor
-    /// 6. Update DB session (Running)
-    /// 7. Spawn background monitor for output_rx
-    /// 8. Register in running sessions map
+    /// 2. Validate executor exists (fail fast before allocating resources)
+    /// 3. Check no active session for this task
+    /// 4. Create DB session (Pending)
+    /// 5. Create git worktree (via spawn_blocking)
+    /// 6. Start agent executor
+    /// 7. Update DB session (Running)
+    /// 8. Spawn background monitor for output_rx
+    /// 9. Register in running sessions map
     pub async fn start_session(&self, req: StartSessionRequest) -> AppResult<StartSessionResult> {
         // Step 1: Acquire per-task lock
         let task_lock = {
@@ -87,10 +88,19 @@ impl AgentOrchestrator {
         };
         let _guard = task_lock.lock().await;
 
-        // Step 2: Duplicate prevention (now atomic under task lock)
+        // Step 2: Validate executor exists before allocating resources
+        let executor = self
+            .executors
+            .get(&req.agent_type)
+            .ok_or_else(|| {
+                AppError::Validation(format!("unsupported agent type: {}", req.agent_type))
+            })?
+            .clone();
+
+        // Step 3: Duplicate prevention (now atomic under task lock)
         self.check_no_active_session(req.task_id).await?;
 
-        // Step 3: Create DB session
+        // Step 4: Create DB session (now safe: executor is validated)
         let session = agent_session_service::create_agent_session(
             &self.pool,
             req.task_id,
@@ -100,7 +110,7 @@ impl AgentOrchestrator {
         )
         .await?;
 
-        // Step 4: Create worktree (spawn_blocking for synchronous git2 operations)
+        // Step 5: Create worktree (spawn_blocking for synchronous git2 operations)
         let worktree_name = format!("task-{}-session-{}", req.task_id, session.id);
         let repo_path = self.repo_path.clone();
         let wt_name = worktree_name.clone();
@@ -117,7 +127,7 @@ impl AgentOrchestrator {
             }
         };
 
-        // Step 5: Start executor
+        // Step 6: Start executor
         let config = AgentConfig {
             agent_type: req.agent_type,
             session_id: session.id,
@@ -126,10 +136,6 @@ impl AgentOrchestrator {
             prompt: req.prompt,
             allowed_tools: vec![],
         };
-
-        let executor = self.executors.get(&config.agent_type).ok_or_else(|| {
-            AppError::Validation(format!("unsupported agent type: {:?}", config.agent_type))
-        })?;
 
         let handle = match executor.start(config).await {
             Ok(h) => h,
@@ -140,7 +146,7 @@ impl AgentOrchestrator {
             }
         };
 
-        // Step 6: Update DB session to Running
+        // Step 7: Update DB session to Running
         let running_session = match agent_session_service::update_agent_session(
             &self.pool,
             req.task_id,
@@ -165,7 +171,7 @@ impl AgentOrchestrator {
         self.sse_hub
             .broadcast(SseEvent::agent_session_status_changed(running_session));
 
-        // Step 7: Spawn background monitor to drain output_rx and update DB on completion
+        // Step 8: Spawn background monitor to drain output_rx and update DB on completion
         let monitor_handle = self.spawn_session_monitor(
             handle.output_rx,
             handle.join_handle,
@@ -174,7 +180,7 @@ impl AgentOrchestrator {
             session.id,
         );
 
-        // Step 8: Register in running sessions map
+        // Step 9: Register in running sessions map
         let worktree_path = worktree.path.clone();
         {
             let mut running = self.running.lock().await;
@@ -759,6 +765,15 @@ mod tests {
         assert!(
             matches!(result, Err(AppError::Validation(_))),
             "expected Validation error for unsupported agent type, got: {result:?}"
+        );
+
+        // Verify no DB session was created (early validation prevents resource leaks)
+        let sessions = agent_session_service::list_agent_sessions(&pool, task_id)
+            .await
+            .unwrap();
+        assert!(
+            sessions.is_empty(),
+            "no DB session should be created for unsupported agent type"
         );
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,11 +1,14 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use gantry_board::agent::claude_code::ClaudeCodeExecutor;
+use gantry_board::agent::executor::AgentExecutor;
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::db;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::services::session_service;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
@@ -42,9 +45,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .as_deref()
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
-    let executor = Arc::new(ClaudeCodeExecutor);
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(ClaudeCodeExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        executor,
+        executors,
         pool.clone(),
         repo_path,
         Arc::clone(&sse_hub),

--- a/backend/src/models/agent_session.rs
+++ b/backend/src/models/agent_session.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, sqlx::Type)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, sqlx::Type)]
 #[sqlx(type_name = "TEXT", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum AgentType {

--- a/backend/src/models/agent_session.rs
+++ b/backend/src/models/agent_session.rs
@@ -11,6 +11,15 @@ pub enum AgentType {
     GeminiCli,
 }
 
+impl std::fmt::Display for AgentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClaudeCode => write!(f, "claude_code"),
+            Self::GeminiCli => write!(f, "gemini_cli"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, sqlx::Type)]
 #[sqlx(type_name = "TEXT", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]

--- a/backend/src/sse/handler.rs
+++ b/backend/src/sse/handler.rs
@@ -58,8 +58,13 @@ mod tests {
             .expect("Failed to run migrations");
 
         let sse_hub = Arc::new(SseHub::default());
+        let mut executors = std::collections::HashMap::new();
+        executors.insert(
+            crate::models::agent_session::AgentType::ClaudeCode,
+            Arc::new(NoopExecutor) as Arc<dyn crate::agent::executor::AgentExecutor>,
+        );
         let orchestrator = Arc::new(AgentOrchestrator::new(
-            Arc::new(NoopExecutor),
+            executors,
             pool.clone(),
             PathBuf::from("."),
             Arc::clone(&sse_hub),

--- a/backend/tests/agent_sessions_api.rs
+++ b/backend/tests/agent_sessions_api.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -43,8 +45,10 @@ async fn create_test_server() -> (TempDir, TestServer) {
         .unwrap();
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         repo_path,
         Arc::clone(&sse_hub),

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -31,8 +33,10 @@ async fn create_test_server() -> TestServer {
     };
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         PathBuf::from("."),
         Arc::clone(&sse_hub),

--- a/backend/tests/authorization_api.rs
+++ b/backend/tests/authorization_api.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::{header, StatusCode};
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -31,8 +33,10 @@ async fn create_test_server() -> TestServer {
     };
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         PathBuf::from("."),
         Arc::clone(&sse_hub),

--- a/backend/tests/project_members_api.rs
+++ b/backend/tests/project_members_api.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -32,8 +34,10 @@ async fn create_test_server() -> TestServer {
     };
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         PathBuf::from("."),
         Arc::clone(&sse_hub),

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -30,8 +32,10 @@ async fn create_test_server() -> TestServer {
     };
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         PathBuf::from("."),
         Arc::clone(&sse_hub),

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::NoopExecutor;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use serde_json::json;
@@ -32,8 +34,10 @@ async fn create_test_server() -> TestServer {
     };
 
     let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
     let orchestrator = Arc::new(AgentOrchestrator::new(
-        Arc::new(NoopExecutor),
+        executors,
         pool.clone(),
         PathBuf::from("."),
         Arc::clone(&sse_hub),


### PR DESCRIPTION
## Summary
- Change `AgentOrchestrator` from single `Arc<dyn AgentExecutor>` to `HashMap<AgentType, Arc<dyn AgentExecutor>>`
- Add `Hash`, `Eq`, `PartialEq` derives to `AgentType` for HashMap key usage
- Route executor selection based on `config.agent_type` in `start_session`
- Return `AppError::Validation` for unsupported agent types
- Update all test helpers and integration tests for new constructor signature

Closes #59

## Test plan
- [x] New test `test_start_session_unsupported_agent_type` verifies Validation error for unregistered agent types
- [x] All 244 existing tests pass
- [x] `task check` passes (fmt, lint, build, test)