### PR TITLE
fix: 🔒️ resolve critical and security issues

### DIFF
--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -97,21 +97,35 @@ impl AgentOrchestrator {
             })?
             .clone();
 
-        // Step 3: Duplicate prevention (now atomic under task lock)
-        self.check_no_active_session(req.task_id).await?;
+        // Steps 3-4b: Wrapped in transaction for atomicity
+        let session = {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| AppError::Internal(format!("failed to begin transaction: {e}")))?;
 
-        // Step 4: Create DB session (now safe: executor is validated)
-        let session = agent_session_service::create_agent_session(
-            &self.pool,
-            req.task_id,
-            &CreateAgentSessionRequest {
-                agent_type: req.agent_type.clone(),
-            },
-        )
-        .await?;
+            // Step 3: Duplicate prevention
+            agent_session_service::check_no_active_session_tx(&mut *tx, req.task_id).await?;
 
-        // Step 4b: Save prompt for restart support
-        agent_session_service::save_prompt(&self.pool, session.id, &req.prompt).await?;
+            // Step 4: Create DB session (Pending)
+            let session = agent_session_service::create_agent_session_tx(
+                &mut *tx,
+                req.task_id,
+                &CreateAgentSessionRequest {
+                    agent_type: req.agent_type.clone(),
+                },
+            )
+            .await?;
+
+            // Step 4b: Save prompt for restart support
+            agent_session_service::save_prompt_tx(&mut *tx, session.id, &req.prompt).await?;
+
+            tx.commit()
+                .await
+                .map_err(|e| AppError::Internal(format!("failed to commit transaction: {e}")))?;
+            session
+        };
 
         // Step 5: Create worktree (spawn_blocking for synchronous git2 operations)
         let worktree_name = format!("task-{}-session-{}", req.task_id, session.id);
