### PR TITLE
feat: ✨ add project settings and member management (#121, #122)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,8 +5,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppRoutes } from './App';
 import * as authApi from './api/generated/endpoints/auth/auth';
+import * as membersApi from './api/generated/endpoints/project-members/project-members';
 import * as projectsApi from './api/generated/endpoints/projects/projects';
 import * as tasksApi from './api/generated/endpoints/tasks/tasks';
+import * as usersApi from './api/generated/endpoints/users/users';
 import { useAuthStore } from './stores/authStore';
 import { useUiStore } from './stores/uiStore';
 
@@ -22,6 +24,22 @@ vi.stubGlobal('EventSource', MockEventSource);
 vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
   useCreateProject: vi.fn(),
+  useGetProject: vi.fn(),
+  useUpdateProject: vi.fn(),
+  useDeleteProject: vi.fn(),
+  getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
+}));
+
+vi.mock('./api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
+  useAddMember: vi.fn(),
+  useUpdateMember: vi.fn(),
+  useRemoveMember: vi.fn(),
+  getListMembersQueryKey: vi.fn(() => ['/api/projects/members']),
+}));
+
+vi.mock('./api/generated/endpoints/users/users', () => ({
+  useSearchUsers: vi.fn(),
 }));
 
 vi.mock('./api/generated/endpoints/tasks/tasks', () => ({
@@ -97,11 +115,49 @@ describe('App', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof tasksApi.useCreateTask>);
+    // Mock project detail hooks
+    vi.mocked(projectsApi.useGetProject).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof projectsApi.useGetProject>);
+    vi.mocked(projectsApi.useUpdateProject).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useUpdateProject>);
+    vi.mocked(projectsApi.useDeleteProject).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useDeleteProject>);
+    // Mock member hooks
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
+    vi.mocked(membersApi.useAddMember).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useAddMember>);
+    vi.mocked(membersApi.useUpdateMember).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useUpdateMember>);
+    vi.mocked(membersApi.useRemoveMember).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useRemoveMember>);
+    // Mock user search
+    vi.mocked(usersApi.useSearchUsers).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof usersApi.useSearchUsers>);
     // Reset ui store
     useUiStore.setState({
       isTaskModalOpen: false,
       defaultStatus: null,
       isProjectModalOpen: false,
+      isProjectSettingsOpen: false,
+      isProjectMembersOpen: false,
     });
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { KanbanBoard } from './components/KanbanBoard';
 import { LoginPage } from './components/LoginPage';
 import { ProjectCreateDialog } from './components/ProjectCreateDialog';
+import { ProjectMembersPanel } from './components/ProjectMembersPanel';
+import { ProjectSettingsModal } from './components/ProjectSettingsModal';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { RegisterPage } from './components/RegisterPage';
 import { TaskCreateDialog } from './components/TaskCreateDialog';
@@ -24,6 +26,8 @@ function KanbanApp() {
   const logout = useLogout();
   const setUser = useAuthStore((state) => state.setUser);
   const openProjectModal = useUiStore((s) => s.openProjectModal);
+  const openProjectSettings = useUiStore((s) => s.openProjectSettings);
+  const openProjectMembers = useUiStore((s) => s.openProjectMembers);
 
   // Connect to SSE for real-time updates
   // biome-ignore lint/correctness/useExhaustiveDependencies: queryClient is stable from provider
@@ -72,6 +76,24 @@ function KanbanApp() {
             >
               New Project
             </button>
+            {selectedProjectId && (
+              <>
+                <button
+                  type="button"
+                  onClick={openProjectSettings}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Settings
+                </button>
+                <button
+                  type="button"
+                  onClick={openProjectMembers}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Members
+                </button>
+              </>
+            )}
 
             <div className="flex items-center gap-2 border-l pl-4">
               <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
@@ -99,6 +121,15 @@ function KanbanApp() {
       <ProjectCreateDialog />
       {selectedProjectId && <TaskCreateDialog projectId={selectedProjectId} />}
       <TaskDetailModal />
+      {selectedProjectId && (
+        <ProjectSettingsModal
+          projectId={selectedProjectId}
+          onProjectDeleted={() => setSelectedProjectId(null)}
+        />
+      )}
+      {selectedProjectId && (
+        <ProjectMembersPanel projectId={selectedProjectId} />
+      )}
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -127,9 +127,7 @@ function KanbanApp() {
           onProjectDeleted={() => setSelectedProjectId(null)}
         />
       )}
-      {selectedProjectId && (
-        <ProjectMembersPanel projectId={selectedProjectId} />
-      )}
+      {selectedProjectId && <ProjectMembersPanel projectId={selectedProjectId} />}
     </div>
   );
 }

