### PR TITLE
feat: ✨ add observability and transaction handling (#163, #166)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,11 @@ anyhow = "1"
 figment = { version = "0.10", features = ["env", "toml"] }
 dotenvy = "0.15"
 
-# Logging
+# Logging / Metrics
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+axum-prometheus = "0.10"
+metrics = "0.24"
 
 # Utilities
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,6 +26,8 @@ figment = { workspace = true }
 dotenvy = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+axum-prometheus = { workspace = true }
+metrics = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }

--- a/backend/src/agent/orchestrator.rs
+++ b/backend/src/agent/orchestrator.rs
@@ -210,6 +210,7 @@ impl AgentOrchestrator {
                     _monitor_handle: monitor_handle,
                 },
             );
+            metrics::gauge!("gantry_agent_sessions_active").set(running.len() as f64);
         }
 
         Ok(StartSessionResult {
@@ -248,6 +249,7 @@ impl AgentOrchestrator {
         {
             let mut running = self.running.lock().await;
             running.remove(&session_id);
+            metrics::gauge!("gantry_agent_sessions_active").set(running.len() as f64);
         }
 
         Ok(())
@@ -265,7 +267,9 @@ impl AgentOrchestrator {
     pub async fn shutdown_gracefully(&self) {
         let sessions: Vec<(Uuid, RunningSession)> = {
             let mut running = self.running.lock().await;
-            running.drain().collect()
+            let drained = running.drain().collect();
+            metrics::gauge!("gantry_agent_sessions_active").set(0.0);
+            drained
         };
 
         if sessions.is_empty() {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,13 +11,14 @@ pub mod sse;
 #[cfg(test)]
 pub mod test_helpers;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use axum::http::Method;
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
-use axum_prometheus::PrometheusMetricLayerBuilder;
+use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
+use axum_prometheus::{GenericMetricLayer, Handle};
 use sqlx::SqlitePool;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::GovernorLayer;
@@ -211,9 +212,10 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
         ));
 
-    let (prometheus_layer, metric_handle) = PrometheusMetricLayerBuilder::new()
-        .with_default_metrics()
-        .build_pair();
+    let metric_handle = init_metrics();
+    let (prometheus_layer, _) = GenericMetricLayer::<'_, PrometheusHandle, Handle>::pair_from(
+        Handle(metric_handle.clone()),
+    );
 
     Ok(Router::new()
         .route("/health", get(handlers::health::health_check))
@@ -247,6 +249,22 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         ))
         .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
         .with_state(state))
+}
+
+/// Initialize the Prometheus metrics recorder once (safe for repeated calls in tests).
+fn init_metrics() -> PrometheusHandle {
+    static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let recorder =
+                axum_prometheus::metrics_exporter_prometheus::PrometheusBuilder::default()
+                    .build_recorder();
+            let handle = recorder.handle();
+            // Ignore error if another recorder was already installed
+            let _ = metrics::set_global_recorder(recorder);
+            handle
+        })
+        .clone()
 }
 
 fn build_cors_layer(config: &config::Config) -> Result<CorsLayer, config::ConfigError> {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use axum::http::Method;
 use axum::routing::{delete, get, patch, post};
 use axum::Router;
+use axum_prometheus::PrometheusMetricLayerBuilder;
 use sqlx::SqlitePool;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::GovernorLayer;
@@ -210,14 +211,23 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
         ));
 
