### PR TITLE
perf: ⚡️ optimize CI pipeline and local test execution

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.default]
+test-threads = "num-cpus"
+retries = 0
+slow-timeout = { period = "30s", terminate-after = 3 }
+
+[profile.ci]
+retries = 2
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -30,8 +31,11 @@ jobs:
               - 'backend/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - '.config/nextest.toml'
+              - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
+              - '.github/workflows/ci.yml'
             api:
               - 'backend/src/handlers/**'
               - 'backend/src/models/**'
@@ -91,7 +95,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-nextest
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo nextest run --profile ci
+      - run: cargo nextest run --profile ci -E 'not binary(export_openapi)'
         working-directory: backend
       - run: cargo test --test export_openapi -- --nocapture
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,38 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── 変更検出 ────────────────────────────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            frontend:
+              - 'frontend/**'
+            api:
+              - 'backend/src/handlers/**'
+              - 'backend/src/models/**'
+              - 'backend/src/lib.rs'
+              - 'backend/tests/export_openapi.rs'
+              - 'frontend/orval.config.*'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
+  # ── PR タイトル lint ─────────────────────────────
   pr-title:
     name: PR title lint
     if: github.event_name == 'pull_request'
@@ -42,46 +74,69 @@ jobs:
             exit 1
           fi
 
+  # ── Rust (fmt, clippy, nextest) ──────────────────
   rust:
-    name: Rust (build, test, clippy)
+    name: Rust (clippy, test)
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.api == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-nextest
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo build
-      - run: cargo test
+      - run: cargo nextest run --profile ci
+        working-directory: backend
+      - run: cargo test --test export_openapi -- --nocapture
+        working-directory: backend
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: openapi.json
+          retention-days: 1
 
+  # ── API (orval diff) ─────────────────────────────
   api:
-    name: API (openapi export, orval diff)
+    name: API (orval diff)
     runs-on: ubuntu-latest
-    needs: rust
+    needs: [changes, rust]
+    if: needs.changes.outputs.api == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v4
+        with:
+          name: openapi-spec
+          path: .
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cargo test --test export_openapi -- --nocapture
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
       - run: cd frontend && npm ci
       - run: cd frontend && npx orval
       - run: cd frontend && npx biome check --write src/api/generated/
       - run: cd frontend && git diff --exit-code src/api/generated/
         name: Check generated API client is up to date
 
+  # ── Frontend (lint, test, build) ─────────────────
   frontend:
-    name: Frontend (lint, format, test, build)
+    name: Frontend (lint, test, build)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
       - run: cd frontend && npm ci
       - run: cd frontend && npx biome check src/
       - run: cd frontend && npx vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             api:
               - 'backend/src/handlers/**'
               - 'backend/src/models/**'
+              - 'backend/src/openapi.rs'
               - 'backend/src/lib.rs'
               - 'backend/tests/export_openapi.rs'
               - 'frontend/orval.config.*'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,10 +19,13 @@ tasks:
       - lint
 
   check:runtime:
-    desc: Build and test (parallel)
+    desc: Build and test (frontend parallel, backend sequential)
     deps:
-      - build
-      - test
+      - frontend:build
+      - frontend:test
+    cmds:
+      - task: backend:build
+      - task: backend:test
 
   fmt:
     desc: Format all code
@@ -78,17 +81,26 @@ tasks:
   backend:test:
     desc: Run all Rust tests (unit + integration)
     dir: "{{.BACKEND_DIR}}"