--- a/frontend/src/components/ProjectMembersPanel.test.tsx
+++ b/frontend/src/components/ProjectMembersPanel.test.tsx
@@ -131,8 +131,10 @@ describe('ProjectMembersPanel', () => {
   it('displays role badges', () => {
     useUiStore.setState({ isProjectMembersOpen: true });
     renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
-    expect(screen.getByText('owner')).toBeInTheDocument();
-    expect(screen.getByText('member')).toBeInTheDocument();
+    // Alice (self/owner) shows a static badge, Bob has a role select
+    // Check that role text exists somewhere in the document
+    expect(screen.getAllByText('owner').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('member').length).toBeGreaterThanOrEqual(1);
   });
 
   describe('owner permissions', () => {
@@ -157,7 +159,8 @@ describe('ProjectMembersPanel', () => {
       useUiStore.setState({ isProjectMembersOpen: true });
       renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
       const roleSelects = screen.getAllByRole('combobox');
-      expect(roleSelects).toHaveLength(1); // Only Bob
+      // 1 for Bob's role change + 1 for invite role select
+      expect(roleSelects).toHaveLength(2);
     });
   });
 

--- a/frontend/src/components/ProjectMembersPanel.test.tsx
+++ b/frontend/src/components/ProjectMembersPanel.test.tsx
@@ -51,14 +51,11 @@ const mockSearchResults: User[] = [
   },
 ];
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (ui: React.ReactElement) => {
   const queryClient = createQueryClient();
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-  );
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 };
 
 describe('ProjectMembersPanel', () => {
@@ -141,9 +138,7 @@ describe('ProjectMembersPanel', () => {
     it('shows invite section for owner', () => {
       useUiStore.setState({ isProjectMembersOpen: true });
       renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
-      expect(
-        screen.getByPlaceholderText(/search users/i),
-      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/search users/i)).toBeInTheDocument();
     });
 
     it('shows remove button for other members', () => {
@@ -183,17 +178,13 @@ describe('ProjectMembersPanel', () => {
     it('does not show invite section for member role', () => {
       useUiStore.setState({ isProjectMembersOpen: true });
       renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
-      expect(
-        screen.queryByPlaceholderText(/search users/i),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText(/search users/i)).not.toBeInTheDocument();
     });
 
     it('does not show remove buttons for member role', () => {
       useUiStore.setState({ isProjectMembersOpen: true });
       renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
-      expect(
-        screen.queryByRole('button', { name: /remove/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
     });
 
     it('does not show role selects for member role', () => {

--- a/frontend/src/components/ProjectMembersPanel.test.tsx
+++ b/frontend/src/components/ProjectMembersPanel.test.tsx
@@ -1,0 +1,310 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as membersApi from '../api/generated/endpoints/project-members/project-members';
+import * as usersApi from '../api/generated/endpoints/users/users';
+import type { ProjectMember, User } from '../api/generated/model';
+import { MemberRole } from '../api/generated/model';
+import { useAuthStore } from '../stores/authStore';
+import { useUiStore } from '../stores/uiStore';
+import { ProjectMembersPanel } from './ProjectMembersPanel';
+
+vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
+  useAddMember: vi.fn(),
+  useUpdateMember: vi.fn(),
+  useRemoveMember: vi.fn(),
+  getListMembersQueryKey: vi.fn(() => ['/api/projects/project-1/members']),
+}));
+
+vi.mock('../api/generated/endpoints/users/users', () => ({
+  useSearchUsers: vi.fn(),
+}));
+
+const mockMembers: ProjectMember[] = [
+  {
+    user_id: 'user-1',
+    user_name: 'Alice',
+    user_email: 'alice@test.com',
+    role: MemberRole.owner,
+    project_id: 'project-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    user_id: 'user-2',
+    user_name: 'Bob',
+    user_email: 'bob@test.com',
+    role: MemberRole.member,
+    project_id: 'project-1',
+    created_at: '2026-01-01T01:00:00Z',
+  },
+];
+
+const mockSearchResults: User[] = [
+  {
+    id: 'user-3',
+    name: 'Carol',
+    email: 'carol@test.com',
+    created_at: '',
+    updated_at: '',
+  },
+];
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe('ProjectMembersPanel', () => {
+  const mockAddMutateAsync = vi.fn();
+  const mockUpdateMutateAsync = vi.fn();
+  const mockRemoveMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useAuthStore.setState({
+      user: {
+        id: 'user-1',
+        email: 'alice@test.com',
+        name: 'Alice',
+        created_at: '',
+        updated_at: '',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    useUiStore.setState({ isProjectMembersOpen: false });
+
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: mockMembers,
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
+
+    vi.mocked(membersApi.useAddMember).mockReturnValue({
+      mutateAsync: mockAddMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useAddMember>);
+
+    vi.mocked(membersApi.useUpdateMember).mockReturnValue({
+      mutateAsync: mockUpdateMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useUpdateMember>);
+
+    vi.mocked(membersApi.useRemoveMember).mockReturnValue({
+      mutateAsync: mockRemoveMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof membersApi.useRemoveMember>);
+
+    vi.mocked(usersApi.useSearchUsers).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof usersApi.useSearchUsers>);
+  });
+
+  it('does not render when panel is closed', () => {
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders member list when open', () => {
+    useUiStore.setState({ isProjectMembersOpen: true });
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('displays member emails', () => {
+    useUiStore.setState({ isProjectMembersOpen: true });
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+    expect(screen.getByText('alice@test.com')).toBeInTheDocument();
+    expect(screen.getByText('bob@test.com')).toBeInTheDocument();
+  });
+
+  it('displays role badges', () => {
+    useUiStore.setState({ isProjectMembersOpen: true });
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+    expect(screen.getByText('owner')).toBeInTheDocument();
+    expect(screen.getByText('member')).toBeInTheDocument();
+  });
+
+  describe('owner permissions', () => {
+    it('shows invite section for owner', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      expect(
+        screen.getByPlaceholderText(/search users/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows remove button for other members', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove/i,
+      });
+      expect(removeButtons).toHaveLength(1); // Only Bob, not self
+    });
+
+    it('shows role select for other members', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      const roleSelects = screen.getAllByRole('combobox');
+      expect(roleSelects).toHaveLength(1); // Only Bob
+    });
+  });
+
+  describe('member permissions (read-only)', () => {
+    beforeEach(() => {
+      // Current user is user-2 (member role)
+      useAuthStore.setState({
+        user: {
+          id: 'user-2',
+          email: 'bob@test.com',
+          name: 'Bob',
+          created_at: '',
+          updated_at: '',
+        },
+        isAuthenticated: true,
+        isLoading: false,
+      });
+    });
+
+    it('does not show invite section for member role', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      expect(
+        screen.queryByPlaceholderText(/search users/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show remove buttons for member role', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      expect(
+        screen.queryByRole('button', { name: /remove/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show role selects for member role', () => {
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('invite flow', () => {
+    it('searches users when typing', async () => {
+      const user = userEvent.setup();
+      vi.mocked(usersApi.useSearchUsers).mockReturnValue({
+        data: mockSearchResults,
+        isLoading: false,
+      } as unknown as ReturnType<typeof usersApi.useSearchUsers>);
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+      const searchInput = screen.getByPlaceholderText(/search users/i);
+      await user.type(searchInput, 'Carol');
+
+      expect(screen.getByText('Carol')).toBeInTheDocument();
+      expect(screen.getByText('carol@test.com')).toBeInTheDocument();
+    });
+
+    it('adds member when search result is clicked and add pressed', async () => {
+      const user = userEvent.setup();
+      mockAddMutateAsync.mockResolvedValue({});
+      vi.mocked(usersApi.useSearchUsers).mockReturnValue({
+        data: mockSearchResults,
+        isLoading: false,
+      } as unknown as ReturnType<typeof usersApi.useSearchUsers>);
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+      const searchInput = screen.getByPlaceholderText(/search users/i);
+      await user.type(searchInput, 'Carol');
+
+      // Click on search result to select
+      const resultButtons = screen.getAllByTestId('search-result');
+      await user.click(resultButtons[0]);
+
+      // Click Add button
+      await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+      expect(mockAddMutateAsync).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        data: { user_id: 'user-3', role: MemberRole.member },
+      });
+    });
+  });
+
+  describe('role change', () => {
+    it('changes member role via select', async () => {
+      const user = userEvent.setup();
+      mockUpdateMutateAsync.mockResolvedValue({});
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+      const roleSelect = screen.getAllByRole('combobox')[0];
+      await user.selectOptions(roleSelect, 'admin');
+
+      expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        userId: 'user-2',
+        data: { role: 'admin' },
+      });
+    });
+  });
+
+  describe('remove member', () => {
+    it('removes member with confirmation', async () => {
+      const user = userEvent.setup();
+      mockRemoveMutateAsync.mockResolvedValue({});
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+      await user.click(screen.getByRole('button', { name: /remove/i }));
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      expect(mockRemoveMutateAsync).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        userId: 'user-2',
+      });
+    });
+
+    it('cancels remove', async () => {
+      const user = userEvent.setup();
+      useUiStore.setState({ isProjectMembersOpen: true });
+      renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+      await user.click(screen.getByRole('button', { name: /remove/i }));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(mockRemoveMutateAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  it('closes on Escape key', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectMembersOpen: true });
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+    await user.keyboard('{Escape}');
+    expect(useUiStore.getState().isProjectMembersOpen).toBe(false);
+  });
+
+  it('closes on backdrop click', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectMembersOpen: true });
+    renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
+
+    await user.click(screen.getByRole('dialog'));
+    expect(useUiStore.getState().isProjectMembersOpen).toBe(false);
+  });
+});

--- a/frontend/src/components/ProjectMembersPanel.tsx
+++ b/frontend/src/components/ProjectMembersPanel.tsx
@@ -22,7 +22,7 @@ export function ProjectMembersPanel({ projectId }: { projectId: string }) {
 
 function ProjectMembersContent({ projectId }: { projectId: string }) {
   const closeProjectMembers = useUiStore((s) => s.closeProjectMembers);
-  const { data: members, isLoading } = useListMembers(projectId);
+  const { data: members, isLoading, isError } = useListMembers(projectId);
   const addMember = useAddMember();
   const updateMember = useUpdateMember();
   const removeMember = useRemoveMember();
@@ -135,6 +135,8 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
         {isLoading ? (
           <p className="text-sm text-gray-500">Loading...</p>
+        ) : isError ? (
+          <p className="text-sm text-red-500">Failed to load members.</p>
         ) : (
           <div className="space-y-3">
             {members?.map((m) => (

--- a/frontend/src/components/ProjectMembersPanel.tsx
+++ b/frontend/src/components/ProjectMembersPanel.tsx
@@ -14,11 +14,7 @@ import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { useUiStore } from '../stores/uiStore';
 
-export function ProjectMembersPanel({
-  projectId,
-}: {
-  projectId: string;
-}) {
+export function ProjectMembersPanel({ projectId }: { projectId: string }) {
   const isOpen = useUiStore((s) => s.isProjectMembersOpen);
   if (!isOpen) return null;
   return <ProjectMembersContent projectId={projectId} />;
@@ -39,9 +35,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
     id: string;
     name: string;
   } | null>(null);
-  const [inviteRole, setInviteRole] = useState<MemberRoleType>(
-    MemberRole.member,
-  );
+  const [inviteRole, setInviteRole] = useState<MemberRoleType>(MemberRole.member);
   const [removingUserId, setRemovingUserId] = useState<string | null>(null);
 
   const { data: searchResults } = useSearchUsers(
@@ -49,16 +43,10 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
     { query: { enabled: searchQuery.length >= 2 } },
   );
 
-  const currentUserRole = members?.find(
-    (m) => m.user_id === currentUser?.id,
-  )?.role;
-  const canManage =
-    currentUserRole === MemberRole.owner ||
-    currentUserRole === MemberRole.admin;
+  const currentUserRole = members?.find((m) => m.user_id === currentUser?.id)?.role;
+  const canManage = currentUserRole === MemberRole.owner || currentUserRole === MemberRole.admin;
 
-  const filteredResults = searchResults?.filter(
-    (u) => !members?.some((m) => m.user_id === u.id),
-  );
+  const filteredResults = searchResults?.filter((u) => !members?.some((m) => m.user_id === u.id));
 
   const invalidateMembers = () => {
     queryClient.invalidateQueries({
@@ -90,10 +78,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
     }
   };
 
-  const handleRoleChange = async (
-    userId: string,
-    role: MemberRoleType,
-  ) => {
+  const handleRoleChange = async (userId: string, role: MemberRoleType) => {
     try {
       await updateMember.mutateAsync({
         projectId,
@@ -119,8 +104,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
   const canManageMember = (memberRole: MemberRoleType) => {
     if (!canManage) return false;
-    if (currentUserRole === MemberRole.admin && memberRole === MemberRole.owner)
-      return false;
+    if (currentUserRole === MemberRole.admin && memberRole === MemberRole.owner) return false;
     return true;
   };
 
@@ -136,10 +120,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
     >
       <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
-          <h2
-            id="project-members-title"
-            className="text-lg font-semibold text-gray-900"
-          >
+          <h2 id="project-members-title" className="text-lg font-semibold text-gray-900">
             Members
           </h2>
           <button
@@ -162,14 +143,11 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 className="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-gray-900">
-                    {m.user_name}
-                  </p>
+                  <p className="text-sm font-medium text-gray-900">{m.user_name}</p>
                   <p className="text-xs text-gray-500">{m.user_email}</p>
                 </div>
 
-                {m.user_id === currentUser?.id ||
-                !canManageMember(m.role) ? (
+                {m.user_id === currentUser?.id || !canManageMember(m.role) ? (
                   <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
                     {m.role}
                   </span>
@@ -195,10 +173,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                     <select
                       value={m.role}
                       onChange={(e) =>
-                        handleRoleChange(
-                          m.user_id,
-                          e.target.value as MemberRoleType,
-                        )
+                        handleRoleChange(m.user_id, e.target.value as MemberRoleType)
                       }
                       className="rounded border border-gray-300 px-1 py-0.5 text-xs"
                     >
@@ -223,9 +198,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
         {canManage && (
           <div className="mt-4 border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">
-              Invite Member
-            </h3>
+            <h3 className="mb-2 text-sm font-medium text-gray-700">Invite Member</h3>
             <div className="relative">
               <input
                 type="text"
@@ -237,36 +210,30 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 placeholder="Search users by name or email..."
                 className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
               />
-              {!selectedUser &&
-                filteredResults &&
-                filteredResults.length > 0 && (
-                  <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
-                    {filteredResults.map((u) => (
-                      <button
-                        key={u.id}
-                        type="button"
-                        data-testid="search-result"
-                        onClick={() => {
-                          setSelectedUser({ id: u.id, name: u.name });
-                          setSearchQuery('');
-                        }}
-                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
-                      >
-                        <span className="font-medium">{u.name}</span>
-                        <span className="text-xs text-gray-500">
-                          {u.email}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
+              {!selectedUser && filteredResults && filteredResults.length > 0 && (
+                <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                  {filteredResults.map((u) => (
+                    <button
+                      key={u.id}
+                      type="button"
+                      data-testid="search-result"
+                      onClick={() => {
+                        setSelectedUser({ id: u.id, name: u.name });
+                        setSearchQuery('');
+                      }}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                    >
+                      <span className="font-medium">{u.name}</span>
+                      <span className="text-xs text-gray-500">{u.email}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
             <div className="mt-2 flex gap-2">
               <select
                 value={inviteRole}
-                onChange={(e) =>
-                  setInviteRole(e.target.value as MemberRoleType)
-                }
+                onChange={(e) => setInviteRole(e.target.value as MemberRoleType)}
                 className="rounded border border-gray-300 px-2 py-1.5 text-sm"
               >
                 <option value="member">member</option>

--- a/frontend/src/components/ProjectMembersPanel.tsx
+++ b/frontend/src/components/ProjectMembersPanel.tsx
@@ -1,0 +1,289 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import {
+  getListMembersQueryKey,
+  useAddMember,
+  useListMembers,
+  useRemoveMember,
+  useUpdateMember,
+} from '../api/generated/endpoints/project-members/project-members';
+import { useSearchUsers } from '../api/generated/endpoints/users/users';
+import type { MemberRole as MemberRoleType } from '../api/generated/model';
+import { MemberRole } from '../api/generated/model';
+import { useAuthStore } from '../stores/authStore';
+import { useToastStore } from '../stores/toastStore';
+import { useUiStore } from '../stores/uiStore';
+
+export function ProjectMembersPanel({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const isOpen = useUiStore((s) => s.isProjectMembersOpen);
+  if (!isOpen) return null;
+  return <ProjectMembersContent projectId={projectId} />;
+}
+
+function ProjectMembersContent({ projectId }: { projectId: string }) {
+  const closeProjectMembers = useUiStore((s) => s.closeProjectMembers);
+  const { data: members, isLoading } = useListMembers(projectId);
+  const addMember = useAddMember();
+  const updateMember = useUpdateMember();
+  const removeMember = useRemoveMember();
+  const queryClient = useQueryClient();
+  const currentUser = useAuthStore((s) => s.user);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedUser, setSelectedUser] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [inviteRole, setInviteRole] = useState<MemberRoleType>(
+    MemberRole.member,
+  );
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+
+  const { data: searchResults } = useSearchUsers(
+    { q: searchQuery, limit: 10 },
+    { query: { enabled: searchQuery.length >= 2 } },
+  );
+
+  const currentUserRole = members?.find(
+    (m) => m.user_id === currentUser?.id,
+  )?.role;
+  const canManage =
+    currentUserRole === MemberRole.owner ||
+    currentUserRole === MemberRole.admin;
+
+  const filteredResults = searchResults?.filter(
+    (u) => !members?.some((m) => m.user_id === u.id),
+  );
+
+  const invalidateMembers = () => {
+    queryClient.invalidateQueries({
+      queryKey: getListMembersQueryKey(projectId),
+    });
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeProjectMembers();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeProjectMembers]);
+
+  const handleInvite = async () => {
+    if (!selectedUser) return;
+    try {
+      await addMember.mutateAsync({
+        projectId,
+        data: { user_id: selectedUser.id, role: inviteRole },
+      });
+      invalidateMembers();
+      setSelectedUser(null);
+      setSearchQuery('');
+      addToast('success', `${selectedUser.name} added.`);
+    } catch {
+      addToast('error', 'Failed to add member.');
+    }
+  };
+
+  const handleRoleChange = async (
+    userId: string,
+    role: MemberRoleType,
+  ) => {
+    try {
+      await updateMember.mutateAsync({
+        projectId,
+        userId,
+        data: { role },
+      });
+      invalidateMembers();
+    } catch {
+      addToast('error', 'Failed to update role.');
+    }
+  };
+
+  const handleRemove = async (userId: string) => {
+    try {
+      await removeMember.mutateAsync({ projectId, userId });
+      invalidateMembers();
+      setRemovingUserId(null);
+      addToast('success', 'Member removed.');
+    } catch {
+      addToast('error', 'Failed to remove member.');
+    }
+  };
+
+  const canManageMember = (memberRole: MemberRoleType) => {
+    if (!canManage) return false;
+    if (currentUserRole === MemberRole.admin && memberRole === MemberRole.owner)
+      return false;
+    return true;
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="project-members-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeProjectMembers();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2
+            id="project-members-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Members
+          </h2>
+          <button
+            type="button"
+            onClick={closeProjectMembers}
+            className="text-gray-400 hover:text-gray-600"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-500">Loading...</p>
+        ) : (
+          <div className="space-y-3">
+            {members?.map((m) => (
+              <div
+                key={m.user_id}
+                className="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900">
+                    {m.user_name}
+                  </p>
+                  <p className="text-xs text-gray-500">{m.user_email}</p>
+                </div>
+
+                {m.user_id === currentUser?.id ||
+                !canManageMember(m.role) ? (
+                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                    {m.role}
+                  </span>
+                ) : removingUserId === m.user_id ? (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(m.user_id)}
+                      className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setRemovingUserId(null)}
+                      className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={m.role}
+                      onChange={(e) =>
+                        handleRoleChange(
+                          m.user_id,
+                          e.target.value as MemberRoleType,
+                        )
+                      }
+                      className="rounded border border-gray-300 px-1 py-0.5 text-xs"
+                    >
+                      <option value="owner">owner</option>
+                      <option value="admin">admin</option>
+                      <option value="member">member</option>
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => setRemovingUserId(m.user_id)}
+                      className="text-xs text-gray-400 hover:text-red-600"
+                      aria-label="Remove"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {canManage && (
+          <div className="mt-4 border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium text-gray-700">
+              Invite Member
+            </h3>
+            <div className="relative">
+              <input
+                type="text"
+                value={selectedUser ? selectedUser.name : searchQuery}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  setSelectedUser(null);
+                }}
+                placeholder="Search users by name or email..."
+                className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              />
+              {!selectedUser &&
+                filteredResults &&
+                filteredResults.length > 0 && (
+                  <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                    {filteredResults.map((u) => (
+                      <button
+                        key={u.id}
+                        type="button"
+                        data-testid="search-result"
+                        onClick={() => {
+                          setSelectedUser({ id: u.id, name: u.name });
+                          setSearchQuery('');
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                      >
+                        <span className="font-medium">{u.name}</span>
+                        <span className="text-xs text-gray-500">
+                          {u.email}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+            </div>
+            <div className="mt-2 flex gap-2">
+              <select
+                value={inviteRole}
+                onChange={(e) =>
+                  setInviteRole(e.target.value as MemberRoleType)
+                }
+                className="rounded border border-gray-300 px-2 py-1.5 text-sm"
+              >
+                <option value="member">member</option>
+                <option value="admin">admin</option>
+              </select>
+              <button
+                type="button"
+                onClick={handleInvite}
+                disabled={!selectedUser || addMember.isPending}
+                className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectSettingsModal.test.tsx
+++ b/frontend/src/components/ProjectSettingsModal.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../api/generated/endpoints/projects/projects', () => ({
   useUpdateProject: vi.fn(),
   useDeleteProject: vi.fn(),
   getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
+  getGetProjectQueryKey: vi.fn((id: string) => ['/api/projects', id]),
 }));
 
 vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
@@ -236,6 +237,34 @@ describe('ProjectSettingsModal', () => {
     await user.click(screen.getByRole('button', { name: /cancel/i }));
 
     expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+  });
+
+  describe('member permissions (read-only)', () => {
+    beforeEach(() => {
+      vi.mocked(membersApi.useListMembers).mockReturnValue({
+        data: [{ ...mockMembers[0], role: MemberRole.member }],
+        isLoading: false,
+      } as unknown as ReturnType<typeof membersApi.useListMembers>);
+    });
+
+    it('does not allow editing name for member role', () => {
+      useUiStore.setState({ isProjectSettingsOpen: true });
+      renderWithProviders(
+        <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
+      );
+      // Name should be displayed as static text, not a clickable button
+      expect(screen.getByText('Test Project')).toBeInTheDocument();
+      expect(screen.getByText('Test Project').tagName).toBe('P');
+    });
+
+    it('does not allow editing description for member role', () => {
+      useUiStore.setState({ isProjectSettingsOpen: true });
+      renderWithProviders(
+        <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
+      );
+      expect(screen.getByText('Test description')).toBeInTheDocument();
+      expect(screen.getByText('Test description').tagName).toBe('P');
+    });
   });
 
   it('closes on Escape key', async () => {

--- a/frontend/src/components/ProjectSettingsModal.test.tsx
+++ b/frontend/src/components/ProjectSettingsModal.test.tsx
@@ -1,0 +1,311 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as membersApi from '../api/generated/endpoints/project-members/project-members';
+import * as projectsApi from '../api/generated/endpoints/projects/projects';
+import type { Project, ProjectMember } from '../api/generated/model';
+import { MemberRole } from '../api/generated/model';
+import { useAuthStore } from '../stores/authStore';
+import { useUiStore } from '../stores/uiStore';
+import { ProjectSettingsModal } from './ProjectSettingsModal';
+
+vi.mock('../api/generated/endpoints/projects/projects', () => ({
+  useGetProject: vi.fn(),
+  useUpdateProject: vi.fn(),
+  useDeleteProject: vi.fn(),
+  getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
+}));
+
+vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
+}));
+
+const mockProject: Project = {
+  id: 'project-1',
+  name: 'Test Project',
+  description: 'Test description',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const mockMembers: ProjectMember[] = [
+  {
+    user_id: 'user-1',
+    user_name: 'Alice',
+    user_email: 'alice@test.com',
+    role: MemberRole.owner,
+    project_id: 'project-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe('ProjectSettingsModal', () => {
+  const mockOnProjectDeleted = vi.fn();
+  const mockUpdateMutateAsync = vi.fn();
+  const mockDeleteMutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useAuthStore.setState({
+      user: {
+        id: 'user-1',
+        email: 'alice@test.com',
+        name: 'Alice',
+        created_at: '',
+        updated_at: '',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    useUiStore.setState({
+      isProjectSettingsOpen: false,
+    });
+
+    vi.mocked(projectsApi.useGetProject).mockReturnValue({
+      data: mockProject,
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof projectsApi.useGetProject>);
+
+    vi.mocked(projectsApi.useUpdateProject).mockReturnValue({
+      mutateAsync: mockUpdateMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useUpdateProject>);
+
+    vi.mocked(projectsApi.useDeleteProject).mockReturnValue({
+      mutateAsync: mockDeleteMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof projectsApi.useDeleteProject>);
+
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: mockMembers,
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
+  });
+
+  it('does not render when modal is closed', () => {
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders when modal is open', () => {
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('displays project name', () => {
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(screen.getByText('Test Project')).toBeInTheDocument();
+  });
+
+  it('displays project description', () => {
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('enters name edit mode on click', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByText('Test Project'));
+    expect(screen.getByDisplayValue('Test Project')).toBeInTheDocument();
+  });
+
+  it('saves name on blur', async () => {
+    const user = userEvent.setup();
+    mockUpdateMutateAsync.mockResolvedValue({});
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByText('Test Project'));
+    const input = screen.getByDisplayValue('Test Project');
+    await user.clear(input);
+    await user.type(input, 'Updated Name');
+    await user.tab();
+
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      id: 'project-1',
+      data: { name: 'Updated Name' },
+    });
+  });
+
+  it('does not save empty name', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByText('Test Project'));
+    const input = screen.getByDisplayValue('Test Project');
+    await user.clear(input);
+    await user.tab();
+
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('saves description on blur', async () => {
+    const user = userEvent.setup();
+    mockUpdateMutateAsync.mockResolvedValue({});
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByText('Test description'));
+    const textarea = screen.getByDisplayValue('Test description');
+    await user.clear(textarea);
+    await user.type(textarea, 'Updated desc');
+    await user.tab();
+
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      id: 'project-1',
+      data: { description: 'Updated desc' },
+    });
+  });
+
+  it('shows delete button for owner', () => {
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /delete project/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show delete button for non-owner', () => {
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: [{ ...mockMembers[0], role: MemberRole.member }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /delete project/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('deletes project on confirm', async () => {
+    const user = userEvent.setup();
+    mockDeleteMutateAsync.mockResolvedValue({});
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete project/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ id: 'project-1' });
+    expect(mockOnProjectDeleted).toHaveBeenCalled();
+  });
+
+  it('cancels delete', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete project/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape key', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.keyboard('{Escape}');
+    expect(useUiStore.getState().isProjectSettingsOpen).toBe(false);
+  });
+
+  it('closes on backdrop click', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({ isProjectSettingsOpen: true });
+    renderWithProviders(
+      <ProjectSettingsModal
+        projectId="project-1"
+        onProjectDeleted={mockOnProjectDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole('dialog'));
+    expect(useUiStore.getState().isProjectSettingsOpen).toBe(false);
+  });
+});

--- a/frontend/src/components/ProjectSettingsModal.test.tsx
+++ b/frontend/src/components/ProjectSettingsModal.test.tsx
@@ -40,14 +40,11 @@ const mockMembers: ProjectMember[] = [
   },
 ];
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (ui: React.ReactElement) => {
   const queryClient = createQueryClient();
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-  );
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 };
 
 describe('ProjectSettingsModal', () => {
@@ -98,10 +95,7 @@ describe('ProjectSettingsModal', () => {
 
   it('does not render when modal is closed', () => {
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -109,10 +103,7 @@ describe('ProjectSettingsModal', () => {
   it('renders when modal is open', () => {
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
@@ -120,10 +111,7 @@ describe('ProjectSettingsModal', () => {
   it('displays project name', () => {
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
     expect(screen.getByText('Test Project')).toBeInTheDocument();
   });
@@ -131,10 +119,7 @@ describe('ProjectSettingsModal', () => {
   it('displays project description', () => {
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
     expect(screen.getByText('Test description')).toBeInTheDocument();
   });
@@ -143,10 +128,7 @@ describe('ProjectSettingsModal', () => {
     const user = userEvent.setup();
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByText('Test Project'));
@@ -158,10 +140,7 @@ describe('ProjectSettingsModal', () => {
     mockUpdateMutateAsync.mockResolvedValue({});
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByText('Test Project'));
@@ -180,10 +159,7 @@ describe('ProjectSettingsModal', () => {
     const user = userEvent.setup();
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByText('Test Project'));
@@ -199,10 +175,7 @@ describe('ProjectSettingsModal', () => {
     mockUpdateMutateAsync.mockResolvedValue({});
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByText('Test description'));
@@ -220,14 +193,9 @@ describe('ProjectSettingsModal', () => {
   it('shows delete button for owner', () => {
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
-    expect(
-      screen.getByRole('button', { name: /delete project/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete project/i })).toBeInTheDocument();
   });
 
   it('does not show delete button for non-owner', () => {
@@ -237,14 +205,9 @@ describe('ProjectSettingsModal', () => {
     } as unknown as ReturnType<typeof membersApi.useListMembers>);
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
-    expect(
-      screen.queryByRole('button', { name: /delete project/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete project/i })).not.toBeInTheDocument();
   });
 
   it('deletes project on confirm', async () => {
@@ -252,10 +215,7 @@ describe('ProjectSettingsModal', () => {
     mockDeleteMutateAsync.mockResolvedValue({});
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByRole('button', { name: /delete project/i }));
@@ -269,10 +229,7 @@ describe('ProjectSettingsModal', () => {
     const user = userEvent.setup();
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByRole('button', { name: /delete project/i }));
@@ -285,10 +242,7 @@ describe('ProjectSettingsModal', () => {
     const user = userEvent.setup();
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.keyboard('{Escape}');
@@ -299,10 +253,7 @@ describe('ProjectSettingsModal', () => {
     const user = userEvent.setup();
     useUiStore.setState({ isProjectSettingsOpen: true });
     renderWithProviders(
-      <ProjectSettingsModal
-        projectId="project-1"
-        onProjectDeleted={mockOnProjectDeleted}
-      />,
+      <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
     await user.click(screen.getByRole('dialog'));

--- a/frontend/src/components/ProjectSettingsModal.tsx
+++ b/frontend/src/components/ProjectSettingsModal.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import {
+  getGetProjectQueryKey,
   getListProjectsQueryKey,
   useDeleteProject,
   useGetProject,
@@ -45,6 +46,7 @@ function ProjectSettingsContent({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const currentUserRole = members?.find((m) => m.user_id === currentUser?.id)?.role;
+  const canEdit = currentUserRole === MemberRole.owner || currentUserRole === MemberRole.admin;
   const isOwner = currentUserRole === MemberRole.owner;
 
   useEffect(() => {
@@ -81,6 +83,9 @@ function ProjectSettingsContent({
         });
         queryClient.invalidateQueries({
           queryKey: getListProjectsQueryKey(),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getGetProjectQueryKey(projectId),
         });
         addToast('success', `Project ${field} updated.`);
       }
@@ -147,7 +152,7 @@ function ProjectSettingsContent({
                   className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   autoFocus
                 />
-              ) : (
+              ) : canEdit ? (
                 <button
                   type="button"
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-900 hover:bg-gray-100"
@@ -155,6 +160,8 @@ function ProjectSettingsContent({
                 >
                   {project.name}
                 </button>
+              ) : (
+                <p className="mt-1 px-1 text-sm text-gray-900">{project.name}</p>
               )}
             </div>
 
@@ -169,7 +176,7 @@ function ProjectSettingsContent({
                   className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   autoFocus
                 />
-              ) : (
+              ) : canEdit ? (
                 <button
                   type="button"
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
@@ -177,6 +184,10 @@ function ProjectSettingsContent({
                 >
                   {project.description || 'No description'}
                 </button>
+              ) : (
+                <p className="mt-1 px-1 text-sm text-gray-600">
+                  {project.description || 'No description'}
+                </p>
               )}
             </div>
 

--- a/frontend/src/components/ProjectSettingsModal.tsx
+++ b/frontend/src/components/ProjectSettingsModal.tsx
@@ -1,8 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import {
-  useListMembers,
-} from '../api/generated/endpoints/project-members/project-members';
+import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import {
   getListProjectsQueryKey,
   useDeleteProject,
@@ -23,12 +21,7 @@ export function ProjectSettingsModal({
 }) {
   const isOpen = useUiStore((s) => s.isProjectSettingsOpen);
   if (!isOpen) return null;
-  return (
-    <ProjectSettingsContent
-      projectId={projectId}
-      onProjectDeleted={onProjectDeleted}
-    />
-  );
+  return <ProjectSettingsContent projectId={projectId} onProjectDeleted={onProjectDeleted} />;
 }
 
 function ProjectSettingsContent({
@@ -47,15 +40,11 @@ function ProjectSettingsContent({
   const currentUser = useAuthStore((s) => s.user);
   const addToast = useToastStore((s) => s.addToast);
 
-  const [editingField, setEditingField] = useState<
-    'name' | 'description' | null
-  >(null);
+  const [editingField, setEditingField] = useState<'name' | 'description' | null>(null);
   const [editValue, setEditValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const currentUserRole = members?.find(
-    (m) => m.user_id === currentUser?.id,
-  )?.role;
+  const currentUserRole = members?.find((m) => m.user_id === currentUser?.id)?.role;
   const isOwner = currentUserRole === MemberRole.owner;
 
   useEffect(() => {
@@ -83,8 +72,7 @@ function ProjectSettingsContent({
       setEditingField(null);
       return;
     }
-    const currentValue =
-      field === 'name' ? project?.name : project?.description;
+    const currentValue = field === 'name' ? project?.name : project?.description;
     try {
       if (trimmed !== (currentValue ?? '')) {
         await updateProject.mutateAsync({
@@ -129,10 +117,7 @@ function ProjectSettingsContent({
     >
       <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
-          <h2
-            id="project-settings-title"
-            className="text-lg font-semibold text-gray-900"
-          >
+          <h2 id="project-settings-title" className="text-lg font-semibold text-gray-900">
             Project Settings
           </h2>
           <button
@@ -188,9 +173,7 @@ function ProjectSettingsContent({
                 <button
                   type="button"
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
-                  onClick={() =>
-                    startEditing('description', project.description ?? '')
-                  }
+                  onClick={() => startEditing('description', project.description ?? '')}
                 >
                   {project.description || 'No description'}
                 </button>
@@ -201,9 +184,7 @@ function ProjectSettingsContent({
               <div className="border-t pt-4">
                 {showDeleteConfirm ? (
                   <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
-                    <p className="text-sm text-red-700">
-                      Are you sure? This cannot be undone.
-                    </p>
+                    <p className="text-sm text-red-700">Are you sure? This cannot be undone.</p>
                     <div className="flex gap-2">
                       <button
                         type="button"

--- a/frontend/src/components/ProjectSettingsModal.tsx
+++ b/frontend/src/components/ProjectSettingsModal.tsx
@@ -1,0 +1,240 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import {
+  useListMembers,
+} from '../api/generated/endpoints/project-members/project-members';
+import {
+  getListProjectsQueryKey,
+  useDeleteProject,
+  useGetProject,
+  useUpdateProject,
+} from '../api/generated/endpoints/projects/projects';
+import { MemberRole } from '../api/generated/model';
+import { useAuthStore } from '../stores/authStore';
+import { useToastStore } from '../stores/toastStore';
+import { useUiStore } from '../stores/uiStore';
+
+export function ProjectSettingsModal({
+  projectId,
+  onProjectDeleted,
+}: {
+  projectId: string;
+  onProjectDeleted: () => void;
+}) {
+  const isOpen = useUiStore((s) => s.isProjectSettingsOpen);
+  if (!isOpen) return null;
+  return (
+    <ProjectSettingsContent
+      projectId={projectId}
+      onProjectDeleted={onProjectDeleted}
+    />
+  );
+}
+
+function ProjectSettingsContent({
+  projectId,
+  onProjectDeleted,
+}: {
+  projectId: string;
+  onProjectDeleted: () => void;
+}) {
+  const closeProjectSettings = useUiStore((s) => s.closeProjectSettings);
+  const { data: project, isLoading, isError } = useGetProject(projectId);
+  const { data: members } = useListMembers(projectId);
+  const updateProject = useUpdateProject();
+  const deleteProject = useDeleteProject();
+  const queryClient = useQueryClient();
+  const currentUser = useAuthStore((s) => s.user);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [editingField, setEditingField] = useState<
+    'name' | 'description' | null
+  >(null);
+  const [editValue, setEditValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const currentUserRole = members?.find(
+    (m) => m.user_id === currentUser?.id,
+  )?.role;
+  const isOwner = currentUserRole === MemberRole.owner;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (editingField) {
+          setEditingField(null);
+        } else {
+          closeProjectSettings();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeProjectSettings, editingField]);
+
+  const startEditing = (field: 'name' | 'description', value: string) => {
+    setEditingField(field);
+    setEditValue(value);
+  };
+
+  const saveField = async (field: 'name' | 'description') => {
+    const trimmed = editValue.trim();
+    if (field === 'name' && !trimmed) {
+      setEditingField(null);
+      return;
+    }
+    const currentValue =
+      field === 'name' ? project?.name : project?.description;
+    try {
+      if (trimmed !== (currentValue ?? '')) {
+        await updateProject.mutateAsync({
+          id: projectId,
+          data: { [field]: trimmed },
+        });
+        queryClient.invalidateQueries({
+          queryKey: getListProjectsQueryKey(),
+        });
+        addToast('success', `Project ${field} updated.`);
+      }
+    } catch {
+      addToast('error', `Failed to update ${field}.`);
+    } finally {
+      setEditingField(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteProject.mutateAsync({ id: projectId });
+      queryClient.invalidateQueries({
+        queryKey: getListProjectsQueryKey(),
+      });
+      closeProjectSettings();
+      onProjectDeleted();
+      addToast('success', 'Project deleted.');
+    } catch {
+      addToast('error', 'Failed to delete project.');
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="project-settings-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeProjectSettings();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2
+            id="project-settings-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Project Settings
+          </h2>
+          <button
+            type="button"
+            onClick={closeProjectSettings}
+            className="text-gray-400 hover:text-gray-600"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-500">Loading...</p>
+        ) : isError || !project ? (
+          <p className="text-sm text-red-500">Failed to load project.</p>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-sm font-medium text-gray-700">Name</h3>
+              {editingField === 'name' ? (
+                <input
+                  type="text"
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={() => saveField('name')}
+                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-900 hover:bg-gray-100"
+                  onClick={() => startEditing('name', project.name)}
+                >
+                  {project.name}
+                </button>
+              )}
+            </div>
+
+            <div>
+              <h3 className="text-sm font-medium text-gray-700">Description</h3>
+              {editingField === 'description' ? (
+                <textarea
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onBlur={() => saveField('description')}
+                  rows={3}
+                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  autoFocus
+                />
+              ) : (
+                <button
+                  type="button"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                  onClick={() =>
+                    startEditing('description', project.description ?? '')
+                  }
+                >
+                  {project.description || 'No description'}
+                </button>
+              )}
+            </div>
+
+            {isOwner && (
+              <div className="border-t pt-4">
+                {showDeleteConfirm ? (
+                  <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
+                    <p className="text-sm text-red-700">
+                      Are you sure? This cannot be undone.
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setShowDeleteConfirm(false)}
+                        className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleDelete}
+                        className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+                      >
+                        Confirm
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
+                  >
+                    Delete Project
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stores/uiStore.test.ts
+++ b/frontend/src/stores/uiStore.test.ts
@@ -12,6 +12,8 @@ describe('uiStore', () => {
       isProjectModalOpen: false,
       selectedTaskId: null,
       isTaskDetailOpen: false,
+      isProjectSettingsOpen: false,
+      isProjectMembersOpen: false,
     });
   });
 
@@ -83,6 +85,40 @@ describe('uiStore', () => {
       useUiStore.getState().openProjectModal();
       useUiStore.getState().closeProjectModal();
       expect(useUiStore.getState().isProjectModalOpen).toBe(false);
+    });
+  });
+
+  describe('project settings modal', () => {
+    it('has correct initial state', () => {
+      expect(useUiStore.getState().isProjectSettingsOpen).toBe(false);
+    });
+
+    it('opens project settings modal', () => {
+      useUiStore.getState().openProjectSettings();
+      expect(useUiStore.getState().isProjectSettingsOpen).toBe(true);
+    });
+
+    it('closes project settings modal', () => {
+      useUiStore.getState().openProjectSettings();
+      useUiStore.getState().closeProjectSettings();
+      expect(useUiStore.getState().isProjectSettingsOpen).toBe(false);
+    });
+  });
+
+  describe('project members panel', () => {
+    it('has correct initial state', () => {
+      expect(useUiStore.getState().isProjectMembersOpen).toBe(false);
+    });
+
+    it('opens project members panel', () => {
+      useUiStore.getState().openProjectMembers();
+      expect(useUiStore.getState().isProjectMembersOpen).toBe(true);
+    });
+
+    it('closes project members panel', () => {
+      useUiStore.getState().openProjectMembers();
+      useUiStore.getState().closeProjectMembers();
+      expect(useUiStore.getState().isProjectMembersOpen).toBe(false);
     });
   });
 });

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -14,6 +14,12 @@ interface UiState {
   isProjectModalOpen: boolean;
   openProjectModal: () => void;
   closeProjectModal: () => void;
+  isProjectSettingsOpen: boolean;
+  openProjectSettings: () => void;
+  closeProjectSettings: () => void;
+  isProjectMembersOpen: boolean;
+  openProjectMembers: () => void;
+  closeProjectMembers: () => void;
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -29,4 +35,10 @@ export const useUiStore = create<UiState>((set) => ({
   isProjectModalOpen: false,
   openProjectModal: () => set({ isProjectModalOpen: true }),
   closeProjectModal: () => set({ isProjectModalOpen: false }),
+  isProjectSettingsOpen: false,
+  openProjectSettings: () => set({ isProjectSettingsOpen: true }),
+  closeProjectSettings: () => set({ isProjectSettingsOpen: false }),
+  isProjectMembersOpen: false,
+  openProjectMembers: () => set({ isProjectMembersOpen: true }),
+  closeProjectMembers: () => set({ isProjectMembersOpen: false }),
 }));


### PR DESCRIPTION
## Summary
- Add ProjectSettingsModal with inline editing for name/description and owner-only project deletion (#122)
- Add ProjectMembersPanel with member list, invite flow, role management, and remove with confirmation (#121)
- Extend uiStore with open/close state for both modals
- Integrate Settings and Members buttons into App header (shown when a project is selected)

## Changes
| File | Description |
|------|-------------|
| `uiStore.ts` | Add `isProjectSettingsOpen` / `isProjectMembersOpen` state |
| `ProjectSettingsModal.tsx` | Inline edit name/description, owner-only delete with double confirm |
| `ProjectMembersPanel.tsx` | Member list, user search + invite, role change, remove with confirm |
| `App.tsx` | Add Settings/Members buttons + render modals |

## Test plan
- [x] uiStore: 6 new tests (open/close for settings and members)
- [x] ProjectSettingsModal: 14 tests (render, edit, delete, permissions, close)
- [x] ProjectMembersPanel: 17 tests (list, permissions, invite, role change, remove, close)
- [x] App.test.tsx: Updated with project-members and users API mocks
- [x] All 195 tests pass
- [x] Biome check passes

Closes #121, closes #122