### PR TITLE
refactor: ♻️ deduplicate authorization patterns in handlers

### DIFF
--- a/backend/src/handlers/agent_sessions.rs
+++ b/backend/src/handlers/agent_sessions.rs
@@ -14,9 +14,7 @@ use crate::models::agent_session::{
     UpdateAgentSessionRequest,
 };
 use crate::models::agent_session_output::AgentSessionOutput;
-use crate::services::{
-    agent_session_output_service, agent_session_service, authorization_service, task_service,
-};
+use crate::services::{agent_session_output_service, agent_session_service, authorization_service};
 use crate::AppState;
 
 #[utoipa::path(
@@ -37,9 +35,7 @@ pub async fn create_agent_session(
     Path(task_id): Path<Uuid>,
     Json(body): Json<CreateAgentSessionRequest>,
 ) -> AppResult<(StatusCode, Json<AgentSession>)> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let session = agent_session_service::create_agent_session(&state.pool, task_id, &body).await?;
     Ok((StatusCode::CREATED, Json(session)))
 }
@@ -60,9 +56,7 @@ pub async fn list_agent_sessions(
     auth: AuthUser,
     Path(task_id): Path<Uuid>,
 ) -> AppResult<Json<Vec<AgentSession>>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let sessions = agent_session_service::list_agent_sessions(&state.pool, task_id).await?;
     Ok(Json(sessions))
 }
@@ -86,9 +80,7 @@ pub async fn get_agent_session(
     auth: AuthUser,
     Path((task_id, session_id)): Path<(Uuid, Uuid)>,
 ) -> AppResult<Json<AgentSession>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let session =
         agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
     Ok(Json(session))