@@ -240,22 +254,6 @@ impl AgentOrchestrator {
     pub async fn is_running(&self, session_id: Uuid) -> bool {
         let running = self.running.lock().await;
         running.contains_key(&session_id)
-    }
-
-    async fn check_no_active_session(&self, task_id: Uuid) -> AppResult<()> {
-        let sessions = agent_session_service::list_agent_sessions(&self.pool, task_id).await?;
-        let has_active = sessions.iter().any(|s| {
-            matches!(
-                s.status,
-                AgentSessionStatus::Pending | AgentSessionStatus::Running
-            )
-        });
-        if has_active {
-            return Err(AppError::Conflict(format!(
-                "task {task_id} already has an active agent session"
-            )));
-        }
-        Ok(())
     }
 
     async fn mark_session_cancelled(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -106,11 +106,11 @@ impl AgentOrchestrator {
                 .map_err(|e| AppError::Internal(format!("failed to begin transaction: {e}")))?;
 
             // Step 3: Duplicate prevention
-            agent_session_service::check_no_active_session_tx(&mut *tx, req.task_id).await?;
+            agent_session_service::check_no_active_session_tx(&mut tx, req.task_id).await?;
 
             // Step 4: Create DB session (Pending)
             let session = agent_session_service::create_agent_session_tx(
-                &mut *tx,
+                &mut tx,
                 req.task_id,
                 &CreateAgentSessionRequest {
                     agent_type: req.agent_type.clone(),
@@ -119,7 +119,7 @@ impl AgentOrchestrator {
             .await?;
 
             // Step 4b: Save prompt for restart support
-            agent_session_service::save_prompt_tx(&mut *tx, session.id, &req.prompt).await?;
+            agent_session_service::save_prompt_tx(&mut tx, session.id, &req.prompt).await?;
 
             tx.commit()
                 .await

--- a/backend/src/auth/csrf.rs
+++ b/backend/src/auth/csrf.rs
@@ -1,0 +1,77 @@
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// CSRF protection middleware: requires `X-Requested-With` header on state-changing requests.
+///
+/// This prevents cross-origin form submissions because CORS blocks custom headers
+/// from cross-origin requests unless explicitly allowed.
+pub async fn csrf_check(req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
+    let needs_check = matches!(*req.method(), Method::POST | Method::PATCH | Method::DELETE);
+
+    if needs_check && !req.headers().contains_key("x-requested-with") {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::middleware;
+    use axum::routing::{get, post};
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::csrf_check;
+
+    fn test_app() -> Router {
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .route("/test", get(|| async { "ok" }))
+            .layer(middleware::from_fn(csrf_check))
+    }
+
+    #[tokio::test]
+    async fn test_csrf_blocks_post_without_header() {
+        let app = test_app();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_csrf_allows_post_with_header() {
+        let app = test_app();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header("X-Requested-With", "XMLHttpRequest")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_csrf_allows_get_without_header() {
+        let app = test_app();
+        let req = Request::builder()
+            .method("GET")
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -1,2 +1,3 @@
+pub mod csrf;
 pub mod middleware;
 pub mod password;

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3,6 +3,16 @@ use figment::providers::{Env, Format, Toml};
 use figment::Figment;
 use serde::Deserialize;
 
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("GANTRY_CORS_ORIGIN is not a valid HTTP header value: {0:?}")]
+    InvalidCorsOrigin(String),
+    #[error(
+        "GANTRY_CORS_ORIGIN must be set in production. Permissive CORS is only allowed in debug builds."
+    )]
+    MissingCorsOriginInRelease,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     #[serde(default = "default_bind_addr")]
@@ -66,27 +76,28 @@ impl Config {
             .merge(Env::prefixed("GANTRY_"))
             .extract()?;
 
-        config.validate();
+        config
+            .validate()
+            .map_err(|e| figment::Error::from(e.to_string()))?;
 
         Ok(config)
     }
 
     /// Validate config values that cannot be expressed via serde alone.
-    pub fn validate(&self) {
+    pub fn validate(&self) -> Result<(), ConfigError> {
         if let Some(origin) = &self.cors_origin {
-            origin.parse::<HeaderValue>().unwrap_or_else(|_| {
-                panic!("GANTRY_CORS_ORIGIN is not a valid HTTP header value: {origin:?}")
-            });
+            origin
+                .parse::<HeaderValue>()
+                .map_err(|_| ConfigError::InvalidCorsOrigin(origin.clone()))?;
         }
 
         // In release builds, CORS origin must be explicitly configured
         #[cfg(not(debug_assertions))]
         if self.cors_origin.is_none() {
-            panic!(
-                "GANTRY_CORS_ORIGIN must be set in production. \
-                 Permissive CORS is only allowed in debug builds."
-            );
+            return Err(ConfigError::MissingCorsOriginInRelease);
         }
+
+        Ok(())
     }
 
     /// Return the repository path for worktree management.
@@ -98,10 +109,14 @@ impl Config {
     }
 
     /// Parse `cors_origin` into an `HeaderValue`, returning `None` when unset.
-    pub fn cors_origin_header(&self) -> Option<HeaderValue> {
-        self.cors_origin
-            .as_ref()
-            .map(|o| o.parse().expect("cors_origin already validated"))
+    pub fn cors_origin_header(&self) -> Result<Option<HeaderValue>, ConfigError> {
+        match &self.cors_origin {
+            Some(o) => o
+                .parse()
+                .map(Some)
+                .map_err(|_| ConfigError::InvalidCorsOrigin(o.clone())),
+            None => Ok(None),
+        }
     }
 }
 
@@ -151,7 +166,7 @@ mod tests {
     #[test]
     fn test_cors_origin_header_returns_none_when_unset() {
         let config = Config::default();
-        assert!(config.cors_origin_header().is_none());
+        assert!(config.cors_origin_header().unwrap().is_none());
     }
 
     #[test]
@@ -160,18 +175,20 @@ mod tests {
             cors_origin: Some("http://localhost:5173".to_string()),
             ..Default::default()
         };
-        let header = config.cors_origin_header().expect("should return header");
+        let header = config
+            .cors_origin_header()
+            .expect("should not error")
+            .expect("should return Some");
         assert_eq!(header.to_str().unwrap(), "http://localhost:5173");
     }
 
     #[test]
-    #[should_panic(expected = "not a valid HTTP header value")]
     fn test_validate_rejects_invalid_cors_origin() {
         let config = Config {
             cors_origin: Some("not a valid \x00 header".to_string()),
             ..Default::default()
         };
-        config.validate();
+        assert!(config.validate().is_err());
     }
 
     #[test]
@@ -186,7 +203,7 @@ mod tests {
             cors_origin: Some("http://localhost:5173".to_string()),
             ..Default::default()
         };
-        config.validate(); // should not panic
+        assert!(config.validate().is_ok());
     }
 
     #[cfg(debug_assertions)]
@@ -196,6 +213,6 @@ mod tests {
             cors_origin: None,
             ..Default::default()
         };
-        config.validate(); // should not panic in debug builds
+        assert!(config.validate().is_ok());
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -45,6 +45,14 @@ pub struct Config {
     /// Allowed CORS origin (e.g. "http://localhost:5173"). When unset, CORS is permissive.
     #[serde(default)]
     pub cors_origin: Option<String>,
+
+    /// Maximum database connection pool size (default: 20)
+    #[serde(default = "default_max_db_connections")]
+    pub max_db_connections: u32,
+
+    /// SSE broadcast channel capacity (default: 4096)
+    #[serde(default = "default_sse_broadcast_capacity")]
+    pub sse_broadcast_capacity: usize,
 }
 
 fn default_bind_addr() -> String {
@@ -65,6 +73,14 @@ fn default_cookie_secure() -> bool {
 
 fn default_session_cleanup_interval_secs() -> u64 {
     3600 // 1 hour
+}
+
+fn default_max_db_connections() -> u32 {
+    20
+}
+
+fn default_sse_broadcast_capacity() -> usize {
+    4096
 }
 
 impl Config {
@@ -132,6 +148,8 @@ impl Default for Config {
             repository_path: None,
             session_cleanup_interval_secs: default_session_cleanup_interval_secs(),
             cors_origin: None,
+            max_db_connections: default_max_db_connections(),
+            sse_broadcast_capacity: default_sse_broadcast_capacity(),
         }
     }
 }
@@ -214,5 +232,17 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_max_db_connections_defaults_to_20() {
+        let config = Config::default();
+        assert_eq!(config.max_db_connections, 20);
+    }
+
+    #[test]
+    fn test_sse_broadcast_capacity_defaults_to_4096() {
+        let config = Config::default();
+        assert_eq!(config.sse_broadcast_capacity, 4096);
     }
 }

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -2,13 +2,16 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::SqlitePool;
 use std::str::FromStr;
 
-pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
+pub async fn init_pool(
+    database_url: &str,
+    max_connections: u32,
+) -> Result<SqlitePool, sqlx::Error> {
     let options = SqliteConnectOptions::from_str(database_url)?
         .journal_mode(SqliteJournalMode::Wal)
         .create_if_missing(true);
 
     let pool = SqlitePoolOptions::new()
-        .max_connections(5)
+        .max_connections(max_connections)
         .connect_with(options)
         .await?;
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -29,7 +29,15 @@ pub async fn register(
     body.validate_with(&ctx)
         .map_err(|e| AppError::Validation(e.to_string()))?;
 
-    let user = user_service::create_user(&state.pool, &body).await?;
+    let user = match user_service::create_user(&state.pool, &body).await {
+        Ok(user) => user,
+        Err(AppError::Database(ref e)) if e.to_string().contains("UNIQUE constraint failed") => {
+            return Err(AppError::Validation(
+                "unable to complete registration".to_string(),
+            ));
+        }
+        Err(e) => return Err(e),
+    };
 
     // Create session for the new user
     let session =

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -83,6 +83,9 @@ pub async fn login(
 
     let user = user_service::authenticate_user(&state.pool, &body.email, &body.password).await?;
 
+    // Invalidate existing sessions to prevent session fixation
+    session_service::delete_user_sessions(&state.pool, user.id).await?;
+
     // Create session
     let session =
         session_service::create_session(&state.pool, user.id, state.config.session_duration_hours)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -58,6 +58,27 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         .finish()
         .expect("valid governor config");
 
+    // Rate limit: agent start — 1 per 10 seconds, burst 3 per IP.
+    let agent_start_governor = GovernorConfigBuilder::default()
+        .per_second(10) // 1 token every 10s
+        .burst_size(3) // bucket capacity
+        .finish()
+        .expect("valid governor config");
+
+    // Rate limit: agent restart — same as start.
+    let agent_restart_governor = GovernorConfigBuilder::default()
+        .per_second(10)
+        .burst_size(3)
+        .finish()
+        .expect("valid governor config");
+
+    // Rate limit: SSE connections — 5 connections per 10 seconds per IP.
+    let sse_governor = GovernorConfigBuilder::default()
+        .per_second(10) // 1 token every 10s
+        .burst_size(5) // bucket capacity
+        .finish()
+        .expect("valid governor config");
+
     let api_routes = Router::new()
         // Auth endpoints (rate-limited)
         .route(
@@ -122,7 +143,8 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         )
         .route(
             "/tasks/{task_id}/sessions/start",
-            post(handlers::agent_sessions::start_agent_session),
+            post(handlers::agent_sessions::start_agent_session)
+                .layer(GovernorLayer::new(agent_start_governor)),
         )
         .route(
             "/tasks/{task_id}/sessions/{session_id}/stop",
@@ -134,7 +156,8 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         )
         .route(
             "/tasks/{task_id}/sessions/{session_id}/restart",
-            post(handlers::agent_sessions::restart_agent_session),
+            post(handlers::agent_sessions::restart_agent_session)
+                .layer(GovernorLayer::new(agent_restart_governor)),
         )
         // Worktree endpoints
         .route("/worktrees", get(handlers::worktrees::list_worktrees))
@@ -144,8 +167,11 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             "/worktrees/{name}",
             delete(handlers::worktrees::delete_worktree),
         )
-        // SSE for real-time updates
-        .route("/events", get(sse::handler::sse_handler))
+        // SSE for real-time updates (rate-limited)
+        .route(
+            "/events",
+            get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
+        )
         // General API rate limit applied to all routes
         .layer(GovernorLayer::new(general_governor));
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,7 +35,7 @@ pub struct AppState {
     pub orchestrator: Arc<AgentOrchestrator>,
 }
 
-pub fn app(state: AppState) -> Router {
+pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
     // Rate limit: login — 5 attempts per 15 min per IP.
     // per_second(N) sets the replenishment *interval* to N seconds (NOT N req/sec).
     let login_governor = GovernorConfigBuilder::default()
@@ -149,37 +149,37 @@ pub fn app(state: AppState) -> Router {
         // General API rate limit applied to all routes
         .layer(GovernorLayer::new(general_governor));
 
-    Router::new()
+    Ok(Router::new()
         .route("/health", get(handlers::health::health_check))
         .nest("/api", api_routes)
         .merge(
             SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
         )
-        .layer(build_cors_layer(&state.config))
+        .layer(build_cors_layer(&state.config)?)
         .layer(TraceLayer::new_for_http())
-        .with_state(state)
+        .with_state(state))
 }
 
-fn build_cors_layer(config: &config::Config) -> CorsLayer {
-    match config.cors_origin_header() {
-        Some(origin) => CorsLayer::new()
+fn build_cors_layer(config: &config::Config) -> Result<CorsLayer, config::ConfigError> {
+    match config.cors_origin_header()? {
+        Some(origin) => Ok(CorsLayer::new()
             .allow_origin(AllowOrigin::exact(origin))
             .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
             .allow_headers([axum::http::header::CONTENT_TYPE])
-            .allow_credentials(true),
+            .allow_credentials(true)),
         None => {
             // Defense in depth: release builds must never reach this branch.
-            // Config::validate() already panics if cors_origin is None in release,
+            // Config::validate() already returns Err if cors_origin is None in release,
             // but we guard here too in case validate() is bypassed.
             #[cfg(not(debug_assertions))]
-            panic!("GANTRY_CORS_ORIGIN must be set in production");
+            return Err(config::ConfigError::MissingCorsOriginInRelease);
 
             #[cfg(debug_assertions)]
             {
                 tracing::warn!(
                     "GANTRY_CORS_ORIGIN is not set — CORS is permissive (debug build only)"
                 );
-                CorsLayer::permissive()
+                Ok(CorsLayer::permissive())
             }
         }
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -172,6 +172,8 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             "/events",
             get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
         )
+        // CSRF protection: require X-Requested-With header on state-changing requests
+        .layer(axum::middleware::from_fn(auth::csrf::csrf_check))
         // General API rate limit applied to all routes
         .layer(GovernorLayer::new(general_governor));
 
@@ -191,7 +193,10 @@ fn build_cors_layer(config: &config::Config) -> Result<CorsLayer, config::Config
         Some(origin) => Ok(CorsLayer::new()
             .allow_origin(AllowOrigin::exact(origin))
             .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE])
-            .allow_headers([axum::http::header::CONTENT_TYPE])
+            .allow_headers([
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderName::from_static("x-requested-with"),
+            ])
             .allow_credentials(true)),
         None => {
             // Defense in depth: release builds must never reach this branch.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config: Arc::new(config.clone()),
         orchestrator,
     };
-    let app = gantry_board::app(state);
+    let app = gantry_board::app(state)?;
 
     // Spawn background task for periodic session cleanup
     let cleanup_interval_secs = config.session_cleanup_interval_secs.max(1);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -38,8 +38,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    let pool = db::init_pool(&config.database_url).await?;
-    let sse_hub = Arc::new(SseHub::default());
+    let pool = db::init_pool(&config.database_url, config.max_db_connections).await?;
+    let sse_hub = Arc::new(SseHub::new(config.sse_broadcast_capacity));
 
     let repo_path = config
         .repository_path

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use sqlx::prelude::FromRow;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
@@ -125,6 +125,89 @@ pub async fn save_prompt(pool: &SqlitePool, session_id: Uuid, prompt: &str) -> A
     .bind(prompt)
     .bind(session_id.to_string())
     .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!(
+            "Agent session {session_id} not found"
+        )));
+    }
+    Ok(())
+}
+
+/// Check that no active (pending/running) session exists for a task, using a connection (for transactions).
+pub async fn check_no_active_session_tx(
+    conn: &mut SqliteConnection,
+    task_id: Uuid,
+) -> AppResult<()> {
+    let row = sqlx::query_as::<_, AgentSessionRow>(
+        r#"
+        SELECT id, task_id, agent_type, status, prompt, started_at, finished_at, created_at, updated_at
+        FROM agent_sessions
+        WHERE task_id = $1 AND status IN ('pending', 'running')
+        LIMIT 1
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    if row.is_some() {
+        return Err(AppError::Conflict(format!(
+            "task {task_id} already has an active agent session"
+        )));
+    }
+    Ok(())
+}
+
+/// Create an agent session using a connection (for transactions).
+pub async fn create_agent_session_tx(
+    conn: &mut SqliteConnection,
+    task_id: Uuid,
+    req: &CreateAgentSessionRequest,
+) -> AppResult<AgentSession> {
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+
+    sqlx::query(
+        r#"
+        INSERT INTO agent_sessions (id, task_id, agent_type, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .bind(&req.agent_type)
+    .bind(&AgentSessionStatus::Pending)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(AgentSession {
+        id,
+        task_id,
+        agent_type: req.agent_type.clone(),
+        status: AgentSessionStatus::Pending,
+        prompt: None,
+        started_at: None,
+        finished_at: None,
+        created_at: now,
+        updated_at: now,
+    })
+}
+
+/// Save prompt for a session using a connection (for transactions).
+pub async fn save_prompt_tx(
+    conn: &mut SqliteConnection,
+    session_id: Uuid,
+    prompt: &str,
+) -> AppResult<()> {
+    let result = sqlx::query(
+        "UPDATE agent_sessions SET prompt = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+    )
+    .bind(prompt)
+    .bind(session_id.to_string())
+    .execute(&mut *conn)
     .await?;
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound(format!(

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -273,6 +273,49 @@ async fn test_logout_without_auth() {
 }
 
 #[tokio::test]
+async fn test_login_invalidates_previous_sessions() {
+    let server = create_test_server().await;
+
+    // Register user
+    let register_response = server
+        .post("/api/auth/register")
+        .json(&json!({
+            "email": "test@example.com",
+            "name": "Test User",
+            "password": "Tr0ub4dor&3-correct-horse"
+        }))
+        .await;
+
+    let old_cookie = register_response
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+
+    // Login (creates new session, should invalidate old one)
+    let _login_response = server
+        .post("/api/auth/login")
+        .json(&json!({
+            "email": "test@example.com",
+            "password": "Tr0ub4dor&3-correct-horse"
+        }))
+        .await;
+
+    // Old session should now be invalid
+    let me_response = server
+        .get("/api/auth/me")
+        .add_header(header::COOKIE, &*old_cookie)
+        .await;
+
+    me_response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn test_login_rate_limit_returns_429_after_burst() {
     let server = create_test_server().await;
 

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -65,7 +65,7 @@ async fn test_register_validates_password_length() {
 }
 
 #[tokio::test]
-async fn test_register_duplicate_email_fails() {
+async fn test_register_duplicate_email_returns_generic_error() {
     let server = create_test_server().await;
 
     let body = json!({
@@ -77,10 +77,22 @@ async fn test_register_duplicate_email_fails() {
     // First registration should succeed
     server.post("/api/auth/register").json(&body).await;
 
-    // Second registration should fail
+    // Second registration should fail with a generic message (not 409 Conflict)
+    // to prevent user enumeration via registration
     let response = server.post("/api/auth/register").json(&body).await;
 
-    response.assert_status(StatusCode::CONFLICT);
+    response.assert_status(StatusCode::BAD_REQUEST);
+
+    let error_body: serde_json::Value = response.json();
+    let error_msg = error_body["error"].as_str().unwrap_or("");
+    assert!(
+        !error_msg.contains("email"),
+        "error message should not reveal email exists: {error_msg}"
+    );
+    assert!(
+        !error_msg.contains("already exists"),
+        "error message should not reveal resource exists: {error_msg}"
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -56,7 +56,9 @@ async fn create_test_server_impl(
     let app = gantry_board::app(state)
         .expect("Failed to build app")
         .into_make_service_with_connect_info::<SocketAddr>();
-    let server = TestServer::new(app).expect("Failed to create test server");
+    let mut server = TestServer::new(app).expect("Failed to create test server");
+    // CSRF middleware requires X-Requested-With on state-changing requests
+    server.add_header("x-requested-with", "XMLHttpRequest");
     (server, pool)
 }
 

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -53,7 +53,9 @@ async fn create_test_server_impl(
         orchestrator,
     };
 
-    let app = gantry_board::app(state).into_make_service_with_connect_info::<SocketAddr>();
+    let app = gantry_board::app(state)
+        .expect("Failed to build app")
+        .into_make_service_with_connect_info::<SocketAddr>();
     let server = TestServer::new(app).expect("Failed to create test server");
     (server, pool)
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,6 +30,7 @@ export const customInstance = async <T>({
     credentials: 'include', // Include cookies for session auth
     headers: {
       'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       ...headers,
     },
     ...(data ? { body: JSON.stringify(data) } : {}),

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useAuthStore } from './authStore';
+
+describe('authStore', () => {
+  afterEach(() => {
+    useAuthStore.getState().logout();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('uses sessionStorage instead of localStorage', () => {
+    useAuthStore.getState().setUser({
+      id: 'test-id',
+      email: 'test@example.com',
+      name: 'Test User',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    });
+
+    expect(sessionStorage.getItem('auth-storage')).not.toBeNull();
+    expect(localStorage.getItem('auth-storage')).toBeNull();
+  });
+
+  it('persists user data to sessionStorage', () => {
+    useAuthStore.getState().setUser({
+      id: 'test-id',
+      email: 'test@example.com',
+      name: 'Test User',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem('auth-storage') ?? '{}');
+    expect(stored.state.user.email).toBe('test@example.com');
+    expect(stored.state.isAuthenticated).toBe(true);
+  });
+});

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { createJSONStorage, persist } from 'zustand/middleware';
 import type { User } from '../api/generated/model';
 
 interface AuthState {
@@ -28,6 +28,7 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({ user: state.user, isAuthenticated: state.isAuthenticated }),
     },
   ),


### PR DESCRIPTION
## Summary

Resolves 11 issues flagged by automated code review (critical, security, and high priority):

- **#93** Replace `panic!`/`expect` with `Result` propagation in config/app initialization
- **#90, #96** Make DB pool size and SSE broadcast capacity configurable via environment variables
- **#99** Prevent user enumeration via generic registration error messages
- **#94** Invalidate existing sessions on login to prevent session fixation
- **#95, #98** Add rate limiting for agent start/restart and SSE endpoints
- **#91** Wrap agent session creation in a database transaction for atomicity
- **#110** Use `sessionStorage` instead of `localStorage` for auth data
- **#100** Add `X-Requested-With` CSRF protection middleware

Also closed 3 issues (#108, #109, #111) that were already resolved in the existing codebase.

## Changes

| File | Change |
|------|--------|
| `backend/src/config.rs` | Add `ConfigError` enum, `Result`-returning `validate()` and `cors_origin_header()`, configurable `max_db_connections` and `sse_broadcast_capacity` |
| `backend/src/lib.rs` | `app()` returns `Result`, rate limiters for agent/SSE, CSRF middleware layer, CORS `x-requested-with` header |
| `backend/src/main.rs` | Propagate errors from `app()`, pass config values to `init_pool` and `SseHub` |
| `backend/src/db.rs` | Accept `max_connections` parameter |
| `backend/src/handlers/auth.rs` | Generic registration error, session invalidation on login |
| `backend/src/auth/csrf.rs` | New CSRF middleware requiring `X-Requested-With` on state-changing requests |
| `backend/src/services/agent_session_service.rs` | Transaction-aware `_tx` variants for session creation |
| `backend/src/agent/orchestrator.rs` | Use transaction for session creation steps 3-4b |
| `frontend/src/stores/authStore.ts` | Switch to `sessionStorage` |
| `frontend/src/api/client.ts` | Add `X-Requested-With: XMLHttpRequest` header |

## Test plan

- [x] All 291 backend tests pass (`task backend:test`)
- [x] All 129 frontend tests pass (`task frontend:test`)
- [x] `task check` passes (clippy + biome lint + format)
- [x] New tests added for: config error handling, duplicate registration, session fixation, CSRF middleware, sessionStorage
- [ ] Verify rate limiting behavior in staging environment

Closes #90, #91, #93, #94, #95, #96, #98, #99, #100, #110