+    let (prometheus_layer, metric_handle) = PrometheusMetricLayerBuilder::new()
+        .with_default_metrics()
+        .build_pair();
+
     Ok(Router::new()
         .route("/health", get(handlers::health::health_check))
         .route("/health/live", get(handlers::health::liveness))
         .route("/health/ready", get(handlers::health::readiness))
+        .route(
+            "/metrics",
+            get(move || async move { metric_handle.render() }),
+        )
         .nest("/api", api_routes)
         .merge(
             SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
         )
+        .layer(prometheus_layer)
         .layer(build_cors_layer(&state.config)?)
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(TraceLayer::new_for_http().make_span_with(

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -243,6 +243,7 @@ fn validate_status_transition(from: &AgentSessionStatus, to: &AgentSessionStatus
     Ok(())
 }
 
+#[tracing::instrument(skip(pool, req), fields(session_id = %id, %task_id))]
 pub async fn update_agent_session(
     pool: &SqlitePool,
     task_id: Uuid,

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project::{AddMemberRequest, MemberRole, ProjectMember, UpdateMemberRequest};
-use crate::services::user_service;
 
 #[derive(FromRow)]
 struct MemberRow {
@@ -38,8 +37,19 @@ pub async fn add_member(
     project_id: Uuid,
     req: &AddMemberRequest,
 ) -> AppResult<ProjectMember> {
-    // Validate that the user exists before creating the membership
-    user_service::get_user(pool, req.user_id).await?;
+    let mut tx = pool.begin().await?;
+
+    // Validate that the user exists within the transaction
+    let user_exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
+        .bind(req.user_id.to_string())
+        .fetch_optional(&mut *tx)
+        .await?;
+    if user_exists.is_none() {
+        return Err(AppError::NotFound(format!(
+            "user {} not found",
+            req.user_id
+        )));
+    }
 
     let now = Utc::now();
 
@@ -53,8 +63,10 @@ pub async fn add_member(
     .bind(req.user_id.to_string())
     .bind(&req.role)
     .bind(now)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     get_member(pool, project_id, req.user_id).await
 }

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -32,6 +32,7 @@ impl TryFrom<MemberRow> for ProjectMember {
     }
 }
 
+#[tracing::instrument(skip(pool, req), fields(%project_id, user_id = %req.user_id))]
 pub async fn add_member(
     pool: &SqlitePool,
     project_id: Uuid,
@@ -111,6 +112,7 @@ pub async fn list_members(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<
         .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
 }
 
+#[tracing::instrument(skip(pool, req), fields(%project_id, %user_id))]
 pub async fn update_member_role(
     pool: &SqlitePool,
     project_id: Uuid,
@@ -136,6 +138,7 @@ pub async fn update_member_role(
     get_member(pool, project_id, user_id).await
 }
 
+#[tracing::instrument(skip(pool), fields(%project_id, %user_id))]
 pub async fn remove_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) -> AppResult<()> {
     let result = sqlx::query(
         r#"

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -32,6 +32,7 @@ impl TryFrom<MemberRow> for ProjectMember {
 }
 
 #[tracing::instrument(skip(pool, req), fields(%project_id, user_id = %req.user_id))]
+#[allow(clippy::explicit_auto_deref)] // sqlx Transaction requires explicit deref
 pub async fn add_member(
     pool: &SqlitePool,
     project_id: Uuid,

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -369,6 +369,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_add_member_nonexistent_user_leaves_no_row() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let nonexistent_user = Uuid::new_v4();
+
+        // Attempt to add a nonexistent user as a member — should fail
+        let result = add_member(
+            &pool,
+            project_id,
+            &AddMemberRequest {
+                user_id: nonexistent_user,
+                role: MemberRole::Member,
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+
+        // Verify no member row was created (atomicity guarantee)
+        let members = list_members(&pool, project_id)
+            .await
+            .expect("list should succeed");
+        assert!(
+            members.is_empty(),
+            "no member row should exist after failed add_member"
+        );
+    }
+
+    #[tokio::test]
     async fn test_remove_nonexistent_member_returns_not_found() {
         let pool = setup_test_db().await;
         let project_id = create_test_project(&pool).await;

--- a/backend/src/services/preview_service.rs
+++ b/backend/src/services/preview_service.rs
@@ -254,6 +254,7 @@ impl PreviewManager {
 
     /// Build and start a Docker container for a preview.
     /// This runs as a background task; callers should `tokio::spawn` it.
+    #[tracing::instrument(skip(self), fields(%preview_id))]
     pub async fn build_and_start(&self, preview_id: Uuid) -> AppResult<()> {
         // 1. Get preview record
         let preview = get_preview(&self.pool, preview_id).await?;
@@ -337,6 +338,7 @@ impl PreviewManager {
     }
 
     /// Stop a running container.
+    #[tracing::instrument(skip(self), fields(%preview_id))]
     pub async fn stop(&self, preview_id: Uuid) -> AppResult<DockerPreview> {
         let preview = get_preview(&self.pool, preview_id).await?;
 
@@ -356,6 +358,7 @@ impl PreviewManager {
     }
 
     /// Stop and remove the Docker container for a preview.
+    #[tracing::instrument(skip(self), fields(%preview_id))]
     pub async fn cleanup(&self, preview_id: Uuid) -> AppResult<()> {
         let preview = get_preview(&self.pool, preview_id).await?;
 

--- a/backend/src/services/project_service.rs
+++ b/backend/src/services/project_service.rs
@@ -29,6 +29,7 @@ impl TryFrom<ProjectRow> for Project {
     }
 }
 
+#[tracing::instrument(skip(pool, req))]
 pub async fn create_project(pool: &SqlitePool, req: &CreateProjectRequest) -> AppResult<Project> {
     let id = Uuid::new_v4();
     let now = Utc::now();
@@ -189,6 +190,7 @@ pub async fn list_projects_for_user_paginated(
     Ok((projects, total.0))
 }
 
+#[tracing::instrument(skip(pool, req), fields(project_id = %id))]
 pub async fn update_project(
     pool: &SqlitePool,
     id: Uuid,
@@ -226,6 +228,7 @@ pub async fn update_project(
     })
 }
 
+#[tracing::instrument(skip(pool), fields(project_id = %id))]
 pub async fn delete_project(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
     let result = sqlx::query(
         r#"

--- a/backend/src/services/session_service.rs
+++ b/backend/src/services/session_service.rs
@@ -59,6 +59,7 @@ pub async fn get_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<Optio
 
 /// Validate and update session's last_active_at timestamp
 /// Returns the session if valid, Unauthorized error if not found or expired
+#[tracing::instrument(skip(pool))]
 pub async fn validate_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<Session> {
     let session = get_session(pool, session_id).await?;
 
@@ -119,6 +120,7 @@ pub async fn delete_user_sessions(pool: &SqlitePool, user_id: Uuid) -> AppResult
 
 /// Delete all sessions for a user and create a new one atomically.
 /// Prevents session fixation by ensuring no window between delete and create.
+#[tracing::instrument(skip(pool))]
 pub async fn rotate_session(
     pool: &SqlitePool,
     user_id: Uuid,

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -808,6 +808,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_task_validation_failure_preserves_original() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let nonexistent_user = Uuid::new_v4();
+
+        let created = create_task(
+            &pool,
+            &CreateTaskRequest {
+                project_id,
+                title: "Original Title".to_string(),
+                description: Some("Original Description".to_string()),
+                status: Some(TaskStatus::Backlog),
+                priority: Some(TaskPriority::Low),
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("task creation should succeed");
+
+        // Attempt update with invalid assigned_to AND other valid field changes.
+        // The entire operation must be atomic: either all fields update or none do.
+        let result = update_task(
+            &pool,
+            created.id,
+            &UpdateTaskRequest {
+                title: Some("Changed Title".to_string()),
+                description: Some("Changed Description".to_string()),
+                status: Some(TaskStatus::Done),
+                priority: Some(TaskPriority::Urgent),
+                parent_id: None,
+                assigned_to: Some(nonexistent_user),
+                position: Some(99),
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::Validation(_))));
+
+        // Verify the task in DB is completely unchanged
+        let after = get_task(&pool, created.id)
+            .await
+            .expect("task should still exist");
+        assert_eq!(after.title, "Original Title");
+        assert_eq!(after.description, Some("Original Description".to_string()));
+        assert!(matches!(after.status, TaskStatus::Backlog));
+        assert!(matches!(after.priority, TaskPriority::Low));
+        assert_eq!(after.position, 0);
+        assert!(after.assigned_to.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_task_validation_failure_leaves_no_row() {
+        let pool = setup_test_db().await;
+        let project1 = create_test_project(&pool).await;
+        let project2 = create_test_project(&pool).await;
+
+        // Create a parent in project2
+        let parent = create_task(
+            &pool,
+            &CreateTaskRequest {
+                project_id: project2,
+                title: "Parent in P2".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("parent task creation should succeed");
+
+        // Attempt to create a task in project1 with parent in project2 — should fail validation
+        let result = create_task(
+            &pool,
+            &CreateTaskRequest {
+                project_id: project1,
+                title: "Orphan".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: Some(parent.id),
+                assigned_to: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::Validation(_))));
+
+        // Verify no task was created in project1
+        let tasks = list_tasks(&pool, project1)
+            .await
+            .expect("list should succeed");
+        assert!(tasks.is_empty(), "no task should exist after failed create");
+    }
+
+    #[tokio::test]
     async fn test_update_task_with_parent_in_different_project_returns_validation_error() {
         let pool = setup_test_db().await;
         let project1 = create_test_project(&pool).await;

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
 use sqlx::prelude::FromRow;
+use sqlx::sqlite::SqliteConnection;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::task::{CreateTaskRequest, Task, TaskPriority, TaskStatus, UpdateTaskRequest};
-use crate::services::user_service;
 
 #[derive(FromRow)]
 struct TaskRow {
@@ -44,8 +44,10 @@ impl TryFrom<TaskRow> for Task {
 
 #[tracing::instrument(skip(pool, req), fields(project_id = %req.project_id))]
 pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResult<Task> {
-    validate_assigned_to(pool, req.assigned_to).await?;
-    validate_parent_project(pool, req.parent_id, req.project_id).await?;
+    let mut tx = pool.begin().await?;
+
+    validate_assigned_to_tx(&mut *tx, req.assigned_to).await?;
+    validate_parent_project_tx(&mut *tx, req.parent_id, req.project_id).await?;
 
     let id = Uuid::new_v4();
     let now = Utc::now();
@@ -69,8 +71,10 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
     .bind(0i32)
     .bind(now)
     .bind(now)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(Task {
         id,
@@ -165,10 +169,12 @@ pub async fn list_tasks_paginated(
 
 #[tracing::instrument(skip(pool, req), fields(task_id = %id))]
 pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -> AppResult<Task> {
-    let existing = get_task(pool, id).await?;
+    let mut tx = pool.begin().await?;
 
-    validate_assigned_to(pool, req.assigned_to).await?;
-    validate_parent_project(pool, req.parent_id, existing.project_id).await?;
+    let existing = get_task_tx(&mut *tx, id).await?;
+
+    validate_assigned_to_tx(&mut *tx, req.assigned_to).await?;
+    validate_parent_project_tx(&mut *tx, req.parent_id, existing.project_id).await?;
 
     let now = Utc::now();
 
@@ -196,8 +202,10 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     .bind(position)
     .bind(now)
     .bind(id.to_string())
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(Task {
         id,
@@ -214,29 +222,50 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     })
 }
 
-async fn validate_assigned_to(pool: &SqlitePool, assigned_to: Option<Uuid>) -> AppResult<()> {
+async fn get_task_tx(conn: &mut SqliteConnection, id: Uuid) -> AppResult<Task> {
+    let row = sqlx::query_as::<_, TaskRow>(
+        r#"
+        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
+        FROM tasks
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    row.map(|r| r.try_into())
+        .transpose()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("task {} not found", id)))
+}
+
+async fn validate_assigned_to_tx(
+    conn: &mut SqliteConnection,
+    assigned_to: Option<Uuid>,
+) -> AppResult<()> {
     if let Some(user_id) = assigned_to {
-        match user_service::get_user(pool, user_id).await {
-            Err(AppError::NotFound(_)) => {
-                return Err(AppError::Validation(format!(
-                    "assigned user {} does not exist",
-                    user_id
-                )));
-            }
-            Err(e) => return Err(e),
-            Ok(_) => {}
+        let exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
+            .bind(user_id.to_string())
+            .fetch_optional(&mut *conn)
+            .await?;
+        if exists.is_none() {
+            return Err(AppError::Validation(format!(
+                "assigned user {} does not exist",
+                user_id
+            )));
         }
     }
     Ok(())
 }
 
-async fn validate_parent_project(
-    pool: &SqlitePool,
+async fn validate_parent_project_tx(
+    conn: &mut SqliteConnection,
     parent_id: Option<Uuid>,
     project_id: Uuid,
 ) -> AppResult<()> {
     if let Some(pid) = parent_id {
-        let parent = get_task(pool, pid).await.map_err(|e| match e {
+        let parent = get_task_tx(&mut *conn, pid).await.map_err(|e| match e {
             AppError::NotFound(_) => {
                 AppError::Validation(format!("parent task {} does not exist", pid))
             }

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -43,6 +43,7 @@ impl TryFrom<TaskRow> for Task {
 }
 
 #[tracing::instrument(skip(pool, req), fields(project_id = %req.project_id))]
+#[allow(clippy::explicit_auto_deref)] // sqlx Transaction requires explicit deref
 pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 
@@ -168,6 +169,7 @@ pub async fn list_tasks_paginated(
 }
 
 #[tracing::instrument(skip(pool, req), fields(task_id = %id))]
+#[allow(clippy::explicit_auto_deref)] // sqlx Transaction requires explicit deref
 pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 

--- a/backend/src/services/task_service.rs
+++ b/backend/src/services/task_service.rs
@@ -42,6 +42,7 @@ impl TryFrom<TaskRow> for Task {
     }
 }
 
+#[tracing::instrument(skip(pool, req), fields(project_id = %req.project_id))]
 pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResult<Task> {
     validate_assigned_to(pool, req.assigned_to).await?;
     validate_parent_project(pool, req.parent_id, req.project_id).await?;
@@ -162,6 +163,7 @@ pub async fn list_tasks_paginated(
     Ok((tasks, total.0))
 }
 
+#[tracing::instrument(skip(pool, req), fields(task_id = %id))]
 pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -> AppResult<Task> {
     let existing = get_task(pool, id).await?;
 
@@ -249,6 +251,7 @@ async fn validate_parent_project(
     Ok(())
 }
 
+#[tracing::instrument(skip(pool), fields(task_id = %id))]
 pub async fn delete_task(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
     let result = sqlx::query(
         r#"

--- a/backend/src/sse/handler.rs
+++ b/backend/src/sse/handler.rs
@@ -1,4 +1,6 @@
 use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use axum::extract::State;
@@ -10,11 +12,32 @@ use tokio_stream::StreamExt;
 use crate::auth::middleware::AuthUser;
 use crate::AppState;
 
+/// Wrapper stream that decrements the SSE connection gauge on drop.
+struct TrackedStream<S> {
+    inner: Pin<Box<S>>,
+}
+
+impl<S: Stream> Stream for TrackedStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+impl<S> Drop for TrackedStream<S> {
+    fn drop(&mut self) {
+        metrics::gauge!("gantry_sse_connections_active").decrement(1.0);
+    }
+}
+
 /// SSE endpoint for real-time task updates
 pub async fn sse_handler(
     _auth: AuthUser,
     State(state): State<AppState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    metrics::gauge!("gantry_sse_connections_active").increment(1.0);
+
     let rx = state.sse_hub.subscribe();
     let stream = BroadcastStream::new(rx).filter_map(|result| {
         result.ok().and_then(|event| {
@@ -25,7 +48,10 @@ pub async fn sse_handler(
         })
     });
 
-    Sse::new(stream).keep_alive(
+    Sse::new(TrackedStream {
+        inner: Box::pin(stream),
+    })
+    .keep_alive(
         KeepAlive::new()
             .interval(Duration::from_secs(30))
             .text("keep-alive"),

--- a/backend/tests/health_api.rs
+++ b/backend/tests/health_api.rs
@@ -63,6 +63,28 @@ async fn test_response_contains_x_request_id_header() {
 }
 
 #[tokio::test]
+async fn test_metrics_endpoint_returns_prometheus_format() {
+    let server = create_test_server().await;
+
+    // Make a request first so there's at least one metric recorded
+    server.get("/health").await;
+
+    let response = server.get("/metrics").await;
+    response.assert_status(StatusCode::OK);
+
+    let body = response.text();
+    // axum-prometheus provides these standard HTTP metrics
+    assert!(
+        body.contains("axum_http_requests_total"),
+        "metrics should contain axum_http_requests_total"
+    );
+    assert!(
+        body.contains("axum_http_requests_duration_seconds"),
+        "metrics should contain axum_http_requests_duration_seconds"
+    );
+}
+
+#[tokio::test]
 async fn test_x_request_id_propagated_from_client() {
     let server = create_test_server().await;
     let client_id = Uuid::new_v4().to_string();


### PR DESCRIPTION
## Summary

- Add Prometheus metrics endpoint (`/metrics`) with automatic HTTP request metrics (`axum_http_requests_total`, `axum_http_requests_duration_seconds`, `axum_http_requests_pending`)
- Add custom application metrics: `gantry_agent_sessions_active` gauge and `gantry_sse_connections_active` gauge with drop-guard tracking
- Add `#[tracing::instrument]` to 15 service functions across 6 files for structured span creation
- Wrap `create_task`, `update_task`, and `add_member` in SQLite transactions to eliminate TOCTOU race conditions

## Test plan

- [x] `test_metrics_endpoint_returns_prometheus_format` — verifies `/metrics` returns Prometheus text format
- [x] `test_update_task_validation_failure_preserves_original` — verifies atomicity on validation failure
- [x] `test_create_task_validation_failure_leaves_no_row` — verifies no partial task on create failure
- [x] `test_add_member_nonexistent_user_leaves_no_row` — verifies no partial member on add failure
- [x] All 360 tests pass (222 unit + 138 integration)

Closes #163
Closes #166