### PR TITLE
feat: ✨ implement Gemini CLI stream-json parser

### DIFF
--- a/backend/src/agent/gemini_cli.rs
+++ b/backend/src/agent/gemini_cli.rs
@@ -31,9 +31,10 @@ enum GeminiStreamEvent {
 
 #[derive(Debug, Deserialize)]
 struct GeminiError {
-    #[serde(rename = "type")]
-    error_type: String,
-    message: String,
+    #[serde(rename = "type", default)]
+    error_type: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
 }
 
 /// Parse a single NDJSON line from Gemini CLI's `--output-format stream-json` output.
@@ -59,8 +60,14 @@ pub fn parse_gemini_stream_line(line: &str) -> Option<AgentOutputEvent> {
                 Some(AgentOutputEvent::Completed)
             } else {
                 let error_msg = error
-                    .map(|e| format!("{}: {}", e.error_type, e.message))
-                    .unwrap_or_else(|| "unknown error".to_string());
+                    .map(|e| {
+                        format!(
+                            "{}: {}",
+                            e.error_type.as_deref().unwrap_or("unknown"),
+                            e.message.as_deref().unwrap_or("no message"),
+                        )
+                    })
+                    .unwrap_or_else(|| format!("unknown error (status: {status})"));
                 Some(AgentOutputEvent::Failed { error: error_msg })
             }
         }
