### PR TITLE
fix: 🗃️ add unique constraint for concurrent active sessions

### DIFF
--- a/backend/migrations/20260211000001_add_unique_active_session_constraint.sql
+++ b/backend/migrations/20260211000001_add_unique_active_session_constraint.sql
@@ -1,0 +1,4 @@
+-- Prevent concurrent active sessions per task at the database level.
+-- Only one session with status 'pending' or 'running' is allowed per task_id.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_session_per_task
+ON agent_sessions(task_id) WHERE status IN ('pending', 'running');

--- a/backend/migrations/20260211000001_add_unique_active_session_constraint.sql
+++ b/backend/migrations/20260211000001_add_unique_active_session_constraint.sql
@@ -1,4 +1,6 @@
 -- Prevent concurrent active sessions per task at the database level.
 -- Only one session with status 'pending' or 'running' is allowed per task_id.
+-- NOTE: If applied to existing data with duplicates, the CREATE will fail.
+-- In that case, resolve duplicates first (e.g. cancel extra active sessions).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_session_per_task
 ON agent_sessions(task_id) WHERE status IN ('pending', 'running');

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -667,6 +667,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_running_session_blocks_new_session_creation() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        let session = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Transition to running
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+
+        // Second session while first is running: should fail
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(result.is_err(), "Session during running should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_new_session_allowed_after_previous_failed() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        let session = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Transition: pending -> running -> failed
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Failed,
+            },
+        )
+        .await
+        .expect("Transition to failed");
+
+        // New session should now succeed
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(result.is_ok(), "New session after failure should succeed");
+    }
+
+    #[tokio::test]
     async fn test_invalid_transition_pending_to_completed_returns_validation_error() {
         let pool = setup_test_db().await;
         let (_project_id, task_id) = create_test_task(&pool).await;

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -347,9 +347,32 @@ mod tests {
         let req = CreateAgentSessionRequest {
             agent_type: AgentType::ClaudeCode,
         };
-        create_agent_session(&pool, task_id, &req)
+        // Create first session and complete it so we can create another
+        let session1 = create_agent_session(&pool, task_id, &req)
             .await
             .expect("Failed to create 1");
+        update_agent_session(
+            &pool,
+            task_id,
+            session1.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Failed to update to running");
+        update_agent_session(
+            &pool,
+            task_id,
+            session1.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("Failed to update to completed");
+
+        // Now create second session (allowed because first is completed)
         create_agent_session(&pool, task_id, &req)
             .await
             .expect("Failed to create 2");
@@ -546,6 +569,101 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(AppError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_pending_sessions_blocked_by_unique_constraint() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        // First session: OK
+        create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Second session on same task while first is still pending: should fail
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(result.is_err(), "Second pending session should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_new_session_allowed_after_previous_completed() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        let session = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Complete the first session
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("Transition to completed");
+
+        // New session should now succeed
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(
+            result.is_ok(),
+            "New session after completion should succeed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_new_session_allowed_after_previous_cancelled() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        let session = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Cancel the first session
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Cancelled,
+            },
+        )
+        .await
+        .expect("Transition to cancelled");
+
+        // New session should now succeed
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(
+            result.is_ok(),
+            "New session after cancellation should succeed"
+        );
     }
 
     #[tokio::test]

--- a/backend/tests/agent_sessions_api.rs
+++ b/backend/tests/agent_sessions_api.rs
@@ -83,10 +83,25 @@ async fn test_list_agent_sessions_returns_created_sessions() {
     let (_tmp, server) = create_test_server().await;
     let (_project_id, task_id) = create_test_task(&server).await;
 
-    server
+    // Create first session and complete it so we can create another
+    let resp1 = server
         .post(&format!("/api/tasks/{}/sessions", task_id))
         .json(&json!({ "agent_type": "claude_code" }))
         .await;
+    let session1: serde_json::Value = resp1.json();
+    let session1_id = session1["id"].as_str().unwrap();
+
+    // Transition: pending -> running -> completed
+    server
+        .patch(&format!("/api/tasks/{}/sessions/{}", task_id, session1_id))
+        .json(&json!({ "status": "running" }))
+        .await;
+    server
+        .patch(&format!("/api/tasks/{}/sessions/{}", task_id, session1_id))
+        .json(&json!({ "status": "completed" }))
+        .await;
+
+    // Create second session (allowed because first is completed)
     server
         .post(&format!("/api/tasks/{}/sessions", task_id))
         .json(&json!({ "agent_type": "gemini_cli" }))


### PR DESCRIPTION
## Summary
- Add partial unique index on `agent_sessions(task_id) WHERE status IN ('pending', 'running')` to prevent concurrent active sessions at the DB level
- Fix existing test that created two pending sessions on the same task
- Add tests for constraint enforcement and session lifecycle

## Test plan
- [x] `test_concurrent_pending_sessions_blocked_by_unique_constraint` - second pending session rejected
- [x] `test_new_session_allowed_after_previous_completed` - completed session does not block new one
- [x] `test_new_session_allowed_after_previous_cancelled` - cancelled session does not block new one
- [x] All 17 existing agent session service tests pass

Closes #52