### PR TITLE
refactor: ♻️ project structure cleanup and code deduplication

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,7 +1,0 @@
-target/
-*.db
-*.db-shm
-*.db-wal
-.git/
-.gitignore
-CLAUDE.md

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,0 @@
-# Database
-DATABASE_URL=sqlite:gantry_board.db?mode=rwc
-
-# Server
-GANTRY_BIND_ADDR=0.0.0.0:3000

--- a/frontend/src/components/ProjectCreateDialog.tsx
+++ b/frontend/src/components/ProjectCreateDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useCreateProject } from '../api/generated/endpoints/projects/projects';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useUiStore } from '../stores/uiStore';
 
 export function ProjectCreateDialog() {
@@ -18,13 +19,7 @@ function ProjectCreateForm() {
   const [description, setDescription] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeProjectModal();
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeProjectModal]);
+  useEscapeKey(closeProjectModal);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/ProjectMembersPanel.tsx
+++ b/frontend/src/components/ProjectMembersPanel.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   getListMembersQueryKey,
   useAddMember,
@@ -10,6 +10,7 @@ import {
 import { useSearchUsers } from '../api/generated/endpoints/users/users';
 import type { MemberRole as MemberRoleType } from '../api/generated/model';
 import { MemberRole } from '../api/generated/model';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { useUiStore } from '../stores/uiStore';
@@ -54,13 +55,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
     });
   };
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeProjectMembers();
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeProjectMembers]);
+  useEscapeKey(closeProjectMembers);
 
   const handleInvite = async () => {
     if (!selectedUser) return;

--- a/frontend/src/components/ProjectSettingsModal.tsx
+++ b/frontend/src/components/ProjectSettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import {
   getGetProjectQueryKey,
@@ -9,6 +9,7 @@ import {
   useUpdateProject,
 } from '../api/generated/endpoints/projects/projects';
 import { MemberRole } from '../api/generated/model';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useAuthStore } from '../stores/authStore';
 import { useToastStore } from '../stores/toastStore';
 import { useUiStore } from '../stores/uiStore';
@@ -49,19 +50,14 @@ function ProjectSettingsContent({
   const canEdit = currentUserRole === MemberRole.owner || currentUserRole === MemberRole.admin;
   const isOwner = currentUserRole === MemberRole.owner;
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (editingField) {
-          setEditingField(null);
-        } else {
-          closeProjectSettings();
-        }
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeProjectSettings, editingField]);
+  const escapeGuard = useCallback(() => {
+    if (editingField) {
+      setEditingField(null);
+      return true;
+    }
+    return false;
+  }, [editingField]);
+  useEscapeKey(closeProjectSettings, escapeGuard);
 
   const startEditing = (field: 'name' | 'description', value: string) => {
     setEditingField(field);

--- a/frontend/src/components/TaskCreateDialog.tsx
+++ b/frontend/src/components/TaskCreateDialog.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import { useCreateTask } from '../api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useUiStore } from '../stores/uiStore';
 
 interface TaskCreateDialogProps {
@@ -35,13 +36,7 @@ function TaskCreateForm({
   const [assignedTo, setAssignedTo] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeTaskModal();
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeTaskModal]);
+  useEscapeKey(closeTaskModal);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useListMembers } from '../api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '../api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '../api/generated/model';
+import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useUiStore } from '../stores/uiStore';
 import { TaskTimeline } from './TaskTimeline';
 import { WorktreePanel } from './WorktreePanel';
@@ -27,19 +28,14 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (editingField) {
-          setEditingField(null);
-        } else {
-          closeTaskDetail();
-        }
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [closeTaskDetail, editingField]);
+  const escapeGuard = useCallback(() => {
+    if (editingField) {
+      setEditingField(null);
+      return true;
+    }
+    return false;
+  }, [editingField]);
+  useEscapeKey(closeTaskDetail, escapeGuard);
 
   const startEditing = (field: 'title' | 'description', value: string) => {
     setEditingField(field);

--- a/frontend/src/hooks/useEscapeKey.test.ts
+++ b/frontend/src/hooks/useEscapeKey.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useEscapeKey } from './useEscapeKey';
+
+function pressEscape() {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+}
+
+function pressEnter() {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+}
+
+describe('useEscapeKey', () => {
+  it('calls onEscape when Escape is pressed', () => {
+    const onEscape = vi.fn();
+    renderHook(() => useEscapeKey(onEscape));
+
+    pressEscape();
+
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onEscape for other keys', () => {
+    const onEscape = vi.fn();
+    renderHook(() => useEscapeKey(onEscape));
+
+    pressEnter();
+
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('skips onEscape when guard returns true', () => {
+    const onEscape = vi.fn();
+    const guard = vi.fn().mockReturnValue(true);
+    renderHook(() => useEscapeKey(onEscape, guard));
+
+    pressEscape();
+
+    expect(guard).toHaveBeenCalledOnce();
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('calls onEscape when guard returns false', () => {
+    const onEscape = vi.fn();
+    const guard = vi.fn().mockReturnValue(false);
+    renderHook(() => useEscapeKey(onEscape, guard));
+
+    pressEscape();
+
+    expect(guard).toHaveBeenCalledOnce();
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+
+  it('removes event listener on unmount', () => {
+    const onEscape = vi.fn();
+    const { unmount } = renderHook(() => useEscapeKey(onEscape));
+
+    unmount();
+    pressEscape();
+
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useEscapeKey.ts
+++ b/frontend/src/hooks/useEscapeKey.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+/**
+ * Calls the given callback when the Escape key is pressed.
+ * If `guard` is provided and returns true, the callback is skipped for that event.
+ */
+export function useEscapeKey(onEscape: () => void, guard?: (e: KeyboardEvent) => boolean): void {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (guard?.(e)) return;
+        onEscape();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onEscape, guard]);
+}

--- a/frontend/src/hooks/useEscapeKey.ts
+++ b/frontend/src/hooks/useEscapeKey.ts
@@ -2,6 +2,11 @@ import { useEffect } from 'react';
 
 /**
  * Calls the given callback when the Escape key is pressed.
+ *
+ * Both `onEscape` and `guard` should be stable references (for example, obtained from a store
+ * or wrapped with `useCallback`) so that this hook does not re-run its effect and reattach
+ * the underlying keydown listener on every render.
+ *
  * If `guard` is provided and returns true, the callback is skipped for that event.
  */
 export function useEscapeKey(onEscape: () => void, guard?: (e: KeyboardEvent) => boolean): void {


### PR DESCRIPTION
## Summary

- Remove redundant `backend/.env.example` (uses outdated `DATABASE_URL` instead of `GANTRY_DATABASE_URL`) (#147)
- Remove redundant `backend/.dockerignore` (root `.dockerignore` covers backend build context) (#147)
- Extract `useEscapeKey` hook to deduplicate Escape key handling across 5 dialog/modal components (#169)

### Details

**VCS cleanup (#147):**
- `backend/.env.example` was inconsistent with root `.env.example` — root is the single source of truth
- `backend/.dockerignore` is redundant since `docker-compose.yml` sets build context to `.` (root)
- `frontend/.dockerignore` is retained as its build context is `./frontend`

**Code deduplication (#169):**
- New `useEscapeKey(onEscape, guard?)` hook in `frontend/src/hooks/useEscapeKey.ts`
- Simple usage: `useEscapeKey(closeModal)` — 3 components
- Guard usage: `useEscapeKey(closeModal, escapeGuard)` — 2 components (cancel edit first, then close)
- Reduces 5× copy-pasted `useEffect` + `addEventListener` blocks to single-line calls

## Test plan
- [x] All 269 frontend tests pass
- [x] Biome lint clean (no new errors)
- [x] Existing Escape key behavior preserved in all 5 components