### PR TITLE
feat: ✨ add toast notifications and comment UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { ProtectedRoute } from './components/ProtectedRoute';
 import { RegisterPage } from './components/RegisterPage';
 import { TaskCreateDialog } from './components/TaskCreateDialog';
 import { TaskDetailModal } from './components/TaskDetailModal';
+import { ToastContainer } from './components/ToastContainer';
 import { connectEventSource } from './hooks/useEventSource';
 import { useAuthStore } from './stores/authStore';
 import { useUiStore } from './stores/uiStore';
@@ -166,6 +167,7 @@ function App() {
       <ErrorBoundary>
         <AppRoutes />
       </ErrorBoundary>
+      <ToastContainer />
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/CommentSection.test.tsx
+++ b/frontend/src/components/CommentSection.test.tsx
@@ -1,0 +1,214 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as commentsApi from '../api/generated/endpoints/task-comments/task-comments';
+import type { TaskComment } from '../api/generated/model';
+import { useAuthStore } from '../stores/authStore';
+import { CommentSection } from './CommentSection';
+
+vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
+  useListComments: vi.fn(),
+  useCreateComment: vi.fn(),
+  useUpdateComment: vi.fn(),
+  useDeleteComment: vi.fn(),
+}));
+
+const mockComments: TaskComment[] = [
+  {
+    id: 'comment-1',
+    task_id: 'task-1',
+    user_id: 'user-1',
+    user_name: 'Alice',
+    content: 'First comment',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'comment-2',
+    task_id: 'task-1',
+    user_id: 'user-2',
+    user_name: 'Bob',
+    content: 'Second comment',
+    created_at: '2026-01-01T01:00:00Z',
+    updated_at: '2026-01-01T01:00:00Z',
+  },
+];
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('CommentSection', () => {
+  const mockCreateMutateAsync = vi.fn();
+  const mockUpdateMutateAsync = vi.fn();
+  const mockDeleteMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'alice@test.com', name: 'Alice', created_at: '', updated_at: '' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: mockComments,
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+
+    vi.mocked(commentsApi.useCreateComment).mockReturnValue({
+      mutateAsync: mockCreateMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useCreateComment>);
+
+    vi.mocked(commentsApi.useUpdateComment).mockReturnValue({
+      mutateAsync: mockUpdateMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useUpdateComment>);
+
+    vi.mocked(commentsApi.useDeleteComment).mockReturnValue({
+      mutateAsync: mockDeleteMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useDeleteComment>);
+  });
+
+  it('renders comment list', () => {
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    expect(screen.getByText('First comment')).toBeInTheDocument();
+    expect(screen.getByText('Second comment')).toBeInTheDocument();
+  });
+
+  it('renders user names', () => {
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no comments', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    expect(screen.getByText(/no comments/i)).toBeInTheDocument();
+  });
+
+  it('submits a new comment', async () => {
+    const user = userEvent.setup();
+    mockCreateMutateAsync.mockResolvedValue({});
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    await user.type(textarea, 'New comment');
+    await user.click(screen.getByRole('button', { name: /post/i }));
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      data: { content: 'New comment' },
+    });
+  });
+
+  it('clears textarea after successful submission', async () => {
+    const user = userEvent.setup();
+    mockCreateMutateAsync.mockResolvedValue({});
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const textarea = screen.getByPlaceholderText(/add a comment/i);
+    await user.type(textarea, 'New comment');
+    await user.click(screen.getByRole('button', { name: /post/i }));
+
+    expect(textarea).toHaveValue('');
+  });
+
+  it('disables post button when textarea is empty', () => {
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    const button = screen.getByRole('button', { name: /post/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('shows edit and delete buttons for own comments', () => {
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    // user-1 is Alice (current user) — should see edit/delete on comment-1
+    const commentItems = screen.getAllByTestId('comment-item');
+    const firstComment = commentItems[0];
+    expect(firstComment.querySelector('[aria-label="Edit"]')).toBeInTheDocument();
+    expect(firstComment.querySelector('[aria-label="Delete"]')).toBeInTheDocument();
+  });
+
+  it('does not show edit and delete buttons for other users comments', () => {
+    renderWithProviders(<CommentSection taskId="task-1" />);
+    // user-2 is Bob — current user is user-1, should NOT see edit/delete on comment-2
+    const commentItems = screen.getAllByTestId('comment-item');
+    const secondComment = commentItems[1];
+    expect(secondComment.querySelector('[aria-label="Edit"]')).not.toBeInTheDocument();
+    expect(secondComment.querySelector('[aria-label="Delete"]')).not.toBeInTheDocument();
+  });
+
+  it('enters edit mode on edit button click', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
+    await user.click(editBtn!);
+
+    expect(screen.getByDisplayValue('First comment')).toBeInTheDocument();
+  });
+
+  it('saves edited comment', async () => {
+    const user = userEvent.setup();
+    mockUpdateMutateAsync.mockResolvedValue({});
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
+    await user.click(editBtn!);
+
+    const input = screen.getByDisplayValue('First comment');
+    await user.clear(input);
+    await user.type(input, 'Updated comment');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      commentId: 'comment-1',
+      data: { content: 'Updated comment' },
+    });
+  });
+
+  it('cancels editing', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
+    await user.click(editBtn!);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByDisplayValue('First comment')).not.toBeInTheDocument();
+    expect(screen.getByText('First comment')).toBeInTheDocument();
+  });
+
+  it('deletes comment with confirmation', async () => {
+    const user = userEvent.setup();
+    mockDeleteMutateAsync.mockResolvedValue({});
+    renderWithProviders(<CommentSection taskId="task-1" />);
+
+    const deleteBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Delete"]');
+    await user.click(deleteBtn!);
+
+    // Confirmation appears
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      commentId: 'comment-1',
+    });
+  });
+});