@@ -127,10 +134,27 @@ mod tests {
     #[test]
     fn test_parse_result_error_without_details() {
         let line = r#"{"type":"result","status":"error","timestamp":"2025-10-10T12:00:00.000Z"}"#;
-        assert!(matches!(
-            parse_gemini_stream_line(line),
-            Some(AgentOutputEvent::Failed { .. })
-        ));
+        match parse_gemini_stream_line(line) {
+            Some(AgentOutputEvent::Failed { error }) => {
+                assert!(error.contains("error"), "should include status: {error}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_result_error_with_partial_details() {
+        let line = r#"{"type":"result","status":"error","error":{"message":"Something broke"},"timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        match parse_gemini_stream_line(line) {
+            Some(AgentOutputEvent::Failed { error }) => {
+                assert!(error.contains("Something broke"));
+                assert!(
+                    error.contains("unknown"),
+                    "missing type should fall back: {error}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/backend/src/agent/gemini_cli.rs
+++ b/backend/src/agent/gemini_cli.rs
@@ -1,0 +1,138 @@
+use serde::Deserialize;
+use tracing::warn;
+
+use crate::agent::executor::AgentOutputEvent;
+
+/// Gemini CLI stream-json event types.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+enum GeminiStreamEvent {
+    Init {},
+    Message {
+        role: String,
+        content: String,
+        #[serde(default)]
+        delta: Option<bool>,
+    },
+    ToolUse {},
+    ToolResult {},
+    Error {
+        message: String,
+    },
+    Result {
+        status: String,
+        #[serde(default)]
+        error: Option<GeminiError>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct GeminiError {
+    #[serde(rename = "type")]
+    error_type: String,
+    message: String,
+}
+
+/// Parse a single NDJSON line from Gemini CLI's `--output-format stream-json` output.
+///
+/// Returns `Some(AgentOutputEvent)` for lines that produce output,
+/// or `None` for lines that should be ignored.
+pub fn parse_gemini_stream_line(line: &str) -> Option<AgentOutputEvent> {
+    let _ = (line, warn!(""));
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_assistant_delta_message() {
+        let line = r#"{"type":"message","role":"assistant","content":"Hello world","delta":true,"timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        match parse_gemini_stream_line(line) {
+            Some(AgentOutputEvent::Output { text }) => assert_eq!(text, "Hello world"),
+            other => panic!("expected Output, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_assistant_non_delta_ignored() {
+        let line = r#"{"type":"message","role":"assistant","content":"Full response","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_assistant_delta_false_ignored() {
+        let line = r#"{"type":"message","role":"assistant","content":"Full","delta":false,"timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_user_message_ignored() {
+        let line = r#"{"type":"message","role":"user","content":"List files","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_result_success() {
+        let line = r#"{"type":"result","status":"success","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(matches!(
+            parse_gemini_stream_line(line),
+            Some(AgentOutputEvent::Completed)
+        ));
+    }
+
+    #[test]
+    fn test_parse_result_error_with_details() {
+        let line = r#"{"type":"result","status":"error","error":{"type":"api_error","message":"Rate limit exceeded"},"timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        match parse_gemini_stream_line(line) {
+            Some(AgentOutputEvent::Failed { error }) => {
+                assert!(error.contains("api_error"));
+                assert!(error.contains("Rate limit exceeded"));
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_result_error_without_details() {
+        let line = r#"{"type":"result","status":"error","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(matches!(
+            parse_gemini_stream_line(line),
+            Some(AgentOutputEvent::Failed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_parse_init_ignored() {
+        let line = r#"{"type":"init","timestamp":"2025-10-10T12:00:00.000Z","session_id":"abc","model":"gemini-2.0-flash"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_tool_use_ignored() {
+        let line = r#"{"type":"tool_use","tool_name":"Bash","tool_id":"bash-1","parameters":{"command":"ls"},"timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_tool_result_ignored() {
+        let line = r#"{"type":"tool_result","tool_id":"bash-1","status":"success","output":"file1.txt","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        assert!(parse_gemini_stream_line("not json").is_none());
+        assert!(parse_gemini_stream_line("").is_none());
+    }
+
+    #[test]
+    fn test_parse_unknown_type_ignored() {
+        let line = r#"{"type":"unknown_future_event","data":"something","timestamp":"2025-10-10T12:00:00.000Z"}"#;
+        assert!(parse_gemini_stream_line(line).is_none());
+    }
+}

--- a/backend/src/agent/gemini_cli.rs
+++ b/backend/src/agent/gemini_cli.rs
@@ -41,8 +41,35 @@ struct GeminiError {
 /// Returns `Some(AgentOutputEvent)` for lines that produce output,
 /// or `None` for lines that should be ignored.
 pub fn parse_gemini_stream_line(line: &str) -> Option<AgentOutputEvent> {
-    let _ = (line, warn!(""));
-    todo!()
+    let event: GeminiStreamEvent = serde_json::from_str(line).ok()?;
+    match event {
+        GeminiStreamEvent::Message {
+            role,
+            content,
+            delta,
+        } => {
+            if role == "assistant" && delta == Some(true) {
+                Some(AgentOutputEvent::Output { text: content })
+            } else {
+                None
+            }
+        }
+        GeminiStreamEvent::Result { status, error } => {
+            if status == "success" {
+                Some(AgentOutputEvent::Completed)
+            } else {
+                let error_msg = error
+                    .map(|e| format!("{}: {}", e.error_type, e.message))
+                    .unwrap_or_else(|| "unknown error".to_string());
+                Some(AgentOutputEvent::Failed { error: error_msg })
+            }
+        }
+        GeminiStreamEvent::Error { message } => {
+            warn!("gemini non-fatal error: {message}");
+            None
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/agent/mod.rs
+++ b/backend/src/agent/mod.rs
@@ -1,3 +1,4 @@
 pub mod claude_code;
 pub mod executor;
+pub mod gemini_cli;
 pub mod orchestrator;


### PR DESCRIPTION
## Summary
- Add `parse_gemini_stream_line` parser for Gemini CLI's `--output-format stream-json` NDJSON output
- Map `message` (role=assistant, delta=true) to `AgentOutputEvent::Output`
- Map `result` (success/error) to `Completed`/`Failed`
- Ignore `init`, `tool_use`, `tool_result`, user messages, and unknown event types
- Uses `serde(tag = "type")` tagged enum with `#[serde(other)]` for forward compatibility

Closes #61

## Test plan
- [x] 12 unit tests covering all event types, edge cases, and invalid JSON
- [x] All 262 tests pass (`task check`)