### PR TITLE
feat: ✨ add historical output loading to AgentPanel

### DIFF
--- a/frontend/src/components/AgentOutputViewer.test.tsx
+++ b/frontend/src/components/AgentOutputViewer.test.tsx
@@ -26,4 +26,11 @@ describe('AgentOutputViewer', () => {
     expect(container).toHaveClass('bg-gray-900');
     expect(container).toHaveClass('font-mono');
   });
+
+  it('shows loading state when isLoading is true', () => {
+    render(<AgentOutputViewer lines={[]} isLoading={true} />);
+    expect(screen.getByText(/loading output/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no output yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-output-container')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/AgentOutputViewer.tsx
+++ b/frontend/src/components/AgentOutputViewer.tsx
@@ -2,9 +2,10 @@ import { useEffect, useRef } from 'react';
 
 interface AgentOutputViewerProps {
   lines: string[];
+  isLoading?: boolean;
 }
 
-export function AgentOutputViewer({ lines }: AgentOutputViewerProps) {
+export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewerProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   const lineCount = lines.length;
@@ -15,6 +16,12 @@ export function AgentOutputViewer({ lines }: AgentOutputViewerProps) {
       container.scrollTop = container.scrollHeight;
     }
   }, [lineCount]);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">Loading output...</div>
+    );
+  }
 
   if (lines.length === 0) {
     return <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">No output yet</div>;

--- a/frontend/src/components/AgentOutputViewer.tsx
+++ b/frontend/src/components/AgentOutputViewer.tsx
@@ -18,9 +18,7 @@ export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewe
   }, [lineCount]);
 
   if (isLoading) {
-    return (
-      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">Loading output...</div>
-    );
+    return <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">Loading output...</div>;
   }
 
   if (lines.length === 0) {

--- a/frontend/src/components/AgentPanel.test.tsx
+++ b/frontend/src/components/AgentPanel.test.tsx
@@ -196,8 +196,20 @@ describe('AgentPanel', () => {
 
     vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
       data: [
-        { id: 1, session_id: 'session-1', sequence: 0, content: 'output line 1', created_at: '2026-01-01T00:00:00Z' },
-        { id: 2, session_id: 'session-1', sequence: 1, content: 'output line 2', created_at: '2026-01-01T00:00:01Z' },
+        {
+          id: 1,
+          session_id: 'session-1',
+          sequence: 0,
+          content: 'output line 1',
+          created_at: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          session_id: 'session-1',
+          sequence: 1,
+          content: 'output line 2',
+          created_at: '2026-01-01T00:00:01Z',
+        },
       ],
       isLoading: false,
     } as unknown as ReturnType<typeof agentSessionsApi.useGetAgentSessionOutputs>);

--- a/frontend/src/components/AgentPanel.test.tsx
+++ b/frontend/src/components/AgentPanel.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../api/generated/endpoints/agent-sessions/agent-sessions', () => ({
   useListAgentSessions: vi.fn(),
   useStartAgentSession: vi.fn(),
   useStopAgentSession: vi.fn(),
+  useGetAgentSessionOutputs: vi.fn(),
 }));
 
 vi.mock('../hooks/useAgentEvents', () => ({
@@ -144,6 +145,66 @@ describe('AgentPanel', () => {
     await user.click(screen.getByRole('button', { name: /start/i }));
 
     expect(screen.getByText(/failed to start/i)).toBeInTheDocument();
+  });
+
+  it('shows past sessions list', () => {
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'completed',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 'session-2',
+          task_id: 'task-1',
+          agent_type: 'gemini_cli',
+          status: 'failed',
+          created_at: '2026-01-02T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+    expect(screen.getByText(/past sessions/i)).toBeInTheDocument();
+  });
+
+  it('loads historical output when clicking past session', async () => {
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'completed',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
+      data: [
+        { id: 1, session_id: 'session-1', sequence: 0, content: 'output line 1', created_at: '2026-01-01T00:00:00Z' },
+        { id: 2, session_id: 'session-1', sequence: 1, content: 'output line 2', created_at: '2026-01-01T00:00:01Z' },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useGetAgentSessionOutputs>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+
+    // Click the past session to view its output
+    await user.click(screen.getByText(/session-1/i).closest('button')!);
+
+    // Output viewer should be visible with loaded history
+    expect(screen.getByTestId('agent-output-container')).toBeInTheDocument();
   });
 
   it('displays session status badge', () => {

--- a/frontend/src/components/AgentPanel.test.tsx
+++ b/frontend/src/components/AgentPanel.test.tsx
@@ -208,8 +208,10 @@ describe('AgentPanel', () => {
     // Click the past session to view its output (session ID is truncated to 8 chars)
     await user.click(screen.getByText('session-').closest('button')!);
 
-    // Output viewer should be visible with loaded history
+    // Output viewer should be visible with loaded history content
     expect(screen.getByTestId('agent-output-container')).toBeInTheDocument();
+    expect(screen.getByText('output line 1')).toBeInTheDocument();
+    expect(screen.getByText('output line 2')).toBeInTheDocument();
   });
 
   it('displays session status badge', () => {

--- a/frontend/src/components/AgentPanel.test.tsx
+++ b/frontend/src/components/AgentPanel.test.tsx
@@ -46,6 +46,11 @@ describe('AgentPanel', () => {
       mutateAsync: mockStopMutateAsync,
       isPending: false,
     } as unknown as ReturnType<typeof agentSessionsApi.useStopAgentSession>);
+
+    vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useGetAgentSessionOutputs>);
   });
 
   it('renders agent type selector', () => {
@@ -200,8 +205,8 @@ describe('AgentPanel', () => {
     const user = userEvent.setup();
     renderWithProviders(<AgentPanel taskId="task-1" />);
 
-    // Click the past session to view its output
-    await user.click(screen.getByText(/session-1/i).closest('button')!);
+    // Click the past session to view its output (session ID is truncated to 8 chars)
+    await user.click(screen.getByText('session-').closest('button')!);
 
     // Output viewer should be visible with loaded history
     expect(screen.getByTestId('agent-output-container')).toBeInTheDocument();

--- a/frontend/src/components/AgentPanel.tsx
+++ b/frontend/src/components/AgentPanel.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
+  useGetAgentSessionOutputs,
   useListAgentSessions,
   useStartAgentSession,
   useStopAgentSession,
 } from '../api/generated/endpoints/agent-sessions/agent-sessions';
-import type { AgentSessionStatus, AgentType } from '../api/generated/model';
+import type { AgentSession, AgentSessionStatus, AgentType } from '../api/generated/model';
 import { useAgentEvents } from '../hooks/useAgentEvents';
 import { useAgentStore } from '../stores/agentStore';
 import { AgentOutputViewer } from './AgentOutputViewer';
@@ -21,21 +22,48 @@ const STATUS_COLORS: Record<AgentSessionStatus, string> = {
   cancelled: 'bg-gray-100 text-gray-800',
 };
 
+const TERMINAL_STATUSES: AgentSessionStatus[] = ['completed', 'failed', 'cancelled'];
+
 export function AgentPanel({ taskId }: AgentPanelProps) {
   const [agentType, setAgentType] = useState<AgentType>('claude_code');
   const [prompt, setPrompt] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [viewingSessionId, setViewingSessionId] = useState<string | null>(null);
 
   const { data: sessions } = useListAgentSessions(taskId);
   const startSession = useStartAgentSession();
   const stopSession = useStopAgentSession();
 
-  const { activeSessionId, outputLines, appendOutput, setActiveSession, reset } = useAgentStore();
+  const { activeSessionId, outputLines, appendOutput, setActiveSession, setOutputLines, setLoadingHistory, isLoadingHistory, reset } = useAgentStore();
 
   // Derive active session from both store and server data
   const activeSession =
     sessions?.find((s) => s.id === activeSessionId) ??
     sessions?.find((s) => s.status === 'running' || s.status === 'pending');
+
+  // Past (terminal) sessions
+  const pastSessions = sessions?.filter((s) => TERMINAL_STATUSES.includes(s.status)) ?? [];
+
+  // Fetch historical outputs for viewed session
+  const { data: historicalOutputs, isLoading: isLoadingOutputs } = useGetAgentSessionOutputs(
+    taskId,
+    viewingSessionId ?? '',
+    undefined,
+    { query: { enabled: !!viewingSessionId } },
+  );
+
+  // Load historical outputs into store when data arrives
+  useEffect(() => {
+    if (historicalOutputs && viewingSessionId) {
+      const lines = historicalOutputs.map((o) => o.content);
+      setOutputLines(lines);
+      setLoadingHistory(false);
+    }
+  }, [historicalOutputs, viewingSessionId, setOutputLines, setLoadingHistory]);
+
+  useEffect(() => {
+    setLoadingHistory(isLoadingOutputs);
+  }, [isLoadingOutputs, setLoadingHistory]);
 
   // Sync activeSessionId from server data on mount/refresh
   useEffect(() => {
@@ -51,6 +79,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
 
   const handleStart = async () => {
     setError(null);
+    setViewingSessionId(null);
     try {
       reset();
       const result = await startSession.mutateAsync({
@@ -78,6 +107,21 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
     }
   };
 
+  const handleViewSession = (session: AgentSession) => {
+    setViewingSessionId(session.id);
+    setActiveSession(null);
+    setLoadingHistory(true);
+    setOutputLines([]);
+  };
+
+  const handleBackToInput = () => {
+    setViewingSessionId(null);
+    reset();
+  };
+
+  const isViewingHistory = !!viewingSessionId;
+  const viewingSession = sessions?.find((s) => s.id === viewingSessionId);
+
   return (
     <div className="space-y-3">
       {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
@@ -103,7 +147,30 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               Stop
             </button>
           </div>
-          <AgentOutputViewer lines={outputLines} />
+          <AgentOutputViewer lines={outputLines} isLoading={false} />
+        </div>
+      ) : isViewingHistory && viewingSession ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleBackToInput}
+                className="text-sm text-blue-600 hover:text-blue-800"
+              >
+                Back
+              </button>
+              <span className="text-sm text-gray-600">
+                {viewingSession.agent_type === 'claude_code' ? 'Claude Code' : 'Gemini CLI'}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[viewingSession.status]}`}
+              >
+                {viewingSession.status}
+              </span>
+            </div>
+          </div>
+          <AgentOutputViewer lines={outputLines} isLoading={isLoadingHistory} />
         </div>
       ) : (
         <div className="space-y-3">
@@ -145,6 +212,28 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
           >
             Start
           </button>
+          {pastSessions.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-gray-700">Past Sessions</h4>
+              <div className="mt-1 space-y-1">
+                {pastSessions.map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => handleViewSession(session)}
+                    className="flex w-full items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                  >
+                    <span className="truncate text-gray-600">{session.id.slice(0, 8)}</span>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[session.status]}`}
+                    >
+                      {session.status}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/AgentPanel.tsx
+++ b/frontend/src/components/AgentPanel.tsx
@@ -138,14 +138,16 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                 {activeSession.status}
               </span>
             </div>
-            <button
-              type="button"
-              onClick={handleStop}
-              disabled={stopSession.isPending}
-              className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
-            >
-              Stop
-            </button>
+            {!TERMINAL_STATUSES.includes(activeSession.status) && (
+              <button
+                type="button"
+                onClick={handleStop}
+                disabled={stopSession.isPending}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                Stop
+              </button>
+            )}
           </div>
           <AgentOutputViewer lines={outputLines} isLoading={false} />
         </div>

--- a/frontend/src/components/AgentPanel.tsx
+++ b/frontend/src/components/AgentPanel.tsx
@@ -34,7 +34,16 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
   const startSession = useStartAgentSession();
   const stopSession = useStopAgentSession();
 
-  const { activeSessionId, outputLines, appendOutput, setActiveSession, setOutputLines, setLoadingHistory, isLoadingHistory, reset } = useAgentStore();
+  const {
+    activeSessionId,
+    outputLines,
+    appendOutput,
+    setActiveSession,
+    setOutputLines,
+    setLoadingHistory,
+    isLoadingHistory,
+    reset,
+  } = useAgentStore();
 
   // Derive active session from both store and server data
   const activeSession =

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../api/generated/endpoints/agent-sessions/agent-sessions', () => ({
   useListAgentSessions: vi.fn(),
   useStartAgentSession: vi.fn(),
   useStopAgentSession: vi.fn(),
+  useGetAgentSessionOutputs: vi.fn(),
 }));
 
 vi.mock('../hooks/useAgentEvents', () => ({
@@ -82,6 +83,11 @@ describe('TaskDetailModal', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof agentSessionsApi.useStopAgentSession>);
+
+    vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useGetAgentSessionOutputs>);
   });
 
   it('does not render when modal is closed', () => {

--- a/frontend/src/stores/agentStore.test.ts
+++ b/frontend/src/stores/agentStore.test.ts
@@ -45,6 +45,31 @@ describe('agentStore', () => {
     expect(useAgentStore.getState().isStarting).toBe(false);
   });
 
+  it('sets output lines (bulk load for history)', () => {
+    useAgentStore.getState().setOutputLines(['line 1', 'line 2', 'line 3']);
+    expect(useAgentStore.getState().outputLines).toEqual(['line 1', 'line 2', 'line 3']);
+  });
+
+  it('replaces existing output when setOutputLines is called', () => {
+    useAgentStore.getState().appendOutput('old line');
+    useAgentStore.getState().setOutputLines(['new line 1', 'new line 2']);
+    expect(useAgentStore.getState().outputLines).toEqual(['new line 1', 'new line 2']);
+  });
+
+  it('tracks isLoadingHistory state', () => {
+    expect(useAgentStore.getState().isLoadingHistory).toBe(false);
+    useAgentStore.getState().setLoadingHistory(true);
+    expect(useAgentStore.getState().isLoadingHistory).toBe(true);
+    useAgentStore.getState().setLoadingHistory(false);
+    expect(useAgentStore.getState().isLoadingHistory).toBe(false);
+  });
+
+  it('resets isLoadingHistory on reset', () => {
+    useAgentStore.getState().setLoadingHistory(true);
+    useAgentStore.getState().reset();
+    expect(useAgentStore.getState().isLoadingHistory).toBe(false);
+  });
+
   it('limits output to 1000 lines', () => {
     for (let i = 0; i < 1005; i++) {
       useAgentStore.getState().appendOutput(`line ${i}`);

--- a/frontend/src/stores/agentStore.ts
+++ b/frontend/src/stores/agentStore.ts
@@ -4,9 +4,12 @@ interface AgentState {
   activeSessionId: string | null;
   outputLines: string[];
   isStarting: boolean;
+  isLoadingHistory: boolean;
   setActiveSession: (sessionId: string | null) => void;
   appendOutput: (text: string) => void;
+  setOutputLines: (lines: string[]) => void;
   setStarting: (value: boolean) => void;
+  setLoadingHistory: (value: boolean) => void;
   reset: () => void;
 }
 
@@ -16,11 +19,14 @@ export const useAgentStore = create<AgentState>((set) => ({
   activeSessionId: null,
   outputLines: [],
   isStarting: false,
+  isLoadingHistory: false,
   setActiveSession: (sessionId) => set({ activeSessionId: sessionId }),
   appendOutput: (text) =>
     set((state) => ({
       outputLines: [...state.outputLines.slice(-(MAX_OUTPUT_LINES - 1)), text],
     })),
+  setOutputLines: (lines) => set({ outputLines: lines }),
   setStarting: (value) => set({ isStarting: value }),
-  reset: () => set({ activeSessionId: null, outputLines: [], isStarting: false }),
+  setLoadingHistory: (value) => set({ isLoadingHistory: value }),
+  reset: () => set({ activeSessionId: null, outputLines: [], isStarting: false, isLoadingHistory: false }),
 }));

--- a/frontend/src/stores/agentStore.ts
+++ b/frontend/src/stores/agentStore.ts
@@ -25,7 +25,7 @@ export const useAgentStore = create<AgentState>((set) => ({
     set((state) => ({
       outputLines: [...state.outputLines.slice(-(MAX_OUTPUT_LINES - 1)), text],
     })),
-  setOutputLines: (lines) => set({ outputLines: lines }),
+  setOutputLines: (lines) => set({ outputLines: lines.slice(-MAX_OUTPUT_LINES) }),
   setStarting: (value) => set({ isStarting: value }),
   setLoadingHistory: (value) => set({ isLoadingHistory: value }),
   reset: () => set({ activeSessionId: null, outputLines: [], isStarting: false, isLoadingHistory: false }),

--- a/frontend/src/stores/agentStore.ts
+++ b/frontend/src/stores/agentStore.ts
@@ -28,5 +28,6 @@ export const useAgentStore = create<AgentState>((set) => ({
   setOutputLines: (lines) => set({ outputLines: lines.slice(-MAX_OUTPUT_LINES) }),
   setStarting: (value) => set({ isStarting: value }),
   setLoadingHistory: (value) => set({ isLoadingHistory: value }),
-  reset: () => set({ activeSessionId: null, outputLines: [], isStarting: false, isLoadingHistory: false }),
+  reset: () =>
+    set({ activeSessionId: null, outputLines: [], isStarting: false, isLoadingHistory: false }),
 }));


### PR DESCRIPTION
## Summary
- Extended `agentStore` with `isLoadingHistory`, `setOutputLines`, and `setLoadingHistory` state
- Added past sessions list with clickable entries to view historical outputs
- Integrated `useGetAgentSessionOutputs` hook to fetch output history from API
- Added loading state and back navigation for history viewing mode

Closes #65

## Test plan
- [x] Store tests: `setOutputLines`, `setLoadingHistory`, reset behavior
- [x] AgentPanel tests: past sessions list rendering, history loading on click
- [x] TaskDetailModal tests: mock compatibility verified
- [x] All 113 frontend tests pass