### PR TITLE
feat: ✨ add general API rate limiting for all endpoints

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -51,6 +51,13 @@ pub fn app(state: AppState) -> Router {
         .finish()
         .expect("valid governor config");
 
+    // General API rate limit: 60 requests per minute per IP.
+    let general_governor = GovernorConfigBuilder::default()
+        .per_second(1) // 1 token every second
+        .burst_size(60) // bucket capacity: allows bursts up to 60
+        .finish()
+        .expect("valid governor config");
+
     let api_routes = Router::new()
         // Auth endpoints (rate-limited)
         .route(
@@ -126,7 +133,9 @@ pub fn app(state: AppState) -> Router {
             get(handlers::agent_sessions::get_agent_session_outputs),
         )
         // SSE for real-time updates
-        .route("/events", get(sse::handler::sse_handler));
+        .route("/events", get(sse::handler::sse_handler))
+        // General API rate limit applied to all routes
+        .layer(GovernorLayer::new(general_governor));
 
     Router::new()
         .route("/health", get(handlers::health::health_check))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -51,10 +51,10 @@ pub fn app(state: AppState) -> Router {
         .finish()
         .expect("valid governor config");
 
-    // General API rate limit: 60 requests per minute per IP.
+    // General API rate limit: ~1 req/s sustained, 60-request burst capacity per IP.
     let general_governor = GovernorConfigBuilder::default()
-        .per_second(1) // 1 token every second
-        .burst_size(60) // bucket capacity: allows bursts up to 60
+        .per_second(1) // refill 1 token per second
+        .burst_size(60) // bucket capacity: allows initial burst up to 60
         .finish()
         .expect("valid governor config");
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -89,7 +89,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = tokio::net::TcpListener::bind(&config.bind_addr).await?;
     tracing::info!("listening on {}", config.bind_addr);
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add general rate limit of 60 requests/minute per IP across all API endpoints
- Applied as a layer on the `api_routes` router, so all endpoints are protected
- Complements existing endpoint-specific rate limits (login: 5/15min, register: 3/hr)

## Test plan
- [x] Existing login rate limit test passes (verifies tower_governor integration)
- [x] Existing register rate limit test passes
- [x] All auth API tests pass with general limit in place

Closes #48