### PR TITLE
feat: ✨ add agent_session_output persistence table and service

### DIFF
--- a/backend/migrations/20260210000001_create_agent_session_outputs.sql
+++ b/backend/migrations/20260210000001_create_agent_session_outputs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS agent_session_outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+    sequence INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_outputs_session_id ON agent_session_outputs(session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_session_outputs_session_sequence ON agent_session_outputs(session_id, sequence);

--- a/backend/src/models/agent_session_output.rs
+++ b/backend/src/models/agent_session_output.rs
@@ -1,0 +1,37 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::prelude::FromRow;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentSessionOutput {
+    pub id: i64,
+    pub session_id: Uuid,
+    pub sequence: i64,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(FromRow)]
+pub(crate) struct AgentSessionOutputRow {
+    pub id: i64,
+    pub session_id: String,
+    pub sequence: i64,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TryFrom<AgentSessionOutputRow> for AgentSessionOutput {
+    type Error = uuid::Error;
+
+    fn try_from(row: AgentSessionOutputRow) -> Result<Self, Self::Error> {
+        Ok(AgentSessionOutput {
+            id: row.id,
+            session_id: row.session_id.parse()?,
+            sequence: row.sequence,
+            content: row.content,
+            created_at: row.created_at,
+        })
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_session;
+pub mod agent_session_output;
 pub mod project;
 pub mod task;
 pub mod user;

--- a/backend/src/services/agent_session_output_service.rs
+++ b/backend/src/services/agent_session_output_service.rs
@@ -5,27 +5,72 @@ use crate::error::{AppError, AppResult};
 use crate::models::agent_session_output::{AgentSessionOutput, AgentSessionOutputRow};
 
 pub async fn append_output(
-    _pool: &SqlitePool,
-    _session_id: Uuid,
-    _sequence: i64,
-    _content: &str,
+    pool: &SqlitePool,
+    session_id: Uuid,
+    sequence: i64,
+    content: &str,
 ) -> AppResult<AgentSessionOutput> {
-    todo!()
+    let row = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        INSERT INTO agent_session_outputs (session_id, sequence, content)
+        VALUES ($1, $2, $3)
+        RETURNING id, session_id, sequence, content, created_at
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(sequence)
+    .bind(content)
+    .fetch_one(pool)
+    .await?;
+
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
 }
 
 pub async fn get_outputs(
-    _pool: &SqlitePool,
-    _session_id: Uuid,
+    pool: &SqlitePool,
+    session_id: Uuid,
 ) -> AppResult<Vec<AgentSessionOutput>> {
-    todo!()
+    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        SELECT id, session_id, sequence, content, created_at
+        FROM agent_session_outputs
+        WHERE session_id = $1
+        ORDER BY sequence ASC
+        "#,
+    )
+    .bind(session_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| r.try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
 }
 
 pub async fn get_outputs_after(
-    _pool: &SqlitePool,
-    _session_id: Uuid,
-    _after_sequence: i64,
+    pool: &SqlitePool,
+    session_id: Uuid,
+    after_sequence: i64,
 ) -> AppResult<Vec<AgentSessionOutput>> {
-    todo!()
+    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        SELECT id, session_id, sequence, content, created_at
+        FROM agent_session_outputs
+        WHERE session_id = $1 AND sequence > $2
+        ORDER BY sequence ASC
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(after_sequence)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| r.try_into())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
 }
 
 #[cfg(test)]

--- a/backend/src/services/agent_session_output_service.rs
+++ b/backend/src/services/agent_session_output_service.rs
@@ -1,0 +1,167 @@
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::agent_session_output::{AgentSessionOutput, AgentSessionOutputRow};
+
+pub async fn append_output(
+    _pool: &SqlitePool,
+    _session_id: Uuid,
+    _sequence: i64,
+    _content: &str,
+) -> AppResult<AgentSessionOutput> {
+    todo!()
+}
+
+pub async fn get_outputs(
+    _pool: &SqlitePool,
+    _session_id: Uuid,
+) -> AppResult<Vec<AgentSessionOutput>> {
+    todo!()
+}
+
+pub async fn get_outputs_after(
+    _pool: &SqlitePool,
+    _session_id: Uuid,
+    _after_sequence: i64,
+) -> AppResult<Vec<AgentSessionOutput>> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::agent_session::{AgentType, CreateAgentSessionRequest};
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::task::CreateTaskRequest;
+    use crate::services::{agent_session_service, project_service, task_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_session(pool: &SqlitePool) -> Uuid {
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+            },
+        )
+        .await
+        .expect("Failed to create project");
+
+        let task = task_service::create_task(
+            pool,
+            &CreateTaskRequest {
+                project_id: project.id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("Failed to create task");
+
+        let session = agent_session_service::create_agent_session(
+            pool,
+            task.id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create session");
+
+        session.id
+    }
+
+    #[tokio::test]
+    async fn test_append_and_get_outputs_roundtrip() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        let out1 = append_output(&pool, session_id, 0, "Hello ")
+            .await
+            .expect("Failed to append");
+        let out2 = append_output(&pool, session_id, 1, "World")
+            .await
+            .expect("Failed to append");
+
+        assert_eq!(out1.sequence, 0);
+        assert_eq!(out1.content, "Hello ");
+        assert_eq!(out1.session_id, session_id);
+        assert_eq!(out2.sequence, 1);
+        assert_eq!(out2.content, "World");
+
+        let outputs = get_outputs(&pool, session_id).await.expect("Failed to get");
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].sequence, 0);
+        assert_eq!(outputs[0].content, "Hello ");
+        assert_eq!(outputs[1].sequence, 1);
+        assert_eq!(outputs[1].content, "World");
+    }
+
+    #[tokio::test]
+    async fn test_get_outputs_returns_ordered_by_sequence() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        append_output(&pool, session_id, 2, "Third")
+            .await
+            .expect("Failed");
+        append_output(&pool, session_id, 0, "First")
+            .await
+            .expect("Failed");
+        append_output(&pool, session_id, 1, "Second")
+            .await
+            .expect("Failed");
+
+        let outputs = get_outputs(&pool, session_id).await.expect("Failed to get");
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(outputs[0].content, "First");
+        assert_eq!(outputs[1].content, "Second");
+        assert_eq!(outputs[2].content, "Third");
+    }
+
+    #[tokio::test]
+    async fn test_get_outputs_empty_session() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        let outputs = get_outputs(&pool, session_id).await.expect("Failed to get");
+        assert!(outputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_outputs_after_sequence() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        for i in 0..5 {
+            append_output(&pool, session_id, i, &format!("chunk-{}", i))
+                .await
+                .expect("Failed");
+        }
+
+        let outputs = get_outputs_after(&pool, session_id, 2)
+            .await
+            .expect("Failed to get");
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].sequence, 3);
+        assert_eq!(outputs[1].sequence, 4);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_sequence_returns_error() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        append_output(&pool, session_id, 0, "first")
+            .await
+            .expect("First insert should succeed");
+
+        let result = append_output(&pool, session_id, 0, "duplicate").await;
+        assert!(result.is_err(), "Duplicate sequence should fail");
+    }
+}