-    cmd: cargo nextest run
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run{{else}}cargo test{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
 
   backend:test:unit:
     desc: Run unit tests only (fast, no DB/HTTP)
     dir: "{{.BACKEND_DIR}}"
-    cmd: cargo nextest run --lib
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --lib{{else}}cargo test --lib{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
 
   backend:test:integration:
     desc: Run integration tests only (API endpoints)
     dir: "{{.BACKEND_DIR}}"
-    cmd: cargo nextest run --test '*'
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --test "*"{{else}}cargo test --test "*"{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
 
   backend:run:
     desc: Run backend server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,40 +9,50 @@ tasks:
   check:
     desc: Run all checks (fmt, lint, build, test)
     cmds:
-      - task: fmt:check
-      - task: lint
-      - task: build
-      - task: test
+      - task: check:static
+      - task: check:runtime
+
+  check:static:
+    desc: Format and lint checks (parallel)
+    deps:
+      - fmt:check
+      - lint
+
+  check:runtime:
+    desc: Build and test (parallel)
+    deps:
+      - build
+      - test
 
   fmt:
     desc: Format all code
-    cmds:
-      - task: backend:fmt
-      - task: frontend:fmt
+    deps:
+      - backend:fmt
+      - frontend:fmt
 
   fmt:check:
     desc: Check formatting without modifying files
-    cmds:
-      - task: backend:fmt:check
-      - task: frontend:fmt:check
+    deps:
+      - backend:fmt:check
+      - frontend:fmt:check
 
   lint:
     desc: Lint all code
-    cmds:
-      - task: backend:lint
-      - task: frontend:lint
+    deps:
+      - backend:lint
+      - frontend:lint
 
   build:
     desc: Build all
-    cmds:
-      - task: backend:build
-      - task: frontend:build
+    deps:
+      - backend:build
+      - frontend:build
 
   test:
     desc: Run all tests
-    cmds:
-      - task: backend:test
-      - task: frontend:test
+    deps:
+      - backend:test
+      - frontend:test
 
   # ── Backend (Rust) ────────────────────────────
   backend:fmt:
@@ -66,9 +76,19 @@ tasks:
     cmd: cargo build
 
   backend:test:
-    desc: Run Rust tests
+    desc: Run all Rust tests (unit + integration)
     dir: "{{.BACKEND_DIR}}"
-    cmd: cargo test
+    cmd: cargo nextest run
+
+  backend:test:unit:
+    desc: Run unit tests only (fast, no DB/HTTP)
+    dir: "{{.BACKEND_DIR}}"
+    cmd: cargo nextest run --lib
+
+  backend:test:integration:
+    desc: Run integration tests only (API endpoints)
+    dir: "{{.BACKEND_DIR}}"
+    cmd: cargo nextest run --test '*'
 
   backend:run:
     desc: Run backend server

--- a/backend/tests/agent_sessions_api.rs
+++ b/backend/tests/agent_sessions_api.rs
@@ -1,69 +1,10 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_test_server_with_repo as create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use tempfile::TempDir;
 use uuid::Uuid;
-
-async fn create_test_server() -> (TempDir, TestServer) {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: true,
-        ..Default::default()
-    };
-
-    // Create a temporary git repo for worktree operations
-    let tmp = TempDir::new().expect("Failed to create temp dir");
-    let repo_path = tmp.path().join("repo");
-    std::fs::create_dir(&repo_path).expect("Failed to create repo dir");
-    let repo = git2::Repository::init(&repo_path).expect("Failed to init repo");
-    let sig = git2::Signature::now("test", "test@test.com").unwrap();
-    let tree_id = repo.index().unwrap().write_tree().unwrap();
-    let tree = repo.find_tree(tree_id).unwrap();
-    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
-        .unwrap();
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        repo_path,
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    let server = TestServer::new(app).expect("Failed to create test server");
-    (tmp, server)
-}
 
 async fn create_test_task(server: &TestServer) -> (String, String) {
     let response = server

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -1,56 +1,8 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
 use axum::http::{header, StatusCode};
-use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_auth_test_server as create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use std::path::PathBuf;
-
-async fn create_test_server() -> TestServer {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: false, // Enable auth for these tests
-        ..Default::default()
-    };
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        PathBuf::from("."),
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    TestServer::new(app).expect("Failed to create test server")
-}
 
 #[tokio::test]
 async fn test_register_creates_user_and_returns_session_cookie() {

--- a/backend/tests/authorization_api.rs
+++ b/backend/tests/authorization_api.rs
@@ -1,56 +1,9 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
 use axum::http::{header, StatusCode};
 use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_auth_test_server as create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use std::path::PathBuf;
-
-async fn create_test_server() -> TestServer {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: false, // Enable auth for authorization tests
-        ..Default::default()
-    };
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        PathBuf::from("."),
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    TestServer::new(app).expect("Failed to create test server")
-}
 
 /// Register a user and return (user_id, session_cookie_header_value)
 async fn register_user(server: &TestServer, email: &str, name: &str) -> (String, String) {
@@ -305,77 +258,7 @@ async fn create_task(server: &TestServer, cookie: &str, project_id: &str, title:
 }
 
 #[tokio::test]
-async fn test_list_tasks_forbidden_for_non_member() {
-    let server = create_test_server().await;
-    let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (_user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
-
-    let project_id = create_project(&server, &cookie_a, "Project").await;
-
-    let response = server
-        .get(&format!("/api/tasks?project_id={}", project_id))
-        .add_header(header::COOKIE, &cookie_b)
-        .await;
-    response.assert_status(StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn test_list_tasks_allowed_for_member() {
-    let server = create_test_server().await;
-    let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
-
-    let project_id = create_project(&server, &cookie_a, "Project").await;
-    add_member(&server, &cookie_a, &project_id, &user_b_id, "member").await;
-
-    let response = server
-        .get(&format!("/api/tasks?project_id={}", project_id))
-        .add_header(header::COOKIE, &cookie_b)
-        .await;
-    response.assert_status_ok();
-}
-
-#[tokio::test]
-async fn test_create_task_forbidden_for_non_member() {
-    let server = create_test_server().await;
-    let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (_user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
-
-    let project_id = create_project(&server, &cookie_a, "Project").await;
-
-    let response = server
-        .post("/api/tasks")
-        .add_header(header::COOKIE, &cookie_b)
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Unauthorized Task"
-        }))
-        .await;
-    response.assert_status(StatusCode::FORBIDDEN);
-}
-
-#[tokio::test]
-async fn test_create_task_allowed_for_member() {
-    let server = create_test_server().await;
-    let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
-
-    let project_id = create_project(&server, &cookie_a, "Project").await;
-    add_member(&server, &cookie_a, &project_id, &user_b_id, "member").await;
-
-    let response = server
-        .post("/api/tasks")
-        .add_header(header::COOKIE, &cookie_b)
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Member Task"
-        }))
-        .await;
-    response.assert_status(StatusCode::CREATED);
-}
-
-#[tokio::test]
-async fn test_get_task_forbidden_for_non_member() {
+async fn test_task_endpoints_forbidden_for_non_member() {
     let server = create_test_server().await;
     let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
     let (_user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
@@ -383,44 +266,67 @@ async fn test_get_task_forbidden_for_non_member() {
     let project_id = create_project(&server, &cookie_a, "Project").await;
     let task_id = create_task(&server, &cookie_a, &project_id, "Task").await;
 
-    let response = server
+    // list
+    server
+        .get(&format!("/api/tasks?project_id={}", project_id))
+        .add_header(header::COOKIE, &cookie_b)
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+
+    // create
+    server
+        .post("/api/tasks")
+        .add_header(header::COOKIE, &cookie_b)
+        .json(&json!({ "project_id": project_id, "title": "Unauthorized" }))
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+
+    // get
+    server
         .get(&format!("/api/tasks/{}", task_id))
         .add_header(header::COOKIE, &cookie_b)
-        .await;
-    response.assert_status(StatusCode::FORBIDDEN);
-}
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
 
-#[tokio::test]
-async fn test_update_task_forbidden_for_non_member() {
-    let server = create_test_server().await;
-    let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (_user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
-
-    let project_id = create_project(&server, &cookie_a, "Project").await;
-    let task_id = create_task(&server, &cookie_a, &project_id, "Task").await;
-
-    let response = server
+    // update
+    server
         .patch(&format!("/api/tasks/{}", task_id))
         .add_header(header::COOKIE, &cookie_b)
         .json(&json!({ "title": "Hacked" }))
-        .await;
-    response.assert_status(StatusCode::FORBIDDEN);
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+
+    // delete
+    server
+        .delete(&format!("/api/tasks/{}", task_id))
+        .add_header(header::COOKIE, &cookie_b)
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]
-async fn test_delete_task_forbidden_for_non_member() {
+async fn test_task_endpoints_allowed_for_member() {
     let server = create_test_server().await;
     let (_user_a_id, cookie_a) = register_user(&server, "a@example.com", "User A").await;
-    let (_user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
+    let (user_b_id, cookie_b) = register_user(&server, "b@example.com", "User B").await;
 
     let project_id = create_project(&server, &cookie_a, "Project").await;
-    let task_id = create_task(&server, &cookie_a, &project_id, "Task").await;
+    add_member(&server, &cookie_a, &project_id, &user_b_id, "member").await;
 
-    let response = server
-        .delete(&format!("/api/tasks/{}", task_id))
+    // list
+    server
+        .get(&format!("/api/tasks?project_id={}", project_id))
         .add_header(header::COOKIE, &cookie_b)
-        .await;
-    response.assert_status(StatusCode::FORBIDDEN);
+        .await
+        .assert_status_ok();
+
+    // create
+    server
+        .post("/api/tasks")
+        .add_header(header::COOKIE, &cookie_b)
+        .json(&json!({ "project_id": project_id, "title": "Member Task" }))
+        .await
+        .assert_status(StatusCode::CREATED);
 }
 
 // =============================================================

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -1,0 +1,79 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
+use gantry_board::agent::orchestrator::AgentOrchestrator;
+use gantry_board::config::Config;
+use gantry_board::models::agent_session::AgentType;
+use gantry_board::sse::hub::SseHub;
+use gantry_board::AppState;
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn create_test_server_impl(auth_disabled: bool, repo_path: PathBuf) -> TestServer {
+    let pool = SqlitePoolOptions::new()
+        .connect("sqlite::memory:")
+        .await
+        .expect("Failed to create test database");
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let config = Config {
+        bind_addr: "127.0.0.1:0".to_string(),
+        database_url: "sqlite::memory:".to_string(),
+        auth_disabled,
+        ..Default::default()
+    };
+
+    let sse_hub = Arc::new(SseHub::default());
+    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
+    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
+    let orchestrator = Arc::new(AgentOrchestrator::new(
+        executors,
+        pool.clone(),
+        repo_path,
+        Arc::clone(&sse_hub),
+    ));
+    let state = AppState {
+        pool,
+        sse_hub,
+        config: Arc::new(config),
+        orchestrator,
+    };
+
+    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
+    TestServer::new(app).expect("Failed to create test server")
+}
+
+/// Create a test server with auth disabled (for CRUD tests).
+pub async fn create_test_server() -> TestServer {
+    create_test_server_impl(true, PathBuf::from(".")).await
+}
+
+/// Create a test server with auth enabled (for auth/authorization tests).
+pub async fn create_auth_test_server() -> TestServer {
+    create_test_server_impl(false, PathBuf::from(".")).await
+}
+
+/// Create a test server with a temporary git repo (for agent session tests).
+pub async fn create_test_server_with_repo() -> (tempfile::TempDir, TestServer) {
+    let tmp = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let repo_path = tmp.path().join("repo");
+    std::fs::create_dir(&repo_path).expect("Failed to create repo dir");
+    let repo = git2::Repository::init(&repo_path).expect("Failed to init repo");
+    let sig = git2::Signature::now("test", "test@test.com").unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+
+    let server = create_test_server_impl(true, repo_path).await;
+    (tmp, server)
+}

--- a/backend/tests/project_members_api.rs
+++ b/backend/tests/project_members_api.rs
@@ -1,57 +1,10 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use std::path::PathBuf;
 use uuid::Uuid;
-
-async fn create_test_server() -> TestServer {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: true, // Disable auth for API tests
-        ..Default::default()
-    };
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        PathBuf::from("."),
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    TestServer::new(app).expect("Failed to create test server")
-}
 
 async fn create_test_project(server: &TestServer) -> String {
     let response = server

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -1,55 +1,7 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
-use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use std::path::PathBuf;
-
-async fn create_test_server() -> TestServer {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: true, // Disable auth for API tests
-        ..Default::default()
-    };
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        PathBuf::from("."),
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    TestServer::new(app).expect("Failed to create test server")
-}
 
 #[tokio::test]
 async fn test_list_projects_returns_empty_initially() {

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -1,57 +1,10 @@
-use std::collections::HashMap;
-use std::net::SocketAddr;
-use std::sync::Arc;
+mod common;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
-use gantry_board::agent::orchestrator::AgentOrchestrator;
-use gantry_board::config::Config;
-use gantry_board::models::agent_session::AgentType;
-use gantry_board::sse::hub::SseHub;
-use gantry_board::AppState;
+use common::create_test_server;
 use serde_json::json;
-use sqlx::sqlite::SqlitePoolOptions;
-use std::path::PathBuf;
 use uuid::Uuid;
-
-async fn create_test_server() -> TestServer {
-    let pool = SqlitePoolOptions::new()
-        .connect("sqlite::memory:")
-        .await
-        .expect("Failed to create test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
-
-    let config = Config {
-        bind_addr: "127.0.0.1:0".to_string(),
-        database_url: "sqlite::memory:".to_string(),
-        auth_disabled: true, // Disable auth for API tests
-        ..Default::default()
-    };
-
-    let sse_hub = Arc::new(SseHub::default());
-    let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
-    let orchestrator = Arc::new(AgentOrchestrator::new(
-        executors,
-        pool.clone(),
-        PathBuf::from("."),
-        Arc::clone(&sse_hub),
-    ));
-    let state = AppState {
-        pool,
-        sse_hub,
-        config: Arc::new(config),
-        orchestrator,
-    };
-
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
-    TestServer::new(app).expect("Failed to create test server")
-}
 
 async fn create_test_project(server: &TestServer) -> String {
     let response = server

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    pool: 'forks',
   },
 });


### PR DESCRIPTION
## Summary
- Add path-based job filtering (`dorny/paths-filter`) to skip irrelevant CI jobs based on changed files
- Introduce `cargo-nextest` for parallel Rust test execution at the binary level
- Eliminate Rust rebuild in the `api` job by sharing `openapi.json` via artifacts (minutes → ~30s)
- Parallelize Taskfile tasks (`deps` instead of `cmds`) for local backend/frontend execution
- Add `pool: 'forks'` to Vitest for per-file process isolation
- Extract shared `create_test_server()` into `tests/common/mod.rs` (removed ~400 lines of duplication)
- Consolidate authorization Phase 4 task endpoint tests (7 → 2 tests, same coverage)
- Fix Copilot review findings: add `contents: read` permission, include CI/config files in path filters, exclude `export_openapi` from nextest to avoid duplicate execution

## Changes
| File | Description |
|------|-------------|
| `.github/workflows/ci.yml` | Path filtering, nextest, artifact sharing, npm cache, Copilot fixes |
| `.config/nextest.toml` | nextest profiles (default + ci with retries) |
| `Taskfile.yml` | Parallel execution, `backend:test:unit` / `backend:test:integration` targets |
| `frontend/vitest.config.ts` | Enable `forks` pool |
| `backend/tests/common/mod.rs` | Shared test server setup (new) |
| `backend/tests/*.rs` | Use common module, consolidate authorization tests |

## Expected Impact
| Scenario | Before | After |
|----------|--------|-------|
| CI — frontend-only change | ~8 min | ~2 min (backend skipped) |
| CI — api job | ~3 min | ~30 sec (no Rust rebuild) |
| Local `task test` | sequential | parallel (30-40% faster) |
| Local `task check` | fully sequential | staged parallel (40-50% faster) |
| Integration tests | 86 tests | 81 tests (same coverage, fewer server setups) |

## Test plan
- [x] `cargo nextest run --lib` — 159 tests passed
- [x] `cargo nextest run --test '*'` — 81 tests passed
- [x] `npx vitest run` — 107 tests passed (13 files)
- [x] `task check` — full quality check passed (240 total tests)
- [ ] Verify path filtering works in CI (frontend-only change skips rust/api jobs)