### PR TITLE
fix: 🔒️ resolve remaining high and medium priority issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/June3141/gantry_board"
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace", "timeout"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/backend/migrations/20260212000001_add_output_created_at_index.sql
+++ b/backend/migrations/20260212000001_add_output_created_at_index.sql
@@ -1,0 +1,3 @@
+-- Index on created_at for time-based cleanup queries
+CREATE INDEX IF NOT EXISTS idx_agent_session_outputs_created_at
+    ON agent_session_outputs(created_at);

--- a/backend/migrations/20260212000002_add_tasks_assigned_to_index.sql
+++ b/backend/migrations/20260212000002_add_tasks_assigned_to_index.sql
@@ -1,0 +1,2 @@
+-- Index on assigned_to for task filtering queries
+CREATE INDEX IF NOT EXISTS idx_tasks_assigned_to ON tasks(assigned_to);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -53,6 +53,14 @@ pub struct Config {
     /// SSE broadcast channel capacity (default: 4096)
     #[serde(default = "default_sse_broadcast_capacity")]
     pub sse_broadcast_capacity: usize,
+
+    /// Retention period in days for agent session outputs (default: 30)
+    #[serde(default = "default_output_retention_days")]
+    pub output_retention_days: u64,
+
+    /// HTTP request timeout in seconds (default: 60)
+    #[serde(default = "default_request_timeout_secs")]
+    pub request_timeout_secs: u64,
 }
 
 fn default_bind_addr() -> String {
@@ -81,6 +89,14 @@ fn default_max_db_connections() -> u32 {
 
 fn default_sse_broadcast_capacity() -> usize {
     4096
+}
+
+fn default_output_retention_days() -> u64 {
+    30
+}
+
+fn default_request_timeout_secs() -> u64 {
+    60
 }
 
 impl Config {
@@ -150,6 +166,8 @@ impl Default for Config {
             cors_origin: None,
             max_db_connections: default_max_db_connections(),
             sse_broadcast_capacity: default_sse_broadcast_capacity(),
+            output_retention_days: default_output_retention_days(),
+            request_timeout_secs: default_request_timeout_secs(),
         }
     }
 }
@@ -244,5 +262,17 @@ mod tests {
     fn test_sse_broadcast_capacity_defaults_to_4096() {
         let config = Config::default();
         assert_eq!(config.sse_broadcast_capacity, 4096);
+    }
+
+    #[test]
+    fn test_output_retention_days_defaults_to_30() {
+        let config = Config::default();
+        assert_eq!(config.output_retention_days, 30);
+    }
+
+    #[test]
+    fn test_request_timeout_defaults_to_60() {
+        let config = Config::default();
+        assert_eq!(config.request_timeout_secs, 60);
     }
 }

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -53,14 +53,16 @@ impl IntoResponse for AppError {
                 (StatusCode::UNAUTHORIZED, "invalid credentials".to_string())
             }
             AppError::Internal(msg) => {
-                tracing::error!(msg, "internal server error");
+                tracing::debug!(msg, "internal server error details");
+                tracing::error!("internal server error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal server error".to_string(),
                 )
             }
             AppError::Database(err) => {
-                tracing::error!(%err, "database error");
+                tracing::debug!(%err, "database error details");
+                tracing::error!("database error");
                 // Check for constraint violations
                 let err_str = err.to_string();
                 if err_str.contains("UNIQUE constraint failed") {
@@ -88,12 +90,14 @@ impl IntoResponse for AppError {
                     return AppError::Validation(err.message().to_string()).into_response();
                 }
                 _ => {
-                    tracing::error!(%err, "git error");
+                    tracing::debug!(%err, "git error details");
+                    tracing::error!("git error");
                     (StatusCode::INTERNAL_SERVER_ERROR, "git error".to_string())
                 }
             },
             AppError::Anyhow(err) => {
-                tracing::error!(%err, "internal server error");
+                tracing::debug!(%err, "internal server error details");
+                tracing::error!("internal server error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal server error".to_string(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,6 +12,7 @@ pub mod sse;
 pub mod test_helpers;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::http::Method;
 use axum::routing::{delete, get, patch, post};
@@ -20,6 +21,7 @@ use sqlx::SqlitePool;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::GovernorLayer;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -167,15 +169,20 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             "/worktrees/{name}",
             delete(handlers::worktrees::delete_worktree),
         )
-        // SSE for real-time updates (rate-limited)
-        .route(
-            "/events",
-            get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
-        )
         // CSRF protection: require X-Requested-With header on state-changing requests
         .layer(axum::middleware::from_fn(auth::csrf::csrf_check))
         // General API rate limit applied to all routes
-        .layer(GovernorLayer::new(general_governor));
+        .layer(GovernorLayer::new(general_governor))
+        // Request timeout (SSE excluded — it's merged after this layer)
+        .layer(TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(state.config.request_timeout_secs),
+        ))
+        // SSE route: no timeout (long-lived streaming), own rate limit only
+        .merge(Router::new().route(
+            "/events",
+            get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
+        ));
 
     Ok(Router::new()
         .route("/health", get(handlers::health::health_check))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -81,7 +81,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     tracing::info!(count, "cleaned up expired sessions");
                 }
                 Err(e) => {
-                    tracing::error!(error = %e, "failed to cleanup expired sessions");
+                    tracing::debug!(error = %e, "session cleanup error details");
+                    tracing::error!("failed to cleanup expired sessions");
                 }
                 _ => {}
             }
@@ -95,7 +96,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     tracing::info!(count, "cleaned up old agent outputs");
                 }
                 Err(e) => {
-                    tracing::error!(error = %e, "failed to cleanup old agent outputs");
+                    tracing::debug!(error = %e, "output cleanup error details");
+                    tracing::error!("failed to cleanup old agent outputs");
                 }
                 _ => {}
             }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -10,7 +10,7 @@ use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
 use gantry_board::db;
 use gantry_board::models::agent_session::AgentType;
