### PR TITLE
feat: ✨ add assignee, filtering, and timeline (#124, #126, #128)

### DIFF
--- a/frontend/src/components/KanbanBoard.test.tsx
+++ b/frontend/src/components/KanbanBoard.test.tsx
@@ -5,6 +5,7 @@ import * as membersApi from '../api/generated/endpoints/project-members/project-
 import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
 import type { Task } from '../api/generated/model';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useBoardStore } from '../stores/boardStore';
 import { KanbanBoard } from './KanbanBoard';
 
 vi.mock('../api/generated/endpoints/tasks/tasks', () => ({
@@ -45,6 +46,7 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('KanbanBoard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useBoardStore.getState().clearFilters();
     vi.mocked(membersApi.useListMembers).mockReturnValue({
       data: [],
       isLoading: false,
@@ -121,5 +123,76 @@ describe('KanbanBoard', () => {
     renderWithProviders(<KanbanBoard projectId="project-1" />);
 
     expect(screen.getByTestId('kanban-error')).toBeInTheDocument();
+  });
+
+  describe('filtering', () => {
+    const allTasks = [
+      createMockTask({ id: 't1', title: 'Fix login bug', status: TaskStatus.todo, priority: TaskPriority.high, assigned_to: 'user-1' }),
+      createMockTask({ id: 't2', title: 'Add dashboard', status: TaskStatus.todo, priority: TaskPriority.medium, assigned_to: 'user-2' }),
+      createMockTask({ id: 't3', title: 'Setup CI', status: TaskStatus.in_progress, priority: TaskPriority.low }),
+    ];
+
+    beforeEach(() => {
+      vi.mocked(tasksApi.useListTasks).mockReturnValue({
+        data: { data: allTasks, total: allTasks.length, limit: 50, offset: 0 },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof tasksApi.useListTasks>);
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutate: vi.fn(),
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+    });
+
+    it('filters by search text (title match)', () => {
+      useBoardStore.getState().setSearchText('login');
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+
+      expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+      expect(screen.queryByText('Add dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByText('Setup CI')).not.toBeInTheDocument();
+    });
+
+    it('filters by assignee', () => {
+      useBoardStore.getState().setAssigneeFilter(['user-1']);
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+
+      expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+      expect(screen.queryByText('Add dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByText('Setup CI')).not.toBeInTheDocument();
+    });
+
+    it('filters unassigned tasks', () => {
+      useBoardStore.getState().setAssigneeFilter(['unassigned']);
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+
+      expect(screen.queryByText('Fix login bug')).not.toBeInTheDocument();
+      expect(screen.queryByText('Add dashboard')).not.toBeInTheDocument();
+      expect(screen.getByText('Setup CI')).toBeInTheDocument();
+    });
+
+    it('filters by priority', () => {
+      useBoardStore.getState().setPriorityFilter([TaskPriority.high]);
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+
+      expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+      expect(screen.queryByText('Add dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByText('Setup CI')).not.toBeInTheDocument();
+    });
+
+    it('applies AND combination of multiple filters', () => {
+      useBoardStore.getState().setSearchText('bug');
+      useBoardStore.getState().setAssigneeFilter(['user-1']);
+      useBoardStore.getState().setPriorityFilter([TaskPriority.high]);
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+
+      expect(screen.getByText('Fix login bug')).toBeInTheDocument();
+      expect(screen.queryByText('Add dashboard')).not.toBeInTheDocument();
+      expect(screen.queryByText('Setup CI')).not.toBeInTheDocument();
+    });
+
+    it('renders TaskFilterBar', () => {
+      renderWithProviders(<KanbanBoard projectId="project-1" />);
+      expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/KanbanBoard.test.tsx
+++ b/frontend/src/components/KanbanBoard.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as membersApi from '../api/generated/endpoints/project-members/project-members';
 import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
 import type { Task } from '../api/generated/model';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
@@ -9,6 +10,10 @@ import { KanbanBoard } from './KanbanBoard';
 vi.mock('../api/generated/endpoints/tasks/tasks', () => ({
   useListTasks: vi.fn(),
   useUpdateTask: vi.fn(),
+}));
+
+vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
 }));
 
 const createMockTask = (overrides: Partial<Task> = {}): Task => ({
@@ -40,6 +45,10 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('KanbanBoard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
   });
 
   it('renders all status columns', () => {

--- a/frontend/src/components/KanbanBoard.test.tsx
+++ b/frontend/src/components/KanbanBoard.test.tsx
@@ -127,9 +127,26 @@ describe('KanbanBoard', () => {
 
   describe('filtering', () => {
     const allTasks = [
-      createMockTask({ id: 't1', title: 'Fix login bug', status: TaskStatus.todo, priority: TaskPriority.high, assigned_to: 'user-1' }),
-      createMockTask({ id: 't2', title: 'Add dashboard', status: TaskStatus.todo, priority: TaskPriority.medium, assigned_to: 'user-2' }),
-      createMockTask({ id: 't3', title: 'Setup CI', status: TaskStatus.in_progress, priority: TaskPriority.low }),
+      createMockTask({
+        id: 't1',
+        title: 'Fix login bug',
+        status: TaskStatus.todo,
+        priority: TaskPriority.high,
+        assigned_to: 'user-1',
+      }),
+      createMockTask({
+        id: 't2',
+        title: 'Add dashboard',
+        status: TaskStatus.todo,
+        priority: TaskPriority.medium,
+        assigned_to: 'user-2',
+      }),
+      createMockTask({
+        id: 't3',
+        title: 'Setup CI',
+        status: TaskStatus.in_progress,
+        priority: TaskPriority.low,
+      }),
     ];
 
     beforeEach(() => {

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -188,7 +188,9 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           />
         ))}
       </div>
-      <DragOverlay>{activeTask ? <TaskCard task={activeTask} members={members} /> : null}</DragOverlay>
+      <DragOverlay>
+        {activeTask ? <TaskCard task={activeTask} members={members} /> : null}
+      </DragOverlay>
     </DndContext>
   );
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@dnd-kit/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
+import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import {
   getListTasksQueryKey,
   useListTasks,
@@ -35,6 +36,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const queryClient = useQueryClient();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const { data: tasksResponse, isLoading, error } = useListTasks({ project_id: projectId });
+  const { data: members } = useListMembers(projectId);
   const tasks = tasksResponse?.data;
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
@@ -157,10 +159,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             status={status}
             tasks={tasksByStatus[status]}
             activeTaskId={activeTask?.id}
+            members={members}
           />
         ))}
       </div>
-      <DragOverlay>{activeTask ? <TaskCard task={activeTask} /> : null}</DragOverlay>
+      <DragOverlay>{activeTask ? <TaskCard task={activeTask} members={members} /> : null}</DragOverlay>
     </DndContext>
   );
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -17,8 +17,10 @@ import {
 } from '../api/generated/endpoints/tasks/tasks';
 import type { PaginatedResponseTask, Task } from '../api/generated/model';
 import { TaskStatus } from '../api/generated/model';
+import { useBoardStore } from '../stores/boardStore';
 import { KanbanColumn } from './KanbanColumn';
 import { TaskCard } from './TaskCard';
+import { TaskFilterBar } from './TaskFilterBar';
 
 interface KanbanBoardProps {
   projectId: string;
@@ -38,6 +40,9 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const { data: tasksResponse, isLoading, error } = useListTasks({ project_id: projectId });
   const { data: members } = useListMembers(projectId);
   const tasks = tasksResponse?.data;
+  const searchText = useBoardStore((s) => s.searchText);
+  const assigneeFilter = useBoardStore((s) => s.assigneeFilter);
+  const priorityFilter = useBoardStore((s) => s.priorityFilter);
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
 
@@ -88,6 +93,25 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     },
   });
 
+  const filteredTasks = useMemo(() => {
+    if (!tasks) return [];
+    return tasks.filter((task) => {
+      if (searchText && !task.title.toLowerCase().includes(searchText.toLowerCase())) {
+        return false;
+      }
+      if (assigneeFilter.length > 0) {
+        const isUnassigned = !task.assigned_to;
+        const matchesAssignee = assigneeFilter.includes(task.assigned_to ?? '');
+        const matchesUnassigned = assigneeFilter.includes('unassigned') && isUnassigned;
+        if (!matchesAssignee && !matchesUnassigned) return false;
+      }
+      if (priorityFilter.length > 0 && !priorityFilter.includes(task.priority)) {
+        return false;
+      }
+      return true;
+    });
+  }, [tasks, searchText, assigneeFilter, priorityFilter]);
+
   const tasksByStatus = useMemo(() => {
     const grouped: Record<TaskStatus, Task[]> = {
       [TaskStatus.backlog]: [],
@@ -97,14 +121,12 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       [TaskStatus.done]: [],
     };
 
-    if (tasks) {
-      for (const task of tasks) {
-        grouped[task.status].push(task);
-      }
+    for (const task of filteredTasks) {
+      grouped[task.status].push(task);
     }
 
     return grouped;
-  }, [tasks]);
+  }, [filteredTasks]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const task = event.active.data.current?.task as Task | undefined;
@@ -152,6 +174,9 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
   return (
     <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className="px-4 pt-4">
+        <TaskFilterBar members={members} />
+      </div>
       <div className="flex gap-4 overflow-x-auto p-4">
         {COLUMN_ORDER.map((status) => (
           <KanbanColumn

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,5 +1,5 @@
 import { useDroppable } from '@dnd-kit/core';
-import type { Task } from '../api/generated/model';
+import type { ProjectMember, Task } from '../api/generated/model';
 import { TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 import { TaskCard } from './TaskCard';
@@ -8,6 +8,7 @@ interface KanbanColumnProps {
   status: TaskStatus;
   tasks: Task[];
   activeTaskId?: string | null;
+  members?: ProjectMember[];
 }
 
 const statusLabels: Record<TaskStatus, string> = {
@@ -18,7 +19,7 @@ const statusLabels: Record<TaskStatus, string> = {
   [TaskStatus.done]: 'Done',
 };
 
-export function KanbanColumn({ status, tasks, activeTaskId }: KanbanColumnProps) {
+export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanColumnProps) {
   const openTaskModal = useUiStore((s) => s.openTaskModal);
   const { setNodeRef, isOver } = useDroppable({
     id: status,
@@ -46,7 +47,7 @@ export function KanbanColumn({ status, tasks, activeTaskId }: KanbanColumnProps)
           </div>
         ) : (
           tasks.map((task) => (
-            <TaskCard key={task.id} task={task} isDragging={activeTaskId === task.id} />
+            <TaskCard key={task.id} task={task} isDragging={activeTaskId === task.id} members={members} />
           ))
         )}
       </div>

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -47,7 +47,12 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
           </div>
         ) : (
           tasks.map((task) => (
-            <TaskCard key={task.id} task={task} isDragging={activeTaskId === task.id} members={members} />
+            <TaskCard
+              key={task.id}
+              task={task}
+              isDragging={activeTaskId === task.id}
+              members={members}
+            />
           ))
         )}
       </div>

--- a/frontend/src/components/TaskCard.test.tsx
+++ b/frontend/src/components/TaskCard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { Task } from '../api/generated/model';
-import { TaskPriority, TaskStatus } from '../api/generated/model';
+import type { ProjectMember, Task } from '../api/generated/model';
+import { MemberRole, TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 import { TaskCard } from './TaskCard';
 
@@ -104,5 +104,73 @@ describe('TaskCard', () => {
 
     const card = screen.getByText('Test Task').closest('[data-testid="task-card"]');
     expect(card).toHaveClass('cursor-pointer');
+  });
+
+  describe('assignee display', () => {
+    const mockMembers: ProjectMember[] = [
+      {
+        user_id: 'user-1',
+        user_name: 'Alice Smith',
+        user_email: 'alice@test.com',
+        role: MemberRole.owner,
+        project_id: 'project-1',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        user_id: 'user-2',
+        user_name: 'Bob',
+        user_email: 'bob@test.com',
+        role: MemberRole.member,
+        project_id: 'project-1',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    it('displays assignee initials when assigned_to is set', () => {
+      const task = createMockTask({ assigned_to: 'user-1' });
+      render(<TaskCard task={task} members={mockMembers} />);
+
+      const avatar = screen.getByTestId('assignee-avatar');
+      expect(avatar).toBeInTheDocument();
+      expect(avatar).toHaveTextContent('AS');
+    });
+
+    it('does not display assignee when assigned_to is null', () => {
+      const task = createMockTask({ assigned_to: null });
+      render(<TaskCard task={task} members={mockMembers} />);
+
+      expect(screen.queryByTestId('assignee-avatar')).not.toBeInTheDocument();
+    });
+
+    it('does not display assignee when assigned_to is undefined', () => {
+      const task = createMockTask();
+      render(<TaskCard task={task} members={mockMembers} />);
+
+      expect(screen.queryByTestId('assignee-avatar')).not.toBeInTheDocument();
+    });
+
+    it('shows single initial for single-word name', () => {
+      const task = createMockTask({ assigned_to: 'user-2' });
+      render(<TaskCard task={task} members={mockMembers} />);
+
+      const avatar = screen.getByTestId('assignee-avatar');
+      expect(avatar).toHaveTextContent('B');
+    });
+
+    it('shows fallback when member not found', () => {
+      const task = createMockTask({ assigned_to: 'unknown-user' });
+      render(<TaskCard task={task} members={mockMembers} />);
+
+      const avatar = screen.getByTestId('assignee-avatar');
+      expect(avatar).toHaveTextContent('?');
+    });
+
+    it('does not crash when members is undefined', () => {
+      const task = createMockTask({ assigned_to: 'user-1' });
+      render(<TaskCard task={task} />);
+
+      const avatar = screen.getByTestId('assignee-avatar');
+      expect(avatar).toHaveTextContent('?');
+    });
   });
 });

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,12 +1,23 @@
 import { useDraggable } from '@dnd-kit/core';
 import { useRef } from 'react';
-import type { Task } from '../api/generated/model';
+import type { ProjectMember, Task } from '../api/generated/model';
 import { TaskPriority } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 
 interface TaskCardProps {
   task: Task;
   isDragging?: boolean;
+  members?: ProjectMember[];
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
 }
 
 const CLICK_THRESHOLD = 5;
@@ -18,7 +29,7 @@ const priorityStyles: Record<TaskPriority, string> = {
   [TaskPriority.low]: 'bg-gray-100 text-gray-800',
 };
 
-export function TaskCard({ task, isDragging }: TaskCardProps) {
+export function TaskCard({ task, isDragging, members }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({
     id: task.id,
     data: { task },
@@ -81,6 +92,21 @@ export function TaskCard({ task, isDragging }: TaskCardProps) {
           {task.description}
         </p>
       )}
+      {task.assigned_to && (() => {
+        const member = members?.find((m) => m.user_id === task.assigned_to);
+        const initials = member ? getInitials(member.user_name) : '?';
+        return (
+          <div className="mt-2 flex justify-end">
+            <div
+              data-testid="assignee-avatar"
+              className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-medium text-blue-800"
+              title={member?.user_name}
+            >
+              {initials}
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -92,21 +92,22 @@ export function TaskCard({ task, isDragging, members }: TaskCardProps) {
           {task.description}
         </p>
       )}
-      {task.assigned_to && (() => {
-        const member = members?.find((m) => m.user_id === task.assigned_to);
-        const initials = member ? getInitials(member.user_name) : '?';
-        return (
-          <div className="mt-2 flex justify-end">
-            <div
-              data-testid="assignee-avatar"
-              className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-medium text-blue-800"
-              title={member?.user_name}
-            >
-              {initials}
+      {task.assigned_to &&
+        (() => {
+          const member = members?.find((m) => m.user_id === task.assigned_to);
+          const initials = member ? getInitials(member.user_name) : '?';
+          return (
+            <div className="mt-2 flex justify-end">
+              <div
+                data-testid="assignee-avatar"
+                className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-medium text-blue-800"
+                title={member?.user_name}
+              >
+                {initials}
+              </div>
             </div>
-          </div>
-        );
-      })()}
+          );
+        })()}
     </div>
   );
 }

--- a/frontend/src/components/TaskCreateDialog.test.tsx
+++ b/frontend/src/components/TaskCreateDialog.test.tsx
@@ -2,14 +2,39 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as membersApi from '../api/generated/endpoints/project-members/project-members';
 import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
-import { TaskStatus } from '../api/generated/model';
+import type { ProjectMember } from '../api/generated/model';
+import { MemberRole, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 import { TaskCreateDialog } from './TaskCreateDialog';
 
 vi.mock('../api/generated/endpoints/tasks/tasks', () => ({
   useCreateTask: vi.fn(),
 }));
+
+vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
+}));
+
+const mockMembers: ProjectMember[] = [
+  {
+    user_id: 'user-1',
+    user_name: 'Alice',
+    user_email: 'alice@test.com',
+    role: MemberRole.owner,
+    project_id: 'proj-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    user_id: 'user-2',
+    user_name: 'Bob',
+    user_email: 'bob@test.com',
+    role: MemberRole.member,
+    project_id: 'proj-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
 
 const createQueryClient = () =>
   new QueryClient({
@@ -36,6 +61,10 @@ describe('TaskCreateDialog', () => {
       defaultStatus: null,
       isProjectModalOpen: false,
     });
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: mockMembers,
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
   });
 
   it('does not render when modal is closed', () => {
@@ -136,5 +165,45 @@ describe('TaskCreateDialog', () => {
     });
 
     expect(screen.getByLabelText(/title/i)).toHaveValue('');
+  });
+
+  describe('assignee', () => {
+    it('displays assignee select with Unassigned as default', () => {
+      useUiStore.setState({ isTaskModalOpen: true });
+      renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+      const select = screen.getByLabelText(/assignee/i) as HTMLSelectElement;
+      expect(select.value).toBe('');
+      const selectedOption = select.options[select.selectedIndex];
+      expect(selectedOption.text).toBe('Unassigned');
+    });
+
+    it('lists all project members', () => {
+      useUiStore.setState({ isTaskModalOpen: true });
+      renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+      const select = screen.getByLabelText(/assignee/i) as HTMLSelectElement;
+      const options = Array.from(select.options);
+      expect(options.some((o) => o.text === 'Alice')).toBe(true);
+      expect(options.some((o) => o.text === 'Bob')).toBe(true);
+    });
+
+    it('includes assigned_to in create request', async () => {
+      const user = userEvent.setup();
+      useUiStore.setState({ isTaskModalOpen: true, defaultStatus: TaskStatus.todo });
+      renderWithProviders(<TaskCreateDialog projectId="proj-1" />);
+
+      await user.type(screen.getByLabelText(/title/i), 'Assigned Task');
+      await user.selectOptions(screen.getByLabelText(/assignee/i), 'user-2');
+      await user.click(screen.getByRole('button', { name: /create/i }));
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        data: {
+          project_id: 'proj-1',
+          title: 'Assigned Task',
+          status: 'todo',
+          priority: 'medium',
+          assigned_to: 'user-2',
+        },
+      });
+    });
   });
 });

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import { useCreateTask } from '../api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
@@ -25,11 +26,13 @@ function TaskCreateForm({
 }) {
   const closeTaskModal = useUiStore((s) => s.closeTaskModal);
   const createTask = useCreateTask();
+  const { data: members } = useListMembers(projectId);
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [status, setStatus] = useState<TaskStatus>(defaultStatus ?? TaskStatus.backlog);
   const [priority, setPriority] = useState<TaskPriority>(TaskPriority.medium);
+  const [assignedTo, setAssignedTo] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -53,6 +56,7 @@ function TaskCreateForm({
           description: description.trim() || undefined,
           status,
           priority,
+          ...(assignedTo ? { assigned_to: assignedTo } : {}),
         },
       });
       closeTaskModal();
@@ -102,7 +106,7 @@ function TaskCreateForm({
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-3 gap-4">
             <div>
               <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
                 Status
@@ -134,6 +138,24 @@ function TaskCreateForm({
                 <option value={TaskPriority.medium}>Medium</option>
                 <option value={TaskPriority.high}>High</option>
                 <option value={TaskPriority.urgent}>Urgent</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
+                Assignee
+              </label>
+              <select
+                id="task-assignee"
+                value={assignedTo}
+                onChange={(e) => setAssignedTo(e.target.value)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value="">Unassigned</option>
+                {members?.map((m) => (
+                  <option key={m.user_id} value={m.user_id}>
+                    {m.user_name}
+                  </option>
+                ))}
               </select>
             </div>
           </div>

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -375,11 +375,11 @@ describe('TaskDetailModal', () => {
     });
   });
 
-  describe('agent panel', () => {
-    it('renders agent panel section when modal is open', () => {
+  describe('activity', () => {
+    it('renders activity section when modal is open', () => {
       useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
       renderWithProviders(<TaskDetailModal />);
-      expect(screen.getByText('Agent')).toBeInTheDocument();
+      expect(screen.getByText('Activity')).toBeInTheDocument();
       expect(screen.getByLabelText(/agent type/i)).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/TaskDetailModal.test.tsx
+++ b/frontend/src/components/TaskDetailModal.test.tsx
@@ -3,11 +3,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as agentSessionsApi from '../api/generated/endpoints/agent-sessions/agent-sessions';
+import * as membersApi from '../api/generated/endpoints/project-members/project-members';
 import * as commentsApi from '../api/generated/endpoints/task-comments/task-comments';
 import * as tasksApi from '../api/generated/endpoints/tasks/tasks';
 import * as worktreesApi from '../api/generated/endpoints/worktrees/worktrees';
-import type { Task } from '../api/generated/model';
-import { TaskPriority, TaskStatus } from '../api/generated/model';
+import type { ProjectMember, Task } from '../api/generated/model';
+import { MemberRole, TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
 import { TaskDetailModal } from './TaskDetailModal';
 
@@ -30,6 +31,10 @@ vi.mock('../api/generated/endpoints/worktrees/worktrees', () => ({
   useDeleteWorktree: vi.fn(),
 }));
 
+vi.mock('../api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(),
+}));
+
 vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
   useListComments: vi.fn(),
   useCreateComment: vi.fn(),
@@ -40,6 +45,25 @@ vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
 vi.mock('../hooks/useAgentEvents', () => ({
   useAgentEvents: vi.fn(),
 }));
+
+const mockMembers: ProjectMember[] = [
+  {
+    user_id: 'user-1',
+    user_name: 'Alice',
+    user_email: 'alice@test.com',
+    role: MemberRole.owner,
+    project_id: 'project-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    user_id: 'user-2',
+    user_name: 'Bob',
+    user_email: 'bob@test.com',
+    role: MemberRole.member,
+    project_id: 'project-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
 
 const mockTask: Task = {
   id: 'task-1',
@@ -138,6 +162,11 @@ describe('TaskDetailModal', () => {
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof commentsApi.useDeleteComment>);
+
+    vi.mocked(membersApi.useListMembers).mockReturnValue({
+      data: mockMembers,
+      isLoading: false,
+    } as unknown as ReturnType<typeof membersApi.useListMembers>);
   });
 
   it('does not render when modal is closed', () => {
@@ -360,6 +389,86 @@ describe('TaskDetailModal', () => {
       useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
       renderWithProviders(<TaskDetailModal />);
       expect(screen.getByText('Worktrees')).toBeInTheDocument();
+    });
+  });
+
+  describe('assignee', () => {
+    it('displays assignee select', () => {
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+      expect(screen.getByLabelText(/assignee/i)).toBeInTheDocument();
+    });
+
+    it('shows current assignee in select', () => {
+      vi.mocked(tasksApi.useGetTask).mockReturnValue({
+        data: { ...mockTask, assigned_to: 'user-1' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof tasksApi.useGetTask>);
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+      const select = screen.getByLabelText(/assignee/i) as HTMLSelectElement;
+      expect(select.value).toBe('user-1');
+    });
+
+    it('has Unassigned option', () => {
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+      const select = screen.getByLabelText(/assignee/i) as HTMLSelectElement;
+      const options = Array.from(select.options);
+      expect(options.some((o) => o.text === 'Unassigned')).toBe(true);
+    });
+
+    it('lists all project members', () => {
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+      const select = screen.getByLabelText(/assignee/i) as HTMLSelectElement;
+      const options = Array.from(select.options);
+      expect(options.some((o) => o.text === 'Alice')).toBe(true);
+      expect(options.some((o) => o.text === 'Bob')).toBe(true);
+    });
+
+    it('calls updateTask when assignee is changed', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.selectOptions(screen.getByLabelText(/assignee/i), 'user-2');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { assigned_to: 'user-2' },
+      });
+    });
+
+    it('sends null when Unassigned is selected', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({});
+      vi.mocked(tasksApi.useUpdateTask).mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+      } as unknown as ReturnType<typeof tasksApi.useUpdateTask>);
+      vi.mocked(tasksApi.useGetTask).mockReturnValue({
+        data: { ...mockTask, assigned_to: 'user-1' },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof tasksApi.useGetTask>);
+
+      const user = userEvent.setup();
+      useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
+      renderWithProviders(<TaskDetailModal />);
+
+      await user.selectOptions(screen.getByLabelText(/assignee/i), '');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'task-1',
+        data: { assigned_to: null },
+      });
     });
   });
 

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -3,8 +3,7 @@ import { useListMembers } from '../api/generated/endpoints/project-members/proje
 import { useDeleteTask, useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
-import { AgentPanel } from './AgentPanel';
-import { CommentSection } from './CommentSection';
+import { TaskTimeline } from './TaskTimeline';
 import { WorktreePanel } from './WorktreePanel';
 
 export function TaskDetailModal() {
@@ -237,18 +236,13 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Agent</h3>
-              <AgentPanel taskId={taskId} />
-            </div>
-
-            <div className="border-t pt-4">
               <h3 className="text-sm font-medium text-gray-700 mb-2">Worktrees</h3>
               <WorktreePanel />
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Comments</h3>
-              <CommentSection taskId={taskId} />
+              <h3 className="text-sm font-medium text-gray-700 mb-2">Activity</h3>
+              <TaskTimeline taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '../api/generated/model';
 import { useUiStore } from '../stores/uiStore';
@@ -20,6 +21,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const { data: task, isLoading, isError } = useGetTask(taskId);
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
+  const { data: members } = useListMembers(task?.project_id ?? '', { query: { enabled: !!task } });
 
   const [editingField, setEditingField] = useState<'title' | 'description' | null>(null);
   const [editValue, setEditValue] = useState('');
@@ -72,6 +74,17 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       closeTaskDetail();
     } catch {
       setError('Failed to delete task. Please try again.');
+    }
+  };
+
+  const handleAssigneeChange = async (value: string) => {
+    try {
+      await updateTask.mutateAsync({
+        id: taskId,
+        data: { assigned_to: value || null },
+      });
+    } catch {
+      setError('Failed to update assignee. Please try again.');
     }
   };
 
@@ -160,7 +173,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-3 gap-4">
               <div>
                 <label
                   htmlFor="task-detail-status"
@@ -198,6 +211,27 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   <option value="medium">Medium</option>
                   <option value="high">High</option>
                   <option value="urgent">Urgent</option>
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor="task-detail-assignee"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Assignee
+                </label>
+                <select
+                  id="task-detail-assignee"
+                  value={task.assigned_to ?? ''}
+                  onChange={(e) => handleAssigneeChange(e.target.value)}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="">Unassigned</option>
+                  {members?.map((m) => (
+                    <option key={m.user_id} value={m.user_id}>
+                      {m.user_name}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>

--- a/frontend/src/components/TaskFilterBar.test.tsx
+++ b/frontend/src/components/TaskFilterBar.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ProjectMember } from '../api/generated/model';
+import { MemberRole, TaskPriority } from '../api/generated/model';
+import { useBoardStore } from '../stores/boardStore';
+import { TaskFilterBar } from './TaskFilterBar';
+
+const mockMembers: ProjectMember[] = [
+  {
+    user_id: 'user-1',
+    user_name: 'Alice',
+    user_email: 'alice@test.com',
+    role: MemberRole.owner,
+    project_id: 'proj-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    user_id: 'user-2',
+    user_name: 'Bob',
+    user_email: 'bob@test.com',
+    role: MemberRole.member,
+    project_id: 'proj-1',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+describe('TaskFilterBar', () => {
+  beforeEach(() => {
+    useBoardStore.getState().clearFilters();
+  });
+
+  it('renders search input', () => {
+    render(<TaskFilterBar members={mockMembers} />);
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
+  it('updates searchText in boardStore on input', async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.type(screen.getByPlaceholderText(/search/i), 'bug');
+
+    expect(useBoardStore.getState().searchText).toBe('bug');
+  });
+
+  it('renders assignee filter dropdown with members and Unassigned', async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.click(screen.getByRole('button', { name: /assignee/i }));
+
+    const dropdown = screen.getByTestId('assignee-dropdown');
+    expect(within(dropdown).getByLabelText('Unassigned')).toBeInTheDocument();
+    expect(within(dropdown).getByLabelText('Alice')).toBeInTheDocument();
+    expect(within(dropdown).getByLabelText('Bob')).toBeInTheDocument();
+  });
+
+  it('updates assigneeFilter when checkbox is toggled', async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.click(screen.getByRole('button', { name: /assignee/i }));
+    await user.click(screen.getByLabelText('Alice'));
+
+    expect(useBoardStore.getState().assigneeFilter).toEqual(['user-1']);
+  });
+
+  it('renders priority filter with all levels', async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.click(screen.getByRole('button', { name: /priority/i }));
+
+    const dropdown = screen.getByTestId('priority-dropdown');
+    expect(within(dropdown).getByLabelText('Low')).toBeInTheDocument();
+    expect(within(dropdown).getByLabelText('Medium')).toBeInTheDocument();
+    expect(within(dropdown).getByLabelText('High')).toBeInTheDocument();
+    expect(within(dropdown).getByLabelText('Urgent')).toBeInTheDocument();
+  });
+
+  it('updates priorityFilter when checkbox is toggled', async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.click(screen.getByRole('button', { name: /priority/i }));
+    await user.click(screen.getByLabelText('High'));
+
+    expect(useBoardStore.getState().priorityFilter).toEqual([TaskPriority.high]);
+  });
+
+  it('does not show Clear all when no filters active', () => {
+    render(<TaskFilterBar members={mockMembers} />);
+    expect(screen.queryByRole('button', { name: /clear all/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Clear all when filters are active', () => {
+    useBoardStore.getState().setSearchText('test');
+    render(<TaskFilterBar members={mockMembers} />);
+    expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument();
+  });
+
+  it('resets all filters on Clear all click', async () => {
+    const user = userEvent.setup();
+    useBoardStore.getState().setSearchText('test');
+    useBoardStore.getState().setAssigneeFilter(['user-1']);
+    useBoardStore.getState().setPriorityFilter([TaskPriority.high]);
+    render(<TaskFilterBar members={mockMembers} />);
+
+    await user.click(screen.getByRole('button', { name: /clear all/i }));
+
+    const state = useBoardStore.getState();
+    expect(state.searchText).toBe('');
+    expect(state.assigneeFilter).toEqual([]);
+    expect(state.priorityFilter).toEqual([]);
+  });
+});

--- a/frontend/src/components/TaskFilterBar.tsx
+++ b/frontend/src/components/TaskFilterBar.tsx
@@ -1,0 +1,9 @@
+import type { ProjectMember } from '../api/generated/model';
+
+interface TaskFilterBarProps {
+  members?: ProjectMember[];
+}
+
+export function TaskFilterBar(_props: TaskFilterBarProps) {
+  return null;
+}

--- a/frontend/src/components/TaskFilterBar.tsx
+++ b/frontend/src/components/TaskFilterBar.tsx
@@ -1,9 +1,141 @@
+import { useState } from 'react';
 import type { ProjectMember } from '../api/generated/model';
+import { TaskPriority } from '../api/generated/model';
+import { useBoardStore } from '../stores/boardStore';
 
 interface TaskFilterBarProps {
   members?: ProjectMember[];
 }
 
-export function TaskFilterBar(_props: TaskFilterBarProps) {
-  return null;
+const priorityLabels: Record<TaskPriority, string> = {
+  [TaskPriority.low]: 'Low',
+  [TaskPriority.medium]: 'Medium',
+  [TaskPriority.high]: 'High',
+  [TaskPriority.urgent]: 'Urgent',
+};
+
+export function TaskFilterBar({ members }: TaskFilterBarProps) {
+  const searchText = useBoardStore((s) => s.searchText);
+  const setSearchText = useBoardStore((s) => s.setSearchText);
+  const assigneeFilter = useBoardStore((s) => s.assigneeFilter);
+  const setAssigneeFilter = useBoardStore((s) => s.setAssigneeFilter);
+  const priorityFilter = useBoardStore((s) => s.priorityFilter);
+  const setPriorityFilter = useBoardStore((s) => s.setPriorityFilter);
+  const clearFilters = useBoardStore((s) => s.clearFilters);
+  const hasActive = useBoardStore((s) => s.hasActiveFilters);
+
+  const [assigneeOpen, setAssigneeOpen] = useState(false);
+  const [priorityOpen, setPriorityOpen] = useState(false);
+
+  const toggleAssignee = (id: string) => {
+    setAssigneeFilter(
+      assigneeFilter.includes(id)
+        ? assigneeFilter.filter((a) => a !== id)
+        : [...assigneeFilter, id],
+    );
+  };
+
+  const togglePriority = (p: TaskPriority) => {
+    setPriorityFilter(
+      priorityFilter.includes(p)
+        ? priorityFilter.filter((x) => x !== p)
+        : [...priorityFilter, p],
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <input
+        type="text"
+        placeholder="Search tasks..."
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        className="rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+      />
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => {
+            setAssigneeOpen(!assigneeOpen);
+            setPriorityOpen(false);
+          }}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
+        >
+          Assignee
+        </button>
+        {assigneeOpen && (
+          <div
+            data-testid="assignee-dropdown"
+            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-gray-200 bg-white p-2 shadow-lg"
+          >
+            <label className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50">
+              <input
+                type="checkbox"
+                checked={assigneeFilter.includes('unassigned')}
+                onChange={() => toggleAssignee('unassigned')}
+              />
+              Unassigned
+            </label>
+            {members?.map((m) => (
+              <label
+                key={m.user_id}
+                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={assigneeFilter.includes(m.user_id)}
+                  onChange={() => toggleAssignee(m.user_id)}
+                />
+                {m.user_name}
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => {
+            setPriorityOpen(!priorityOpen);
+            setAssigneeOpen(false);
+          }}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
+        >
+          Priority
+        </button>
+        {priorityOpen && (
+          <div
+            data-testid="priority-dropdown"
+            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-gray-200 bg-white p-2 shadow-lg"
+          >
+            {Object.values(TaskPriority).map((p) => (
+              <label
+                key={p}
+                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50"
+              >
+                <input
+                  type="checkbox"
+                  checked={priorityFilter.includes(p)}
+                  onChange={() => togglePriority(p)}
+                />
+                {priorityLabels[p]}
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {hasActive() && (
+        <button
+          type="button"
+          onClick={clearFilters}
+          className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/TaskFilterBar.tsx
+++ b/frontend/src/components/TaskFilterBar.tsx
@@ -37,9 +37,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
 
   const togglePriority = (p: TaskPriority) => {
     setPriorityFilter(
-      priorityFilter.includes(p)
-        ? priorityFilter.filter((x) => x !== p)
-        : [...priorityFilter, p],
+      priorityFilter.includes(p) ? priorityFilter.filter((x) => x !== p) : [...priorityFilter, p],
     );
   };
 

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -7,7 +7,7 @@ import * as commentsApi from '../api/generated/endpoints/task-comments/task-comm
 import type { AgentSession, TaskComment } from '../api/generated/model';
 import { AgentSessionStatus, AgentType } from '../api/generated/model';
 import { useAuthStore } from '../stores/authStore';
-import { type TimelineItem, TaskTimeline, mergeTimeline } from './TaskTimeline';
+import { mergeTimeline, TaskTimeline, type TimelineItem } from './TaskTimeline';
 
 vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
   useListComments: vi.fn(),
@@ -103,8 +103,7 @@ describe('mergeTimeline', () => {
   });
 });
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (ui: React.ReactElement) => {
   const queryClient = createQueryClient();
@@ -165,7 +164,13 @@ describe('TaskTimeline component', () => {
       isLoading: false,
     } as unknown as ReturnType<typeof commentsApi.useListComments>);
     vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
-      data: [createSession({ id: 's1', agent_type: AgentType.claude_code, status: AgentSessionStatus.completed })],
+      data: [
+        createSession({
+          id: 's1',
+          agent_type: AgentType.claude_code,
+          status: AgentSessionStatus.completed,
+        }),
+      ],
       isLoading: false,
     } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
 

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../api/generated/endpoints/agent-sessions/agent-sessions', () => ({
   useStartAgentSession: vi.fn(),
   useStopAgentSession: vi.fn(),
   useGetAgentSessionOutputs: vi.fn(),
+  getListAgentSessionsQueryKey: vi.fn(() => ['agent-sessions']),
 }));
 
 vi.mock('../hooks/useAgentEvents', () => ({
@@ -293,5 +294,60 @@ describe('TaskTimeline component', () => {
       taskId: 'task-1',
       data: { content: 'New comment' },
     });
+  });
+
+  it('starts agent session when Start is clicked', async () => {
+    const mockStart = vi.fn().mockResolvedValue({ session: { id: 'new-session' } });
+    vi.mocked(agentSessionsApi.useStartAgentSession).mockReturnValue({
+      mutateAsync: mockStart,
+      isPending: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useStartAgentSession>);
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    await user.type(screen.getByPlaceholderText(/enter prompt/i), 'Fix the bug');
+    await user.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(mockStart).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      data: { agent_type: 'claude_code', prompt: 'Fix the bug' },
+    });
+  });
+
+  it('session items are clickable to view outputs', async () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        createSession({
+          id: 's1',
+          agent_type: AgentType.claude_code,
+          status: AgentSessionStatus.completed,
+        }),
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    const sessionItem = screen.getByTestId('timeline-session');
+    expect(sessionItem.tagName).toBe('BUTTON');
+
+    await user.click(sessionItem);
+
+    // After clicking, the historical viewer should be shown with a Back button
+    expect(screen.getByText('Back')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -171,8 +171,9 @@ describe('TaskTimeline component', () => {
 
     renderWithProviders(<TaskTimeline taskId="task-1" />);
 
-    expect(screen.getByText('Claude Code')).toBeInTheDocument();
-    expect(screen.getByText('completed')).toBeInTheDocument();
+    const sessionItem = screen.getByTestId('timeline-session');
+    expect(sessionItem).toHaveTextContent('Claude Code');
+    expect(sessionItem).toHaveTextContent('completed');
   });
 
   it('shows edit/delete for own comments', () => {

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -113,7 +113,15 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('TaskTimeline component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAuthStore.setState({ user: { id: 'user-1', name: 'Alice', email: 'alice@test.com' } });
+    useAuthStore.setState({
+      user: {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'alice@test.com',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    });
 
     vi.mocked(commentsApi.useCreateComment).mockReturnValue({
       mutateAsync: vi.fn(),

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSession, TaskComment } from '../api/generated/model';
+import { AgentSessionStatus, AgentType } from '../api/generated/model';
+import { type TimelineItem, mergeTimeline } from './TaskTimeline';
+
+const createComment = (overrides: Partial<TaskComment> = {}): TaskComment => ({
+  id: 'comment-1',
+  task_id: 'task-1',
+  user_id: 'user-1',
+  user_name: 'Alice',
+  content: 'Test comment',
+  created_at: '2026-01-01T12:00:00Z',
+  updated_at: '2026-01-01T12:00:00Z',
+  ...overrides,
+});
+
+const createSession = (overrides: Partial<AgentSession> = {}): AgentSession => ({
+  id: 'session-1',
+  task_id: 'task-1',
+  agent_type: AgentType.claude_code,
+  status: AgentSessionStatus.completed,
+  created_at: '2026-01-01T10:00:00Z',
+  updated_at: '2026-01-01T10:00:00Z',
+  ...overrides,
+});
+
+describe('mergeTimeline', () => {
+  it('merges comments and sessions sorted by created_at descending', () => {
+    const comments = [
+      createComment({ id: 'c1', created_at: '2026-01-01T12:00:00Z' }),
+      createComment({ id: 'c2', created_at: '2026-01-01T08:00:00Z' }),
+    ];
+    const sessions = [createSession({ id: 's1', created_at: '2026-01-01T10:00:00Z' })];
+
+    const result = mergeTimeline(comments, sessions);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ type: 'comment', data: comments[0] });
+    expect(result[1]).toEqual({ type: 'agent_session', data: sessions[0] });
+    expect(result[2]).toEqual({ type: 'comment', data: comments[1] });
+  });
+
+  it('returns only sessions when comments are empty', () => {
+    const sessions = [createSession({ id: 's1' })];
+    const result = mergeTimeline([], sessions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('agent_session');
+  });
+
+  it('returns only comments when sessions are empty', () => {
+    const comments = [createComment({ id: 'c1' })];
+    const result = mergeTimeline(comments, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('comment');
+  });
+
+  it('returns empty array when both are empty', () => {
+    expect(mergeTimeline([], [])).toEqual([]);
+  });
+
+  it('has correct discriminator types', () => {
+    const comments = [createComment({ id: 'c1', created_at: '2026-01-01T12:00:00Z' })];
+    const sessions = [createSession({ id: 's1', created_at: '2026-01-01T10:00:00Z' })];
+
+    const result = mergeTimeline(comments, sessions);
+
+    const commentItem = result.find((item): item is TimelineItem & { type: 'comment' } => item.type === 'comment');
+    const sessionItem = result.find((item): item is TimelineItem & { type: 'agent_session' } => item.type === 'agent_session');
+
+    expect(commentItem?.data.content).toBe('Test comment');
+    expect(sessionItem?.data.agent_type).toBe(AgentType.claude_code);
+  });
+});

--- a/frontend/src/components/TaskTimeline.test.tsx
+++ b/frontend/src/components/TaskTimeline.test.tsx
@@ -1,7 +1,32 @@
-import { describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as agentSessionsApi from '../api/generated/endpoints/agent-sessions/agent-sessions';
+import * as commentsApi from '../api/generated/endpoints/task-comments/task-comments';
 import type { AgentSession, TaskComment } from '../api/generated/model';
 import { AgentSessionStatus, AgentType } from '../api/generated/model';
-import { type TimelineItem, mergeTimeline } from './TaskTimeline';
+import { useAuthStore } from '../stores/authStore';
+import { type TimelineItem, TaskTimeline, mergeTimeline } from './TaskTimeline';
+
+vi.mock('../api/generated/endpoints/task-comments/task-comments', () => ({
+  useListComments: vi.fn(),
+  useCreateComment: vi.fn(),
+  useUpdateComment: vi.fn(),
+  useDeleteComment: vi.fn(),
+  getListCommentsQueryKey: vi.fn(() => ['comments']),
+}));
+
+vi.mock('../api/generated/endpoints/agent-sessions/agent-sessions', () => ({
+  useListAgentSessions: vi.fn(),
+  useStartAgentSession: vi.fn(),
+  useStopAgentSession: vi.fn(),
+  useGetAgentSessionOutputs: vi.fn(),
+}));
+
+vi.mock('../hooks/useAgentEvents', () => ({
+  useAgentEvents: vi.fn(),
+}));
 
 const createComment = (overrides: Partial<TaskComment> = {}): TaskComment => ({
   id: 'comment-1',
@@ -66,10 +91,193 @@ describe('mergeTimeline', () => {
 
     const result = mergeTimeline(comments, sessions);
 
-    const commentItem = result.find((item): item is TimelineItem & { type: 'comment' } => item.type === 'comment');
-    const sessionItem = result.find((item): item is TimelineItem & { type: 'agent_session' } => item.type === 'agent_session');
+    const commentItem = result.find(
+      (item): item is TimelineItem & { type: 'comment' } => item.type === 'comment',
+    );
+    const sessionItem = result.find(
+      (item): item is TimelineItem & { type: 'agent_session' } => item.type === 'agent_session',
+    );
 
     expect(commentItem?.data.content).toBe('Test comment');
     expect(sessionItem?.data.agent_type).toBe(AgentType.claude_code);
+  });
+});
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('TaskTimeline component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ user: { id: 'user-1', name: 'Alice', email: 'alice@test.com' } });
+
+    vi.mocked(commentsApi.useCreateComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useCreateComment>);
+    vi.mocked(commentsApi.useUpdateComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useUpdateComment>);
+    vi.mocked(commentsApi.useDeleteComment).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useDeleteComment>);
+    vi.mocked(agentSessionsApi.useStartAgentSession).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useStartAgentSession>);
+    vi.mocked(agentSessionsApi.useStopAgentSession).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useStopAgentSession>);
+    vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useGetAgentSessionOutputs>);
+  });
+
+  it('displays comment with user name and content', () => {
+    const comments = [createComment({ id: 'c1', user_name: 'Alice', content: 'Hello world' })];
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: comments,
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('displays agent session with type and status', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [createSession({ id: 's1', agent_type: AgentType.claude_code, status: AgentSessionStatus.completed })],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    expect(screen.getByText('completed')).toBeInTheDocument();
+  });
+
+  it('shows edit/delete for own comments', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [createComment({ id: 'c1', user_id: 'user-1' })],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByLabelText('Edit')).toBeInTheDocument();
+    expect(screen.getByLabelText('Delete')).toBeInTheDocument();
+  });
+
+  it('hides edit/delete for other users comments', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [createComment({ id: 'c1', user_id: 'user-2', user_name: 'Bob' })],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.queryByLabelText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('displays comment input form', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByPlaceholderText(/add a comment/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /post/i })).toBeInTheDocument();
+  });
+
+  it('displays agent start section', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByLabelText(/agent type/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start/i })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no items', () => {
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    expect(screen.getByText(/no activity/i)).toBeInTheDocument();
+  });
+
+  it('submits a new comment', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({});
+    vi.mocked(commentsApi.useCreateComment).mockReturnValue({
+      mutateAsync: mockCreate,
+      isPending: false,
+    } as unknown as ReturnType<typeof commentsApi.useCreateComment>);
+    vi.mocked(commentsApi.useListComments).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof commentsApi.useListComments>);
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<TaskTimeline taskId="task-1" />);
+
+    await user.type(screen.getByPlaceholderText(/add a comment/i), 'New comment');
+    await user.click(screen.getByRole('button', { name: /post/i }));
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      data: { content: 'New comment' },
+    });
   });
 });

--- a/frontend/src/components/TaskTimeline.tsx
+++ b/frontend/src/components/TaskTimeline.tsx
@@ -1,0 +1,16 @@
+import type { AgentSession, TaskComment } from '../api/generated/model';
+
+export type TimelineItem =
+  | { type: 'comment'; data: TaskComment }
+  | { type: 'agent_session'; data: AgentSession };
+
+export function mergeTimeline(
+  _comments: TaskComment[],
+  _sessions: AgentSession[],
+): TimelineItem[] {
+  return [];
+}
+
+export function TaskTimeline(_props: { taskId: string }) {
+  return null;
+}

--- a/frontend/src/components/TaskTimeline.tsx
+++ b/frontend/src/components/TaskTimeline.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  getListAgentSessionsQueryKey,
   useGetAgentSessionOutputs,
   useListAgentSessions,
   useStartAgentSession,
@@ -209,11 +210,19 @@ function TimelineCommentItem({
   );
 }
 
-function TimelineAgentSessionItem({ session }: { session: AgentSession }) {
+function TimelineAgentSessionItem({
+  session,
+  onView,
+}: {
+  session: AgentSession;
+  onView: (session: AgentSession) => void;
+}) {
   return (
-    <div
+    <button
+      type="button"
       data-testid="timeline-session"
-      className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2"
+      className="flex w-full items-center gap-3 rounded-md bg-gray-50 px-3 py-2 text-left hover:bg-gray-100"
+      onClick={() => onView(session)}
     >
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-100 text-xs font-medium text-purple-800">
         AI
@@ -229,7 +238,7 @@ function TimelineAgentSessionItem({ session }: { session: AgentSession }) {
         </span>
         <span className="text-xs text-gray-500">{timeAgo(session.created_at)}</span>
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -261,6 +270,8 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
     reset,
   } = useAgentStore();
 
+  const isStartingRef = useRef(false);
+
   const activeSession =
     sessions?.find((s) => s.id === activeSessionId) ??
     sessions?.find((s) => s.status === 'running' || s.status === 'pending');
@@ -268,7 +279,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
   useEffect(() => {
     if (activeSession && !activeSessionId) {
       setActiveSession(activeSession.id);
-    } else if (!activeSession && activeSessionId) {
+    } else if (!activeSession && activeSessionId && !isStartingRef.current) {
       reset();
     }
   }, [activeSession, activeSessionId, setActiveSession, reset]);
@@ -297,9 +308,14 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
     setLoadingHistory(isLoadingOutputs);
   }, [isLoadingOutputs, setLoadingHistory]);
 
+  const invalidateSessions = () => {
+    queryClient.invalidateQueries({ queryKey: getListAgentSessionsQueryKey(taskId) });
+  };
+
   const handleStartAgent = async () => {
     setAgentError(null);
     setViewingSessionId(null);
+    isStartingRef.current = true;
     try {
       reset();
       const result = await startSession.mutateAsync({
@@ -308,8 +324,11 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
       });
       setActiveSession(result.session.id);
       setPrompt('');
+      invalidateSessions();
     } catch {
       setAgentError('Failed to start agent session.');
+    } finally {
+      isStartingRef.current = false;
     }
   };
 
@@ -318,6 +337,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
     try {
       await stopSession.mutateAsync({ taskId, sessionId: activeSession.id });
       reset();
+      invalidateSessions();
     } catch {
       setAgentError('Failed to stop agent session.');
     }
@@ -333,6 +353,13 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
     } catch {
       addToast('error', 'Failed to post comment.');
     }
+  };
+
+  const handleViewSession = (session: AgentSession) => {
+    setViewingSessionId(session.id);
+    setActiveSession(null);
+    setLoadingHistory(true);
+    setOutputLines([]);
   };
 
   const isLoading = commentsLoading || sessionsLoading;
@@ -480,7 +507,11 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 isOwner={currentUser?.id === item.data.user_id}
               />
             ) : (
-              <TimelineAgentSessionItem key={item.data.id} session={item.data} />
+              <TimelineAgentSessionItem
+                key={item.data.id}
+                session={item.data}
+                onView={handleViewSession}
+              />
             ),
           )}
         </div>

--- a/frontend/src/components/TaskTimeline.tsx
+++ b/frontend/src/components/TaskTimeline.tsx
@@ -13,7 +13,12 @@ import {
   useListComments,
   useUpdateComment,
 } from '../api/generated/endpoints/task-comments/task-comments';
-import type { AgentSession, AgentSessionStatus, AgentType, TaskComment } from '../api/generated/model';
+import type {
+  AgentSession,
+  AgentSessionStatus,
+  AgentType,
+  TaskComment,
+} from '../api/generated/model';
 import { useAgentEvents } from '../hooks/useAgentEvents';
 import { useAgentStore } from '../stores/agentStore';
 import { useAuthStore } from '../stores/authStore';
@@ -24,10 +29,7 @@ export type TimelineItem =
   | { type: 'comment'; data: TaskComment }
   | { type: 'agent_session'; data: AgentSession };
 
-export function mergeTimeline(
-  comments: TaskComment[],
-  sessions: AgentSession[],
-): TimelineItem[] {
+export function mergeTimeline(comments: TaskComment[], sessions: AgentSession[]): TimelineItem[] {
   const items: TimelineItem[] = [
     ...comments.map((c) => ({ type: 'comment' as const, data: c })),
     ...sessions.map((s) => ({ type: 'agent_session' as const, data: s })),
@@ -209,7 +211,10 @@ function TimelineCommentItem({
 
 function TimelineAgentSessionItem({ session }: { session: AgentSession }) {
   return (
-    <div data-testid="timeline-session" className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2">
+    <div
+      data-testid="timeline-session"
+      className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2"
+    >
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-100 text-xs font-medium text-purple-800">
         AI
       </div>
@@ -364,35 +369,36 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
       )}
 
       {/* Viewing historical session */}
-      {viewingSessionId && (() => {
-        const viewingSession = sessions?.find((s) => s.id === viewingSessionId);
-        if (!viewingSession) return null;
-        return (
-          <div className="space-y-2 rounded-md border border-gray-200 p-3">
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  setViewingSessionId(null);
-                  reset();
-                }}
-                className="text-sm text-blue-600 hover:text-blue-800"
-              >
-                Back
-              </button>
-              <span className="text-sm text-gray-600">
-                {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
-              </span>
-              <span
-                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[viewingSession.status]}`}
-              >
-                {viewingSession.status}
-              </span>
+      {viewingSessionId &&
+        (() => {
+          const viewingSession = sessions?.find((s) => s.id === viewingSessionId);
+          if (!viewingSession) return null;
+          return (
+            <div className="space-y-2 rounded-md border border-gray-200 p-3">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setViewingSessionId(null);
+                    reset();
+                  }}
+                  className="text-sm text-blue-600 hover:text-blue-800"
+                >
+                  Back
+                </button>
+                <span className="text-sm text-gray-600">
+                  {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
+                </span>
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[viewingSession.status]}`}
+                >
+                  {viewingSession.status}
+                </span>
+              </div>
+              <AgentOutputViewer lines={outputLines} isLoading={isLoadingHistory} />
             </div>
-            <AgentOutputViewer lines={outputLines} isLoading={isLoadingHistory} />
-          </div>
-        );
-      })()}
+          );
+        })()}
 
       {/* Agent start section */}
       {!activeSession && !viewingSessionId && (
@@ -474,10 +480,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 isOwner={currentUser?.id === item.data.user_id}
               />
             ) : (
-              <TimelineAgentSessionItem
-                key={item.data.id}
-                session={item.data}
-              />
+              <TimelineAgentSessionItem key={item.data.id} session={item.data} />
             ),
           )}
         </div>

--- a/frontend/src/components/TaskTimeline.tsx
+++ b/frontend/src/components/TaskTimeline.tsx
@@ -5,10 +5,15 @@ export type TimelineItem =
   | { type: 'agent_session'; data: AgentSession };
 
 export function mergeTimeline(
-  _comments: TaskComment[],
-  _sessions: AgentSession[],
+  comments: TaskComment[],
+  sessions: AgentSession[],
 ): TimelineItem[] {
-  return [];
+  const items: TimelineItem[] = [
+    ...comments.map((c) => ({ type: 'comment' as const, data: c })),
+    ...sessions.map((s) => ({ type: 'agent_session' as const, data: s })),
+  ];
+  items.sort((a, b) => new Date(b.data.created_at).getTime() - new Date(a.data.created_at).getTime());
+  return items;
 }
 
 export function TaskTimeline(_props: { taskId: string }) {

--- a/frontend/src/components/TaskTimeline.tsx
+++ b/frontend/src/components/TaskTimeline.tsx
@@ -1,4 +1,24 @@
-import type { AgentSession, TaskComment } from '../api/generated/model';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  useGetAgentSessionOutputs,
+  useListAgentSessions,
+  useStartAgentSession,
+  useStopAgentSession,
+} from '../api/generated/endpoints/agent-sessions/agent-sessions';
+import {
+  getListCommentsQueryKey,
+  useCreateComment,
+  useDeleteComment,
+  useListComments,
+  useUpdateComment,
+} from '../api/generated/endpoints/task-comments/task-comments';
+import type { AgentSession, AgentSessionStatus, AgentType, TaskComment } from '../api/generated/model';
+import { useAgentEvents } from '../hooks/useAgentEvents';
+import { useAgentStore } from '../stores/agentStore';
+import { useAuthStore } from '../stores/authStore';
+import { useToastStore } from '../stores/toastStore';
+import { AgentOutputViewer } from './AgentOutputViewer';
 
 export type TimelineItem =
   | { type: 'comment'; data: TaskComment }
@@ -12,10 +32,456 @@ export function mergeTimeline(
     ...comments.map((c) => ({ type: 'comment' as const, data: c })),
     ...sessions.map((s) => ({ type: 'agent_session' as const, data: s })),
   ];
-  items.sort((a, b) => new Date(b.data.created_at).getTime() - new Date(a.data.created_at).getTime());
+  items.sort(
+    (a, b) => new Date(b.data.created_at).getTime() - new Date(a.data.created_at).getTime(),
+  );
   return items;
 }
 
-export function TaskTimeline(_props: { taskId: string }) {
-  return null;
+const STATUS_COLORS: Record<AgentSessionStatus, string> = {
+  pending: 'bg-yellow-100 text-yellow-800',
+  running: 'bg-blue-100 text-blue-800',
+  completed: 'bg-green-100 text-green-800',
+  failed: 'bg-red-100 text-red-800',
+  cancelled: 'bg-gray-100 text-gray-800',
+};
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  claude_code: 'Claude Code',
+  gemini_cli: 'Gemini CLI',
+};
+
+const TERMINAL_STATUSES: AgentSessionStatus[] = ['completed', 'failed', 'cancelled'];
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+}
+
+function TimelineCommentItem({
+  comment,
+  taskId,
+  isOwner,
+}: {
+  comment: TaskComment;
+  taskId: string;
+  isOwner: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const queryClient = useQueryClient();
+  const updateComment = useUpdateComment();
+  const deleteComment = useDeleteComment();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const invalidateComments = () => {
+    queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
+  };
+
+  const handleSave = async () => {
+    const trimmed = editValue.trim();
+    if (!trimmed) return;
+    try {
+      await updateComment.mutateAsync({
+        taskId,
+        commentId: comment.id,
+        data: { content: trimmed },
+      });
+      setEditing(false);
+      invalidateComments();
+    } catch {
+      addToast('error', 'Failed to update comment.');
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteComment.mutateAsync({ taskId, commentId: comment.id });
+      setShowDeleteConfirm(false);
+      invalidateComments();
+    } catch {
+      addToast('error', 'Failed to delete comment.');
+    }
+  };
+
+  return (
+    <div data-testid="timeline-comment" className="flex gap-3 py-2">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+        {getInitials(comment.user_name)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-900">{comment.user_name}</span>
+          <span className="text-xs text-gray-500">{timeAgo(comment.created_at)}</span>
+          {isOwner && !editing && !showDeleteConfirm && (
+            <div className="ml-auto flex gap-1">
+              <button
+                type="button"
+                aria-label="Edit"
+                onClick={() => {
+                  setEditing(true);
+                  setEditValue(comment.content);
+                }}
+                className="text-xs text-gray-400 hover:text-gray-600"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                aria-label="Delete"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="text-xs text-gray-400 hover:text-red-600"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+        {editing ? (
+          <div className="mt-1 space-y-1">
+            <textarea
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              rows={2}
+              className="block w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={handleSave}
+                className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditing(false)}
+                className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : showDeleteConfirm ? (
+          <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
+            <span className="text-xs text-red-700">Delete this comment?</span>
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(false)}
+              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TimelineAgentSessionItem({ session }: { session: AgentSession }) {
+  return (
+    <div data-testid="timeline-session" className="flex items-center gap-3 rounded-md bg-gray-50 px-3 py-2">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-100 text-xs font-medium text-purple-800">
+        AI
+      </div>
+      <div className="flex flex-1 items-center gap-2">
+        <span className="text-sm font-medium text-gray-900">
+          {AGENT_LABELS[session.agent_type] ?? session.agent_type}
+        </span>
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[session.status]}`}
+        >
+          {session.status}
+        </span>
+        <span className="text-xs text-gray-500">{timeAgo(session.created_at)}</span>
+      </div>
+    </div>
+  );
+}
+
+export function TaskTimeline({ taskId }: { taskId: string }) {
+  const { data: comments, isLoading: commentsLoading } = useListComments(taskId);
+  const { data: sessions, isLoading: sessionsLoading } = useListAgentSessions(taskId);
+  const createComment = useCreateComment();
+  const queryClient = useQueryClient();
+  const currentUser = useAuthStore((s) => s.user);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [newComment, setNewComment] = useState('');
+
+  // Agent start section state
+  const [agentType, setAgentType] = useState<AgentType>('claude_code');
+  const [prompt, setPrompt] = useState('');
+  const [agentError, setAgentError] = useState<string | null>(null);
+  const startSession = useStartAgentSession();
+  const stopSession = useStopAgentSession();
+
+  const {
+    activeSessionId,
+    outputLines,
+    appendOutput,
+    setActiveSession,
+    setOutputLines,
+    setLoadingHistory,
+    isLoadingHistory,
+    reset,
+  } = useAgentStore();
+
+  const activeSession =
+    sessions?.find((s) => s.id === activeSessionId) ??
+    sessions?.find((s) => s.status === 'running' || s.status === 'pending');
+
+  useEffect(() => {
+    if (activeSession && !activeSessionId) {
+      setActiveSession(activeSession.id);
+    } else if (!activeSession && activeSessionId) {
+      reset();
+    }
+  }, [activeSession, activeSessionId, setActiveSession, reset]);
+
+  const handleOutput = useCallback((text: string) => appendOutput(text), [appendOutput]);
+  useAgentEvents(activeSessionId, handleOutput);
+
+  // View historical session
+  const [viewingSessionId, setViewingSessionId] = useState<string | null>(null);
+  const { data: historicalOutputs, isLoading: isLoadingOutputs } = useGetAgentSessionOutputs(
+    taskId,
+    viewingSessionId ?? '',
+    undefined,
+    { query: { enabled: !!viewingSessionId } },
+  );
+
+  useEffect(() => {
+    if (historicalOutputs && viewingSessionId) {
+      const lines = historicalOutputs.map((o) => o.content);
+      setOutputLines(lines);
+      setLoadingHistory(false);
+    }
+  }, [historicalOutputs, viewingSessionId, setOutputLines, setLoadingHistory]);
+
+  useEffect(() => {
+    setLoadingHistory(isLoadingOutputs);
+  }, [isLoadingOutputs, setLoadingHistory]);
+
+  const handleStartAgent = async () => {
+    setAgentError(null);
+    setViewingSessionId(null);
+    try {
+      reset();
+      const result = await startSession.mutateAsync({
+        taskId,
+        data: { agent_type: agentType, prompt },
+      });
+      setActiveSession(result.session.id);
+      setPrompt('');
+    } catch {
+      setAgentError('Failed to start agent session.');
+    }
+  };
+
+  const handleStopAgent = async () => {
+    if (!activeSession) return;
+    try {
+      await stopSession.mutateAsync({ taskId, sessionId: activeSession.id });
+      reset();
+    } catch {
+      setAgentError('Failed to stop agent session.');
+    }
+  };
+
+  const handleSubmitComment = async () => {
+    const trimmed = newComment.trim();
+    if (!trimmed) return;
+    try {
+      await createComment.mutateAsync({ taskId, data: { content: trimmed } });
+      setNewComment('');
+      queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
+    } catch {
+      addToast('error', 'Failed to post comment.');
+    }
+  };
+
+  const isLoading = commentsLoading || sessionsLoading;
+  const terminalSessions = sessions?.filter((s) => TERMINAL_STATUSES.includes(s.status)) ?? [];
+  const timeline = mergeTimeline(comments ?? [], terminalSessions);
+
+  return (
+    <div className="space-y-4">
+      {/* Active session */}
+      {activeSession && !TERMINAL_STATUSES.includes(activeSession.status) && (
+        <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">
+                {AGENT_LABELS[activeSession.agent_type] ?? activeSession.agent_type}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[activeSession.status]}`}
+              >
+                {activeSession.status}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={handleStopAgent}
+              disabled={stopSession.isPending}
+              className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              Stop
+            </button>
+          </div>
+          <AgentOutputViewer lines={outputLines} isLoading={false} />
+        </div>
+      )}
+
+      {/* Viewing historical session */}
+      {viewingSessionId && (() => {
+        const viewingSession = sessions?.find((s) => s.id === viewingSessionId);
+        if (!viewingSession) return null;
+        return (
+          <div className="space-y-2 rounded-md border border-gray-200 p-3">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setViewingSessionId(null);
+                  reset();
+                }}
+                className="text-sm text-blue-600 hover:text-blue-800"
+              >
+                Back
+              </button>
+              <span className="text-sm text-gray-600">
+                {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[viewingSession.status]}`}
+              >
+                {viewingSession.status}
+              </span>
+            </div>
+            <AgentOutputViewer lines={outputLines} isLoading={isLoadingHistory} />
+          </div>
+        );
+      })()}
+
+      {/* Agent start section */}
+      {!activeSession && !viewingSessionId && (
+        <div className="space-y-2 rounded-md border border-gray-200 p-3">
+          {agentError && (
+            <div className="rounded-md bg-red-50 p-2 text-sm text-red-700">{agentError}</div>
+          )}
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label
+                htmlFor="timeline-agent-type"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Agent Type
+              </label>
+              <select
+                id="timeline-agent-type"
+                value={agentType}
+                onChange={(e) => setAgentType(e.target.value as AgentType)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value="claude_code">Claude Code</option>
+                <option value="gemini_cli">Gemini CLI</option>
+              </select>
+            </div>
+            <div className="flex items-end">
+              <button
+                type="button"
+                onClick={handleStartAgent}
+                disabled={!prompt.trim() || startSession.isPending}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                Start
+              </button>
+            </div>
+          </div>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Enter prompt for the agent..."
+            rows={2}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+      )}
+
+      {/* Comment input */}
+      <div className="flex gap-2">
+        <textarea
+          value={newComment}
+          onChange={(e) => setNewComment(e.target.value)}
+          placeholder="Add a comment..."
+          rows={2}
+          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={handleSubmitComment}
+          disabled={!newComment.trim() || createComment.isPending}
+          className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Post
+        </button>
+      </div>
+
+      {/* Timeline */}
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading activity...</p>
+      ) : timeline.length === 0 ? (
+        <p className="text-sm text-gray-500">No activity yet.</p>
+      ) : (
+        <div className="divide-y">
+          {timeline.map((item) =>
+            item.type === 'comment' ? (
+              <TimelineCommentItem
+                key={item.data.id}
+                comment={item.data}
+                taskId={taskId}
+                isOwner={currentUser?.id === item.data.user_id}
+              />
+            ) : (
+              <TimelineAgentSessionItem
+                key={item.data.id}
+                session={item.data}
+              />
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/stores/boardStore.test.ts
+++ b/frontend/src/stores/boardStore.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TaskPriority } from '../api/generated/model';
+import { useBoardStore } from './boardStore';
+
+describe('boardStore filters', () => {
+  beforeEach(() => {
+    useBoardStore.setState({
+      searchText: '',
+      assigneeFilter: [],
+      priorityFilter: [],
+    });
+  });
+
+  it('has empty initial filter state', () => {
+    const state = useBoardStore.getState();
+    expect(state.searchText).toBe('');
+    expect(state.assigneeFilter).toEqual([]);
+    expect(state.priorityFilter).toEqual([]);
+  });
+
+  it('sets search text', () => {
+    useBoardStore.getState().setSearchText('bug fix');
+    expect(useBoardStore.getState().searchText).toBe('bug fix');
+  });
+
+  it('sets assignee filter', () => {
+    useBoardStore.getState().setAssigneeFilter(['user-1', 'unassigned']);
+    expect(useBoardStore.getState().assigneeFilter).toEqual(['user-1', 'unassigned']);
+  });
+
+  it('sets priority filter', () => {
+    useBoardStore.getState().setPriorityFilter([TaskPriority.high, TaskPriority.urgent]);
+    expect(useBoardStore.getState().priorityFilter).toEqual([
+      TaskPriority.high,
+      TaskPriority.urgent,
+    ]);
+  });
+
+  it('clears all filters', () => {
+    useBoardStore.getState().setSearchText('test');
+    useBoardStore.getState().setAssigneeFilter(['user-1']);
+    useBoardStore.getState().setPriorityFilter([TaskPriority.low]);
+
+    useBoardStore.getState().clearFilters();
+
+    const state = useBoardStore.getState();
+    expect(state.searchText).toBe('');
+    expect(state.assigneeFilter).toEqual([]);
+    expect(state.priorityFilter).toEqual([]);
+  });
+
+  it('hasActiveFilters returns false when no filters', () => {
+    expect(useBoardStore.getState().hasActiveFilters()).toBe(false);
+  });
+
+  it('hasActiveFilters returns true when searchText is set', () => {
+    useBoardStore.getState().setSearchText('search');
+    expect(useBoardStore.getState().hasActiveFilters()).toBe(true);
+  });
+
+  it('hasActiveFilters returns true when assigneeFilter is set', () => {
+    useBoardStore.getState().setAssigneeFilter(['user-1']);
+    expect(useBoardStore.getState().hasActiveFilters()).toBe(true);
+  });
+
+  it('hasActiveFilters returns true when priorityFilter is set', () => {
+    useBoardStore.getState().setPriorityFilter([TaskPriority.medium]);
+    expect(useBoardStore.getState().hasActiveFilters()).toBe(true);
+  });
+});

--- a/frontend/src/stores/boardStore.ts
+++ b/frontend/src/stores/boardStore.ts
@@ -28,9 +28,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   hasActiveFilters: () => {
     const state = get();
     return (
-      state.searchText !== '' ||
-      state.assigneeFilter.length > 0 ||
-      state.priorityFilter.length > 0
+      state.searchText !== '' || state.assigneeFilter.length > 0 || state.priorityFilter.length > 0
     );
   },
 }));

--- a/frontend/src/stores/boardStore.ts
+++ b/frontend/src/stores/boardStore.ts
@@ -1,11 +1,36 @@
 import { create } from 'zustand';
 
+import type { TaskPriority } from '../api/generated/model';
+
 interface BoardState {
   activeTaskId: string | null;
   setActiveTaskId: (id: string | null) => void;
+  searchText: string;
+  setSearchText: (text: string) => void;
+  assigneeFilter: string[];
+  setAssigneeFilter: (ids: string[]) => void;
+  priorityFilter: TaskPriority[];
+  setPriorityFilter: (priorities: TaskPriority[]) => void;
+  clearFilters: () => void;
+  hasActiveFilters: () => boolean;
 }
 
-export const useBoardStore = create<BoardState>((set) => ({
+export const useBoardStore = create<BoardState>((set, get) => ({
   activeTaskId: null,
   setActiveTaskId: (id) => set({ activeTaskId: id }),
+  searchText: '',
+  setSearchText: (text) => set({ searchText: text }),
+  assigneeFilter: [],
+  setAssigneeFilter: (ids) => set({ assigneeFilter: ids }),
+  priorityFilter: [],
+  setPriorityFilter: (priorities) => set({ priorityFilter: priorities }),
+  clearFilters: () => set({ searchText: '', assigneeFilter: [], priorityFilter: [] }),
+  hasActiveFilters: () => {
+    const state = get();
+    return (
+      state.searchText !== '' ||
+      state.assigneeFilter.length > 0 ||
+      state.priorityFilter.length > 0
+    );
+  },
 }));


### PR DESCRIPTION
## Summary
- **#124 Task Assignee Display and Selection**: Add assignee initials avatar to TaskCard, assignee select to TaskDetailModal and TaskCreateDialog. Members fetched once in KanbanBoard and passed down to avoid N+1.
- **#126 Task Filtering and Search**: Add client-side filtering with search text, assignee filter, and priority filter. New boardStore filter state, TaskFilterBar component, and KanbanBoard integration with AND combination logic.
- **#128 Unified Task Timeline View**: New TaskTimeline component merging comments and agent sessions chronologically. Replaces separate AgentPanel and CommentSection in TaskDetailModal with unified Activity section.

## Test plan
- [x] TaskCard assignee display tests (6 tests)
- [x] TaskDetailModal assignee select tests (6 tests)
- [x] TaskCreateDialog assignee field tests (3 tests)
- [x] boardStore filter state tests (9 tests)
- [x] TaskFilterBar component tests (9 tests)
- [x] KanbanBoard filtering integration tests (6 tests)
- [x] mergeTimeline utility tests (5 tests)
- [x] TaskTimeline component tests (8 tests)
- [x] All 249 tests passing
- [x] Biome lint/format clean

Closes #124, #126, #128