--- a/backend/src/services/agent_session_output_service.rs
+++ b/backend/src/services/agent_session_output_service.rs
@@ -207,6 +207,9 @@ mod tests {
             .expect("First insert should succeed");
 
         let result = append_output(&pool, session_id, 0, "duplicate").await;
-        assert!(result.is_err(), "Duplicate sequence should fail");
+        assert!(
+            matches!(result, Err(AppError::Database(_))),
+            "Duplicate sequence should fail with database error, got: {result:?}"
+        );
     }
 }

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_session_output_service;
 pub mod agent_session_service;
 pub mod authorization_service;
 pub mod member_service;


### PR DESCRIPTION
## Summary
- Add `agent_session_outputs` migration table (`INTEGER AUTOINCREMENT` PK, `UNIQUE(session_id, sequence)`)
- Add `AgentSessionOutput` model with `FromRow` → `TryFrom` conversion pattern
- Add service functions: `append_output`, `get_outputs`, `get_outputs_after`

Closes #60

## Test plan
- [x] `test_append_and_get_outputs_roundtrip` — insert + fetch 確認
- [x] `test_get_outputs_returns_ordered_by_sequence` — 挿入順序に依存しない sequence ソート
- [x] `test_get_outputs_empty_session` — 空セッション 0 件
- [x] `test_get_outputs_after_sequence` — `after` による差分取得
- [x] `test_duplicate_sequence_returns_error` — UNIQUE 制約違反