-use gantry_board::services::session_service;
+use gantry_board::services::{agent_session_output_service, session_service};
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use tracing_subscriber::EnvFilter;
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     let cleanup_pool = pool.clone();
+    let output_retention_days = config.output_retention_days;
 
     let state = AppState {
         pool,
@@ -81,6 +82,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 Err(e) => {
                     tracing::error!(error = %e, "failed to cleanup expired sessions");
+                }
+                _ => {}
+            }
+            match agent_session_output_service::cleanup_old_outputs(
+                &cleanup_pool,
+                output_retention_days,
+            )
+            .await
+            {
+                Ok(count) if count > 0 => {
+                    tracing::info!(count, "cleaned up old agent outputs");
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to cleanup old agent outputs");
                 }
                 _ => {}
             }

--- a/backend/src/services/agent_session_output_service.rs
+++ b/backend/src/services/agent_session_output_service.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -71,6 +72,26 @@ pub async fn get_outputs_after(
         .map(|r| r.try_into())
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+/// Delete agent session outputs older than the given number of days.
+/// Only deletes outputs for completed/failed/cancelled sessions.
+pub async fn cleanup_old_outputs(pool: &SqlitePool, retention_days: u64) -> AppResult<u64> {
+    let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
+    let result = sqlx::query(
+        r#"
+        DELETE FROM agent_session_outputs
+        WHERE created_at <= $1
+          AND session_id IN (
+            SELECT id FROM agent_sessions
+            WHERE status IN ('completed', 'failed', 'cancelled')
+          )
+        "#,
+    )
+    .bind(cutoff.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
 }
 
 #[cfg(test)]
@@ -195,6 +216,107 @@ mod tests {
         assert_eq!(outputs.len(), 2);
         assert_eq!(outputs[0].sequence, 3);
         assert_eq!(outputs[1].sequence, 4);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_old_outputs_deletes_expired() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        // Add output
+        append_output(&pool, session_id, 0, "old output")
+            .await
+            .expect("Failed to append");
+
+        // Mark session as completed
+        agent_session_service::update_agent_session(
+            &pool,
+            get_task_id_for_session(&pool, session_id).await,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: crate::models::agent_session::AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Failed to update to running");
+        agent_session_service::update_agent_session(
+            &pool,
+            get_task_id_for_session(&pool, session_id).await,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: crate::models::agent_session::AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("Failed to update to completed");
+
+        // Backdate the output's created_at
+        sqlx::query("UPDATE agent_session_outputs SET created_at = '2020-01-01T00:00:00.000Z' WHERE session_id = $1")
+            .bind(session_id.to_string())
+            .execute(&pool)
+            .await
+            .expect("Failed to backdate");
+
+        // Cleanup with 30-day retention — should delete the backdated output
+        let count = cleanup_old_outputs(&pool, 30)
+            .await
+            .expect("Failed to cleanup");
+        assert_eq!(count, 1);
+
+        let outputs = get_outputs(&pool, session_id).await.expect("Failed to get");
+        assert!(outputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_old_outputs_preserves_recent() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        // Add output (created_at is now, so it's recent)
+        append_output(&pool, session_id, 0, "recent output")
+            .await
+            .expect("Failed to append");
+
+        // Mark session as completed
+        agent_session_service::update_agent_session(
+            &pool,
+            get_task_id_for_session(&pool, session_id).await,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: crate::models::agent_session::AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Failed to update to running");
+        agent_session_service::update_agent_session(
+            &pool,
+            get_task_id_for_session(&pool, session_id).await,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: crate::models::agent_session::AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("Failed to update to completed");
+
+        // Cleanup with 30-day retention — recent output should be preserved
+        let count = cleanup_old_outputs(&pool, 30)
+            .await
+            .expect("Failed to cleanup");
+        assert_eq!(count, 0);
+
+        let outputs = get_outputs(&pool, session_id).await.expect("Failed to get");
+        assert_eq!(outputs.len(), 1);
+    }
+
+    /// Helper to get task_id from a session_id (for tests only)
+    async fn get_task_id_for_session(pool: &SqlitePool, session_id: Uuid) -> Uuid {
+        let row: (String,) = sqlx::query_as("SELECT task_id FROM agent_sessions WHERE id = $1")
+            .bind(session_id.to_string())
+            .fetch_one(pool)
+            .await
+            .expect("Failed to get task_id");
+        row.0.parse().expect("Failed to parse task_id")
     }
 
     #[tokio::test]

--- a/backend/src/services/agent_session_output_service.rs
+++ b/backend/src/services/agent_session_output_service.rs
@@ -77,7 +77,9 @@ pub async fn get_outputs_after(
 /// Delete agent session outputs older than the given number of days.
 /// Only deletes outputs for completed/failed/cancelled sessions.
 pub async fn cleanup_old_outputs(pool: &SqlitePool, retention_days: u64) -> AppResult<u64> {
-    let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
+    let retention_days_i64 = i64::try_from(retention_days)
+        .map_err(|_| AppError::Internal("retention_days too large".to_string()))?;
+    let cutoff = Utc::now() - chrono::Duration::days(retention_days_i64);
     let result = sqlx::query(
         r#"
         DELETE FROM agent_session_outputs


### PR DESCRIPTION
## Summary

Addresses 4 remaining high/medium/security issues from automated code review:

- **#112** Redact sensitive details (SQL fragments, file paths, error chains) from ERROR-level logs; detailed info available at DEBUG level
- **#97** Add TTL-based cleanup for agent session outputs with configurable retention period (default: 30 days), preventing unbounded database growth
- **#101** Add missing database index on `tasks.assigned_to` for efficient assignee filtering queries
- **#104** Add HTTP request timeout middleware (default: 60s) to prevent hung connections; SSE endpoint excluded from timeout

Also closed **#92** (migration rollback strategy) — sqlx executes each migration in its own transaction, preventing partial application.

## Changes

| File | Change |
|------|--------|
| `backend/src/error.rs` | Use `tracing::debug!` for detailed errors, `tracing::error!` for generic messages only |
| `backend/src/config.rs` | Add `output_retention_days` (default 30) and `request_timeout_secs` (default 60) fields |
| `backend/src/services/agent_session_output_service.rs` | Add `cleanup_old_outputs()` function with retention policy |
| `backend/src/main.rs` | Integrate output cleanup into background task |
| `backend/src/lib.rs` | Add `TimeoutLayer`, separate SSE route from timeout scope |
| `Cargo.toml` | Enable `timeout` feature for tower-http |
| `backend/migrations/20260212000001_add_output_created_at_index.sql` | Index on `agent_session_outputs.created_at` |
| `backend/migrations/20260212000002_add_tasks_assigned_to_index.sql` | Index on `tasks.assigned_to` |

## Test plan

- [x] All 295 backend tests pass (`task backend:test`)
- [x] `task check` passes (clippy + biome lint + format)
- [x] New tests: `cleanup_old_outputs_deletes_expired`, `cleanup_old_outputs_preserves_recent`, `output_retention_days_defaults_to_30`, `request_timeout_defaults_to_60`

Closes #97, #101, #104, #112