@@ -116,9 +108,7 @@ pub async fn update_agent_session(
     Path((task_id, session_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<UpdateAgentSessionRequest>,
 ) -> AppResult<Json<AgentSession>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let session =
         agent_session_service::update_agent_session(&state.pool, task_id, session_id, &body)
             .await?;
@@ -147,9 +137,7 @@ pub async fn start_agent_session(
 ) -> AppResult<(StatusCode, Json<StartAgentSessionResponse>)> {
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
 
     let result = state
         .orchestrator
@@ -187,9 +175,7 @@ pub async fn stop_agent_session(
     auth: AuthUser,
     Path((task_id, session_id)): Path<(Uuid, Uuid)>,
 ) -> AppResult<Json<AgentSession>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
 
     // Ensure the session belongs to this task before attempting to stop it
     agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
@@ -222,9 +208,7 @@ pub async fn restart_agent_session(
     auth: AuthUser,
     Path((task_id, session_id)): Path<(Uuid, Uuid)>,
 ) -> AppResult<(StatusCode, Json<StartAgentSessionResponse>)> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
 
     let old_session =
         agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
@@ -275,9 +259,7 @@ pub async fn get_agent_session_outputs(
     Path((task_id, session_id)): Path<(Uuid, Uuid)>,
     Query(query): Query<GetOutputsQuery>,
 ) -> AppResult<Json<Vec<AgentSessionOutput>>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
 
     let outputs = match query.after {

--- a/backend/src/handlers/project_members.rs
+++ b/backend/src/handlers/project_members.rs
@@ -25,8 +25,7 @@ pub async fn list_members(
     auth: AuthUser,
     Path(project_id): Path<Uuid>,
 ) -> AppResult<Json<Vec<ProjectMember>>> {
-    project_service::get_project(&state.pool, project_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, project_id).await?;
+    authorization_service::authorize_project(&state.pool, auth.user_id, project_id).await?;
     let members = member_service::list_members(&state.pool, project_id).await?;
     Ok(Json(members))
 }

--- a/backend/src/handlers/task_comments.rs
+++ b/backend/src/handlers/task_comments.rs
@@ -32,9 +32,7 @@ pub async fn create_comment(
 ) -> AppResult<(StatusCode, Json<TaskComment>)> {
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let comment =
         task_comment_service::create_comment(&state.pool, task_id, auth.user_id, &body).await?;
     state
@@ -59,9 +57,7 @@ pub async fn list_comments(
     auth: AuthUser,
     Path(task_id): Path<Uuid>,
 ) -> AppResult<Json<Vec<TaskComment>>> {
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let comments = task_comment_service::list_comments(&state.pool, task_id).await?;
     Ok(Json(comments))
 }
@@ -90,9 +86,7 @@ pub async fn update_comment(
 ) -> AppResult<Json<TaskComment>> {
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
-    let task = task_service::get_task(&state.pool, task_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
     let comment =
         task_comment_service::update_comment(&state.pool, comment_id, auth.user_id, &body).await?;
     state

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -9,7 +9,7 @@ use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, AppResult};
 use crate::models::pagination::{self, PaginatedResponse};
 use crate::models::task::{CreateTaskRequest, Task, UpdateTaskRequest};
-use crate::services::{authorization_service, project_service, task_service};
+use crate::services::{authorization_service, task_service};
 use crate::sse::event::SseEvent;
 use crate::AppState;
 
@@ -43,9 +43,7 @@ pub async fn list_tasks(
     Query(query): Query<ListTasksQuery>,
 ) -> AppResult<Json<PaginatedResponse<Task>>> {
     pagination::validate(query.limit, query.offset)?;
-    project_service::get_project(&state.pool, query.project_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, query.project_id)
-        .await?;
+    authorization_service::authorize_project(&state.pool, auth.user_id, query.project_id).await?;
     let (tasks, total) = task_service::list_tasks_paginated(
         &state.pool,
         query.project_id,
@@ -80,9 +78,7 @@ pub async fn create_task(
 ) -> AppResult<(StatusCode, Json<Task>)> {
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
-    project_service::get_project(&state.pool, body.project_id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, body.project_id)
-        .await?;
+    authorization_service::authorize_project(&state.pool, auth.user_id, body.project_id).await?;
     let task = task_service::create_task(&state.pool, &body).await?;
     state
         .sse_hub
@@ -106,9 +102,7 @@ pub async fn get_task(
     auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> AppResult<Json<Task>> {
-    let task = task_service::get_task(&state.pool, id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, task.project_id)
-        .await?;
+    let task = authorization_service::authorize_task(&state.pool, auth.user_id, id).await?;
     Ok(Json(task))
 }
 
@@ -133,9 +127,7 @@ pub async fn update_task(
 ) -> AppResult<Json<Task>> {
     body.validate()
         .map_err(|e| AppError::Validation(e.to_string()))?;
-    let existing = task_service::get_task(&state.pool, id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, existing.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, id).await?;
     let task = task_service::update_task(&state.pool, id, &body).await?;
     state
         .sse_hub
@@ -159,9 +151,7 @@ pub async fn delete_task(
     auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> AppResult<StatusCode> {
-    let existing = task_service::get_task(&state.pool, id).await?;
-    authorization_service::require_project_member(&state.pool, auth.user_id, existing.project_id)
-        .await?;
+    authorization_service::authorize_task(&state.pool, auth.user_id, id).await?;
     task_service::delete_task(&state.pool, id).await?;
     state.sse_hub.broadcast(SseEvent::task_deleted(id));
     Ok(StatusCode::NO_CONTENT)

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -9,7 +9,9 @@ use crate::services::{project_service, task_service};
 /// Fetch a task and verify the user is a member of its project.
 /// Returns the task on success.
 pub async fn authorize_task(pool: &SqlitePool, user_id: Uuid, task_id: Uuid) -> AppResult<Task> {
-    todo!()
+    let task = task_service::get_task(pool, task_id).await?;
+    require_project_member(pool, user_id, task.project_id).await?;
+    Ok(task)
 }
 
 /// Verify a project exists and the user is a member.
@@ -18,7 +20,9 @@ pub async fn authorize_project(
     user_id: Uuid,
     project_id: Uuid,
 ) -> AppResult<()> {
-    todo!()
+    project_service::get_project(pool, project_id).await?;
+    require_project_member(pool, user_id, project_id).await?;
+    Ok(())
 }
 
 /// Check if user is a member of the project (any role).

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -3,6 +3,23 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project::MemberRole;
+use crate::models::task::Task;
+use crate::services::{project_service, task_service};
+
+/// Fetch a task and verify the user is a member of its project.
+/// Returns the task on success.
+pub async fn authorize_task(pool: &SqlitePool, user_id: Uuid, task_id: Uuid) -> AppResult<Task> {
+    todo!()
+}
+
+/// Verify a project exists and the user is a member.
+pub async fn authorize_project(
+    pool: &SqlitePool,
+    user_id: Uuid,
+    project_id: Uuid,
+) -> AppResult<()> {
+    todo!()
+}
 
 /// Check if user is a member of the project (any role).
 /// Returns the member's role or Forbidden.
@@ -368,6 +385,103 @@ mod tests {
 
         let project_ids = list_user_project_ids(&pool, user_id).await.unwrap();
         assert!(project_ids.is_empty());
+    }
+
+    // --- authorize_task ---
+
+    #[tokio::test]
+    async fn test_authorize_task_returns_task_for_member() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_with_member(&pool, MemberRole::Member).await;
+        let task = task_service::create_task(
+            &pool,
+            &crate::models::task::CreateTaskRequest {
+                project_id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = authorize_task(&pool, user_id, task.id).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, task.id);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_task_returns_forbidden_for_non_member() {
+        let pool = setup_test_db().await;
+        let (project_id, _owner) = setup_project_with_member(&pool, MemberRole::Owner).await;
+        let task = task_service::create_task(
+            &pool,
+            &crate::models::task::CreateTaskRequest {
+                project_id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let non_member = create_test_user(&pool).await;
+        let result = authorize_task(&pool, non_member, task.id).await;
+        assert!(matches!(result, Err(AppError::Forbidden(_))));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_task_returns_not_found_for_missing_task() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let result = authorize_task(&pool, user_id, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    // --- authorize_project ---
+
+    #[tokio::test]
+    async fn test_authorize_project_allows_member() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_with_member(&pool, MemberRole::Member).await;
+
+        let result = authorize_project(&pool, user_id, project_id).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_authorize_project_returns_forbidden_for_non_member() {
+        let pool = setup_test_db().await;
+        let project = project_service::create_project(
+            &pool,
+            &CreateProjectRequest {
+                name: "Test".to_string(),
+                description: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let non_member = create_test_user(&pool).await;
+        let result = authorize_project(&pool, non_member, project.id).await;
+        assert!(matches!(result, Err(AppError::Forbidden(_))));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_project_returns_not_found_for_missing_project() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let result = authorize_project(&pool, user_id, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
     }
 
     // --- count_owners ---


### PR DESCRIPTION
## Summary
- Add `authorize_task` and `authorize_project` helper functions to `authorization_service` that encapsulate the common pattern of fetching a resource and verifying project membership
- Replace 17 duplicated authorization patterns across 4 handler files (`tasks.rs`, `agent_sessions.rs`, `task_comments.rs`, `project_members.rs`) with calls to the new helpers
- Clean up unused imports (`project_service`, `task_service`) where no longer directly referenced

Closes #169 (partial — backend authorization deduplication)

## Test plan
- [x] 6 new unit tests for `authorize_task` and `authorize_project` (member access, non-member forbidden, resource not found)
- [x] All 356 existing tests pass
- [x] `cargo clippy` reports zero warnings