--- a/frontend/src/components/CommentSection.test.tsx
+++ b/frontend/src/components/CommentSection.test.tsx
@@ -54,7 +54,13 @@ describe('CommentSection', () => {
     vi.clearAllMocks();
 
     useAuthStore.setState({
-      user: { id: 'user-1', email: 'alice@test.com', name: 'Alice', created_at: '', updated_at: '' },
+      user: {
+        id: 'user-1',
+        email: 'alice@test.com',
+        name: 'Alice',
+        created_at: '',
+        updated_at: '',
+      },
       isAuthenticated: true,
       isLoading: false,
     });
@@ -200,7 +206,9 @@ describe('CommentSection', () => {
     mockDeleteMutateAsync.mockResolvedValue({});
     renderWithProviders(<CommentSection taskId="task-1" />);
 
-    const deleteBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Delete"]');
+    const deleteBtn = screen
+      .getAllByTestId('comment-item')[0]
+      .querySelector('[aria-label="Delete"]');
     await user.click(deleteBtn!);
 
     // Confirmation appears

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -1,5 +1,7 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import {
+  getListCommentsQueryKey,
   useCreateComment,
   useDeleteComment,
   useListComments,
@@ -33,9 +35,14 @@ function CommentItem({
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const queryClient = useQueryClient();
   const updateComment = useUpdateComment();
   const deleteComment = useDeleteComment();
   const addToast = useToastStore((s) => s.addToast);
+
+  const invalidateComments = () => {
+    queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
+  };
 
   const handleEdit = () => {
     setEditing(true);
@@ -52,6 +59,7 @@ function CommentItem({
         data: { content: trimmed },
       });
       setEditing(false);
+      invalidateComments();
     } catch {
       addToast('error', 'Failed to update comment.');
     }
@@ -61,6 +69,7 @@ function CommentItem({
     try {
       await deleteComment.mutateAsync({ taskId, commentId: comment.id });
       setShowDeleteConfirm(false);
+      invalidateComments();
     } catch {
       addToast('error', 'Failed to delete comment.');
     }
@@ -157,6 +166,7 @@ function CommentItem({
 export function CommentSection({ taskId }: { taskId: string }) {
   const { data: comments, isLoading } = useListComments(taskId);
   const createComment = useCreateComment();
+  const queryClient = useQueryClient();
   const [newComment, setNewComment] = useState('');
   const currentUser = useAuthStore((s) => s.user);
   const addToast = useToastStore((s) => s.addToast);
@@ -167,6 +177,7 @@ export function CommentSection({ taskId }: { taskId: string }) {
     try {
       await createComment.mutateAsync({ taskId, data: { content: trimmed } });
       setNewComment('');
+      queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
     } catch {
       addToast('error', 'Failed to post comment.');
     }

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import {
+  useCreateComment,
+  useDeleteComment,
+  useListComments,
+  useUpdateComment,
+} from '../api/generated/endpoints/task-comments/task-comments';
+import { useAuthStore } from '../stores/authStore';
+import { useToastStore } from '../stores/toastStore';
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+function CommentItem({
+  comment,
+  taskId,
+  isOwner,
+}: {
+  comment: { id: string; user_name: string; user_id: string; content: string; created_at: string };
+  taskId: string;
+  isOwner: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const updateComment = useUpdateComment();
+  const deleteComment = useDeleteComment();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleEdit = () => {
+    setEditing(true);
+    setEditValue(comment.content);
+  };
+
+  const handleSave = async () => {
+    const trimmed = editValue.trim();
+    if (!trimmed) return;
+    try {
+      await updateComment.mutateAsync({
+        taskId,
+        commentId: comment.id,
+        data: { content: trimmed },
+      });
+      setEditing(false);
+    } catch {
+      addToast('error', 'Failed to update comment.');
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteComment.mutateAsync({ taskId, commentId: comment.id });
+      setShowDeleteConfirm(false);
+    } catch {
+      addToast('error', 'Failed to delete comment.');
+    }
+  };
+
+  const initials = comment.user_name
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div data-testid="comment-item" className="flex gap-3 py-2">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+        {initials}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-900">{comment.user_name}</span>
+          <span className="text-xs text-gray-500">{timeAgo(comment.created_at)}</span>
+          {isOwner && !editing && !showDeleteConfirm && (
+            <div className="ml-auto flex gap-1">
+              <button
+                type="button"
+                aria-label="Edit"
+                onClick={handleEdit}
+                className="text-xs text-gray-400 hover:text-gray-600"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                aria-label="Delete"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-xs text-gray-400 hover:text-red-600"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+        {editing ? (
+          <div className="mt-1 space-y-1">
+            <textarea
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              rows={2}
+              className="block w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={handleSave}
+                className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditing(false)}
+                className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : showDeleteConfirm ? (
+          <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
+            <span className="text-xs text-red-700">Delete this comment?</span>
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(false)}
+              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CommentSection({ taskId }: { taskId: string }) {
+  const { data: comments, isLoading } = useListComments(taskId);
+  const createComment = useCreateComment();
+  const [newComment, setNewComment] = useState('');
+  const currentUser = useAuthStore((s) => s.user);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleSubmit = async () => {
+    const trimmed = newComment.trim();
+    if (!trimmed) return;
+    try {
+      await createComment.mutateAsync({ taskId, data: { content: trimmed } });
+      setNewComment('');
+    } catch {
+      addToast('error', 'Failed to post comment.');
+    }
+  };
+
+  return (
+    <div>
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading comments...</p>
+      ) : comments && comments.length > 0 ? (
+        <div className="divide-y">
+          {comments.map((c) => (
+            <CommentItem
+              key={c.id}
+              comment={c}
+              taskId={taskId}
+              isOwner={currentUser?.id === c.user_id}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">No comments yet.</p>
+      )}
+      <div className="mt-3 flex gap-2">
+        <textarea
+          value={newComment}
+          onChange={(e) => setNewComment(e.target.value)}
+          placeholder="Add a comment..."
+          rows={2}
+          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!newComment.trim() || createComment.isPending}
+          className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as agentSessionsApi from '../api/generated/endpoints/agent-sessions/agent-sessions';
+import * as commentsApi from '../api/generated/endpoints/task-comments/task-comments';
 import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
 import * as worktreesApi from '../api/generated/endpoints/worktrees/worktrees';
 import type { Task } from '../api/generated/model';
@@ -27,6 +28,13 @@ vi.mock('../api/generated/endpoints/worktrees/worktrees', () => ({
   useListWorktrees: vi.fn(),
   useCreateWorktree: vi.fn(),
   useDeleteWorktree: vi.fn(),
+}));
+
+vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
+  useListComments: vi.fn(),
+  useCreateComment: vi.fn(),
+  useUpdateComment: vi.fn(),
+  useDeleteComment: vi.fn(),
 }));
 
 vi.mock('../hooks/useAgentEvents', () => ({
@@ -110,6 +118,26 @@ describe('TaskDetailModal', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof worktreesApi.useDeleteWorktree>);
+
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+
+    vi.mocked(commentsApi.useCreateComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useCreateComment>);
+
+    vi.mocked(commentsApi.useUpdateComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useUpdateComment>);
+
+    vi.mocked(commentsApi.useDeleteComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useDeleteComment>);
   });
 
   it('does not render when modal is closed', () => {

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -3,6 +3,7 @@ import { useDeleteTask, useGetTask, useUpdateTask } from '../api/generated/endpo
 import type { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 import { AgentPanel } from './AgentPanel';
+import { CommentSection } from './CommentSection';
 import { WorktreePanel } from './WorktreePanel';
 
 export function TaskDetailModal() {
@@ -209,6 +210,11 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             <div className="border-t pt-4">
               <h3 className="text-sm font-medium text-gray-700 mb-2">Worktrees</h3>
               <WorktreePanel />
+            </div>
+
+            <div className="border-t pt-4">
+              <h3 className="text-sm font-medium text-gray-700 mb-2">Comments</h3>
+              <CommentSection taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">

--- a/frontend/src/components/ToastContainer.test.tsx
+++ b/frontend/src/components/ToastContainer.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useToastStore } from '../stores/toastStore';
+import { ToastContainer } from './ToastContainer';
+
+describe('ToastContainer', () => {
+  afterEach(() => {
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it('renders nothing when no toasts', () => {
+    const { container } = render(<ToastContainer />);
+    expect(container.querySelector('[data-testid="toast-container"]')?.children).toHaveLength(0);
+  });
+
+  it('renders toast message', () => {
+    useToastStore.setState({
+      toasts: [{ id: '1', type: 'success', message: 'Saved successfully' }],
+    });
+    render(<ToastContainer />);
+    expect(screen.getByText('Saved successfully')).toBeInTheDocument();
+  });
+
+  it('renders multiple toasts', () => {
+    useToastStore.setState({
+      toasts: [
+        { id: '1', type: 'success', message: 'First toast' },
+        { id: '2', type: 'error', message: 'Second toast' },
+      ],
+    });
+    render(<ToastContainer />);
+    expect(screen.getByText('First toast')).toBeInTheDocument();
+    expect(screen.getByText('Second toast')).toBeInTheDocument();
+  });
+
+  it('dismisses toast when close button is clicked', async () => {
+    const user = userEvent.setup();
+    useToastStore.setState({
+      toasts: [{ id: '1', type: 'info', message: 'Dismiss me' }],
+    });
+    render(<ToastContainer />);
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('applies green styling for success toast', () => {
+    useToastStore.setState({
+      toasts: [{ id: '1', type: 'success', message: 'Success msg' }],
+    });
+    render(<ToastContainer />);
+    const toast = screen.getByText('Success msg').closest('[data-testid="toast-item"]');
+    expect(toast).toHaveClass('bg-green-50');
+  });
+
+  it('applies red styling for error toast', () => {
+    useToastStore.setState({
+      toasts: [{ id: '1', type: 'error', message: 'Error msg' }],
+    });
+    render(<ToastContainer />);
+    const toast = screen.getByText('Error msg').closest('[data-testid="toast-item"]');
+    expect(toast).toHaveClass('bg-red-50');
+  });
+
+  it('applies blue styling for info toast', () => {
+    useToastStore.setState({
+      toasts: [{ id: '1', type: 'info', message: 'Info msg' }],
+    });
+    render(<ToastContainer />);
+    const toast = screen.getByText('Info msg').closest('[data-testid="toast-item"]');
+    expect(toast).toHaveClass('bg-blue-50');
+  });
+});

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -11,7 +11,10 @@ export function ToastContainer() {
   const removeToast = useToastStore((s) => s.removeToast);
 
   return (
-    <div data-testid="toast-container" className="fixed right-4 bottom-4 z-[60] flex flex-col gap-2">
+    <div
+      data-testid="toast-container"
+      className="fixed right-4 bottom-4 z-[60] flex flex-col gap-2"
+    >
       {toasts.map((toast) => (
         <div
           key={toast.id}

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,34 @@
+import { useToastStore } from '../stores/toastStore';
+
+const typeStyles = {
+  success: 'bg-green-50 border-green-400 text-green-800',
+  error: 'bg-red-50 border-red-400 text-red-800',
+  info: 'bg-blue-50 border-blue-400 text-blue-800',
+};
+
+export function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+  const removeToast = useToastStore((s) => s.removeToast);
+
+  return (
+    <div data-testid="toast-container" className="fixed right-4 bottom-4 z-[60] flex flex-col gap-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          data-testid="toast-item"
+          className={`flex items-center gap-2 rounded-md border px-4 py-3 shadow-md ${typeStyles[toast.type]}`}
+        >
+          <span className="flex-1 text-sm">{toast.message}</span>
+          <button
+            type="button"
+            onClick={() => removeToast(toast.id)}
+            aria-label="Dismiss"
+            className="ml-2 text-lg leading-none opacity-60 hover:opacity-100"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 
-import type { AgentSession, Task } from '../api/generated/model';
+import type { AgentSession, Task, TaskComment } from '../api/generated/model';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
 
@@ -9,7 +9,10 @@ export type SseEvent =
   | { type: 'TaskUpdated'; task: Task }
   | { type: 'TaskDeleted'; task_id: string }
   | { type: 'AgentOutput'; session_id: string; text: string }
-  | { type: 'AgentSessionStatusChanged'; session: AgentSession };
+  | { type: 'AgentSessionStatusChanged'; session: AgentSession }
+  | { type: 'CommentCreated'; comment: TaskComment }
+  | { type: 'CommentUpdated'; comment: TaskComment }
+  | { type: 'CommentDeleted'; comment_id: string; task_id: string };
 
 export function connectEventSource(queryClient: QueryClient): () => void {
   const eventSource = new EventSource(`${API_BASE_URL}/api/events`);
@@ -57,6 +60,25 @@ export function connectEventSource(queryClient: QueryClient): () => void {
     }
   };
   eventSource.addEventListener('agent_session_status_changed', handleAgentSessionEvent);
+
+  const handleCommentEvent = (event: MessageEvent) => {
+    try {
+      const parsed = JSON.parse(event.data) as SseEvent;
+      const taskId =
+        'comment' in parsed ? parsed.comment.task_id : 'task_id' in parsed ? parsed.task_id : null;
+      if (taskId) {
+        queryClient.invalidateQueries({
+          queryKey: [`/api/tasks/${taskId}/comments`],
+          exact: false,
+        });
+      }
+    } catch {
+      console.error('Failed to parse SSE event:', event.data);
+    }
+  };
+  eventSource.addEventListener('comment_created', handleCommentEvent);
+  eventSource.addEventListener('comment_updated', handleCommentEvent);
+  eventSource.addEventListener('comment_deleted', handleCommentEvent);
 
   eventSource.onerror = (event: Event) => {
     const source = event.currentTarget as EventSource | null;

--- a/frontend/src/stores/toastStore.test.ts
+++ b/frontend/src/stores/toastStore.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useToastStore } from './toastStore';
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllTimers();
+    useToastStore.setState({ toasts: [] });
+  });
+
+  it('has correct initial state', () => {
+    const state = useToastStore.getState();
+    expect(state.toasts).toEqual([]);
+  });
+
+  it('adds a toast with addToast', () => {
+    useToastStore.getState().addToast('success', 'Operation succeeded');
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe('success');
+    expect(toasts[0].message).toBe('Operation succeeded');
+    expect(toasts[0].id).toBeDefined();
+  });
+
+  it('adds multiple toasts', () => {
+    const { addToast } = useToastStore.getState();
+    addToast('success', 'First');
+    addToast('error', 'Second');
+    addToast('info', 'Third');
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(3);
+    expect(toasts[0].type).toBe('success');
+    expect(toasts[1].type).toBe('error');
+    expect(toasts[2].type).toBe('info');
+  });
+
+  it('removes a toast with removeToast', () => {
+    useToastStore.getState().addToast('info', 'Will be removed');
+    const { toasts } = useToastStore.getState();
+    const toastId = toasts[0].id;
+
+    useToastStore.getState().removeToast(toastId);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('only removes the specified toast', () => {
+    const { addToast } = useToastStore.getState();
+    addToast('success', 'Keep me');
+    addToast('error', 'Remove me');
+    const toasts = useToastStore.getState().toasts;
+    const removeId = toasts[1].id;
+
+    useToastStore.getState().removeToast(removeId);
+    const remaining = useToastStore.getState().toasts;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].message).toBe('Keep me');
+  });
+
+  it('auto-removes toast after 5 seconds', () => {
+    useToastStore.getState().addToast('success', 'Auto dismiss');
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('does not remove toast before 5 seconds', () => {
+    useToastStore.getState().addToast('success', 'Not yet');
+    vi.advanceTimersByTime(4999);
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+});

--- a/frontend/src/stores/toastStore.test.ts
+++ b/frontend/src/stores/toastStore.test.ts
@@ -8,8 +8,9 @@ describe('toastStore', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllTimers();
+    vi.clearAllTimers();
     useToastStore.setState({ toasts: [] });
+    vi.useRealTimers();
   });
 
   it('has correct initial state', () => {

--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+export interface Toast {
+  id: string;
+  type: 'success' | 'error' | 'info';
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (type: Toast['type'], message: string) => void;
+  removeToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  addToast: (type, message) => {
+    const id = crypto.randomUUID();
+    set((state) => ({ toasts: [...state.toasts, { id, type, message }] }));
+    setTimeout(() => {
+      set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+    }, 5000);
+  },
+  removeToast: (id) => {
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+  },
+}));

--- a/frontend/src/stores/toastStore.ts
+++ b/frontend/src/stores/toastStore.ts
@@ -12,16 +12,27 @@ interface ToastState {
   removeToast: (id: string) => void;
 }
 
-export const useToastStore = create<ToastState>((set) => ({
-  toasts: [],
-  addToast: (type, message) => {
-    const id = crypto.randomUUID();
-    set((state) => ({ toasts: [...state.toasts, { id, type, message }] }));
-    setTimeout(() => {
+export const useToastStore = create<ToastState>((set) => {
+  const timeouts = new Map<string, number>();
+
+  return {
+    toasts: [],
+    addToast: (type, message) => {
+      const id = crypto.randomUUID();
+      set((state) => ({ toasts: [...state.toasts, { id, type, message }] }));
+      const timeoutId = window.setTimeout(() => {
+        set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+        timeouts.delete(id);
+      }, 5000);
+      timeouts.set(id, timeoutId);
+    },
+    removeToast: (id) => {
+      const timeoutId = timeouts.get(id);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeouts.delete(id);
+      }
       set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
-    }, 5000);
-  },
-  removeToast: (id) => {
-    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
-  },
-}));
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- Add toast notification system (Zustand store + ToastContainer) (#115)
- Add task comment UI with inline edit/delete and SSE real-time updates (#127)
- Clean up local junk directories (#130)

## Changes
- `toastStore.ts` / `ToastContainer.tsx` — toast notification with 5s auto-dismiss
- `CommentSection.tsx` — comment list, create, inline edit, delete with confirmation
- `TaskDetailModal.tsx` — integrated CommentSection below Worktrees
- `useEventSource.ts` — SSE listeners for comment_created/updated/deleted events

## Test plan
- [x] 158 frontend tests passing (19 test files)
- [x] Toast store: add/remove/auto-dismiss tests
- [x] ToastContainer: render, dismiss, type-based styling tests
- [x] CommentSection: list, create, edit, delete, owner-only controls tests
- [x] Biome lint passing