### PR TITLE
chore: 🔧 introduce dev tooling (security, coverage, dep health)

### DIFF
--- a/.claude/skills/quality-checks/SKILL.md
+++ b/.claude/skills/quality-checks/SKILL.md
@@ -18,6 +18,9 @@ description: Taskfile commands for code quality checks and formatting
 | API export | `task api:export` | After modifying utoipa annotations |
 | API generate | `task api:generate` | After OpenAPI spec changes |
 | API diff | `task api:diff` | CI — verify generated code is up to date |
+| Security audit | `task audit` | Before release / periodic |
+| Coverage | `task coverage` | After major changes |
+| Dep health | `task deps:check` | Periodic maintenance |
 
 ## Layer-specific Commands
 
@@ -25,6 +28,21 @@ description: Taskfile commands for code quality checks and formatting
 |-------|--------|------|-------|------|
 | Backend | `task backend:fmt` | `task backend:lint` | `task backend:build` | `task backend:test` |
 | Frontend | `task frontend:fmt` | `task frontend:lint` | `task frontend:build` | `task frontend:test` |
+
+## Security & Maintenance Commands
+
+| Check | Command | Description |
+|-------|---------|-------------|
+| cargo-deny | `task backend:deny` | Advisories, licenses, bans, sources |
+| npm audit | `task frontend:audit` | Frontend dependency vulnerabilities |
+| Security (all) | `task audit` | Both backend + frontend security |
+| Backend coverage | `task backend:coverage` | HTML report (opens in browser) |
+| Backend coverage (CI) | `task backend:coverage:lcov` | lcov output for CI |
+| Frontend coverage | `task frontend:coverage` | Vitest with v8 coverage |
+| Coverage (all) | `task coverage` | Both backend + frontend coverage |
+| Outdated deps | `task backend:outdated` | Check for outdated Rust deps |
+| Unused deps | `task backend:machete` | Detect unused Rust deps |
+| Dep health (all) | `task deps:check` | Outdated + unused check |
 
 ## Automated Hooks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
               - 'backend/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'deny.toml'
               - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
             frontend:
@@ -146,3 +147,21 @@ jobs:
       - run: cd frontend && npx biome check src/
       - run: cd frontend && npx vitest run
       - run: cd frontend && npm run build
+
+  # ── Security (cargo-deny, npm audit) ───────────
+  security:
+    name: Security (cargo-deny, npm audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm audit --audit-level=moderate
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       - run: cd frontend && npm run build
 
   # ── Security (cargo-deny, npm audit) ───────────
+  # Runs unconditionally: vulnerability databases update independently of code changes
   security:
     name: Security (cargo-deny, npm audit)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,21 @@ jobs:
       - run: cd frontend && npm ci
       - run: cd frontend && npm audit --audit-level=moderate
         continue-on-error: true
+
+  # ── Coverage (informational) ───────────────────
+  coverage:
+    name: Coverage (informational)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-nextest
+      - run: cargo llvm-cov nextest --text --skip-functions
+        working-directory: backend

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ node_modules/
 dist/
 .vite/
 
+# Coverage reports
+coverage/
+lcov.info
+
 # Environment
 .env
 .env.local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,11 +1,21 @@
 version: "3"
 
-vars:
-  FRONTEND_DIR: frontend
-  BACKEND_DIR: backend
+includes:
+  backend:
+    taskfile: ./taskfiles/backend.yml
+    dir: backend
+  frontend:
+    taskfile: ./taskfiles/frontend.yml
+    dir: frontend
+  db:
+    taskfile: ./taskfiles/db.yml
+    dir: backend
+  api:
+    taskfile: ./taskfiles/api.yml
+    dir: frontend
 
 tasks:
-  # ── 全体 ──────────────────────────────────────
+  # ── Orchestration ───────────────────────────────
   check:
     desc: Run all checks (fmt, lint, build, test)
     cmds:
@@ -57,165 +67,17 @@ tasks:
       - backend:test
       - frontend:test
 
-  # ── Backend (Rust) ────────────────────────────
-  backend:fmt:
-    desc: Format Rust code
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo fmt
-
-  backend:fmt:check:
-    desc: Check Rust formatting
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo fmt --check
-
-  backend:lint:
-    desc: Run clippy
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo clippy --all-targets -- -D warnings
-
-  backend:build:
-    desc: Build Rust backend
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo build
-
-  backend:test:
-    desc: Run all Rust tests (unit + integration)
-    dir: "{{.BACKEND_DIR}}"
-    cmd: '{{if .HAS_NEXTEST}}cargo nextest run{{else}}cargo test{{end}}'
-    vars:
-      HAS_NEXTEST:
-        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
-
-  backend:test:unit:
-    desc: Run unit tests only (fast, no DB/HTTP)
-    dir: "{{.BACKEND_DIR}}"
-    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --lib{{else}}cargo test --lib{{end}}'
-    vars:
-      HAS_NEXTEST:
-        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
-
-  backend:test:integration:
-    desc: Run integration tests only (API endpoints)
-    dir: "{{.BACKEND_DIR}}"
-    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --test "*"{{else}}cargo test --test "*"{{end}}'
-    vars:
-      HAS_NEXTEST:
-        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
-
-  backend:run:
-    desc: Run backend server
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo run
-    env:
-      RUST_LOG: info
-
-  # ── Database (sqlx) ──────────────────────────────
-  db:create:
-    desc: Create SQLite database
-    dir: "{{.BACKEND_DIR}}"
-    cmd: sqlx database create
-
-  db:migrate:
-    desc: Run database migrations
-    dir: "{{.BACKEND_DIR}}"
-    cmd: sqlx migrate run
-
-  db:migrate:add:
-    desc: "Create a new migration (usage: task db:migrate:add -- <name>)"
-    dir: "{{.BACKEND_DIR}}"
-    cmd: sqlx migrate add {{.CLI_ARGS}}
-
-  db:migrate:info:
-    desc: Show migration status
-    dir: "{{.BACKEND_DIR}}"
-    cmd: sqlx migrate info
-
-  db:reset:
-    desc: Drop and recreate database
-    dir: "{{.BACKEND_DIR}}"
-    cmds:
-      - sqlx database drop -y
-      - sqlx database create
-      - sqlx migrate run
-
-  # ── Frontend (React/TypeScript) ───────────────
-  frontend:fmt:
-    desc: Format frontend code with Biome
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npx biome format --write src/
-
-  frontend:fmt:check:
-    desc: Check frontend formatting
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npx biome format src/
-
-  frontend:lint:
-    desc: Lint frontend code
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npx biome lint src/
-
-  frontend:build:
-    desc: Build frontend
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npm run build
-
-  frontend:test:
-    desc: Run frontend tests
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npx vitest run
-
-  frontend:dev:
-    desc: Start Vite dev server
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npm run dev
-
-  # ── Coverage ────────────────────────────────────
-  backend:coverage:
-    desc: Run Rust tests with code coverage (HTML report)
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo llvm-cov nextest --html --open
-
-  backend:coverage:lcov:
-    desc: Run Rust tests with code coverage (lcov output for CI)
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo llvm-cov nextest --lcov --output-path lcov.info
-
-  frontend:coverage:
-    desc: Run frontend tests with coverage
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npx vitest run --coverage
-
   coverage:
     desc: Run all tests with coverage
     deps:
       - backend:coverage:lcov
       - frontend:coverage
 
-  # ── Security ────────────────────────────────────
-  backend:deny:
-    desc: Run cargo-deny (advisories, licenses, bans, sources)
-    cmd: cargo deny check
-
-  frontend:audit:
-    desc: Run npm audit for frontend dependencies
-    dir: "{{.FRONTEND_DIR}}"
-    cmd: npm audit --audit-level=moderate
-
   audit:
     desc: Run security audits (backend + frontend)
     deps:
       - backend:deny
       - frontend:audit
-
-  # ── Dependency health ────────────────────────────
-  backend:outdated:
-    desc: Check for outdated Rust dependencies
-    cmd: cargo outdated --workspace --root-deps-only
-
-  backend:machete:
-    desc: Detect unused Rust dependencies
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo machete
 
   deps:check:
     desc: Check dependency health (outdated + unused)
@@ -227,25 +89,3 @@ tasks:
   gitmoji:sync:
     desc: Sync gitmoji pattern from upstream
     cmd: .claude/hooks/sync-gitmoji-pattern.sh
-
-  # ── API (OpenAPI / orval) ─────────────────────
-  api:export:
-    desc: Export OpenAPI spec from Rust tests
-    dir: "{{.BACKEND_DIR}}"
-    cmd: cargo test --test export_openapi -- --nocapture
-    generates:
-      - openapi.json
-
-  api:generate:
-    desc: Generate TypeScript client from OpenAPI spec
-    dir: "{{.FRONTEND_DIR}}"
-    deps: [api:export]
-    cmds:
-      - npx orval
-      - npx biome check --write src/api/generated/
-
-  api:diff:
-    desc: Check if generated API client is up to date
-    dir: "{{.FRONTEND_DIR}}"
-    deps: [api:generate]
-    cmd: git diff --exit-code src/api/generated/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -169,6 +169,28 @@ tasks:
     dir: "{{.FRONTEND_DIR}}"
     cmd: npm run dev
 
+  # ── Coverage ────────────────────────────────────
+  backend:coverage:
+    desc: Run Rust tests with code coverage (HTML report)
+    dir: "{{.BACKEND_DIR}}"
+    cmd: cargo llvm-cov nextest --html --open
+
+  backend:coverage:lcov:
+    desc: Run Rust tests with code coverage (lcov output for CI)
+    dir: "{{.BACKEND_DIR}}"
+    cmd: cargo llvm-cov nextest --lcov --output-path lcov.info
+
+  frontend:coverage:
+    desc: Run frontend tests with coverage
+    dir: "{{.FRONTEND_DIR}}"
+    cmd: npx vitest run --coverage
+
+  coverage:
+    desc: Run all tests with coverage
+    deps:
+      - backend:coverage:lcov
+      - frontend:coverage
+
   # ── Security ────────────────────────────────────
   backend:deny:
     desc: Run cargo-deny (advisories, licenses, bans, sources)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -169,6 +169,22 @@ tasks:
     dir: "{{.FRONTEND_DIR}}"
     cmd: npm run dev
 
+  # ── Security ────────────────────────────────────
+  backend:deny:
+    desc: Run cargo-deny (advisories, licenses, bans, sources)
+    cmd: cargo deny check
+
+  frontend:audit:
+    desc: Run npm audit for frontend dependencies
+    dir: "{{.FRONTEND_DIR}}"
+    cmd: npm audit --audit-level=moderate
+
+  audit:
+    desc: Run security audits (backend + frontend)
+    deps:
+      - backend:deny
+      - frontend:audit
+
   # ── Gitmoji ───────────────────────────────────
   gitmoji:sync:
     desc: Sync gitmoji pattern from upstream

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -207,6 +207,22 @@ tasks:
       - backend:deny
       - frontend:audit
 
+  # ── Dependency health ────────────────────────────
+  backend:outdated:
+    desc: Check for outdated Rust dependencies
+    cmd: cargo outdated --workspace --root-deps-only
+
+  backend:machete:
+    desc: Detect unused Rust dependencies
+    dir: "{{.BACKEND_DIR}}"
+    cmd: cargo machete
+
+  deps:check:
+    desc: Check dependency health (outdated + unused)
+    cmds:
+      - task: backend:outdated
+      - task: backend:machete
+
   # ── Gitmoji ───────────────────────────────────
   gitmoji:sync:
     desc: Sync gitmoji pattern from upstream

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+[graph]
+targets = []
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+# Advisory database checks (vulnerabilities, unmaintained, yanked)
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but utoipa-axum depends on it; no alternative yet" },
+    { id = "RUSTSEC-2023-0071", reason = "rsa timing sidechannel — transitive dep via octocrab/jsonwebtoken; no fix available" },
+]
+
+# License checks — Apache-2.0 compatible allow list
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "OpenSSL",
+    "CC0-1.0",
+    "BSL-1.0",
+    "MPL-2.0",
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[licenses.private]
+ignore = false
+registries = []
+
+# Ban checks — warn on duplicate versions
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+# Source checks — only allow crates.io
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/devbox.json
+++ b/devbox.json
@@ -21,6 +21,7 @@
       "# Install cargo tools (first time only)",
       "if ! command -v sqlx > /dev/null 2>&1; then echo 'Installing sqlx-cli (first time only)...'; cargo install sqlx-cli --no-default-features --features sqlite --locked; fi",
       "if ! command -v cargo-watch > /dev/null 2>&1; then echo 'Installing cargo-watch (first time only)...'; cargo install cargo-watch --locked; fi",
+      "if ! command -v cargo-deny > /dev/null 2>&1; then echo 'Installing cargo-deny (first time only)...'; cargo install cargo-deny --locked; fi",
       "# Frontend dependencies",
       "if [ ! -d frontend/node_modules ]; then echo 'Installing frontend dependencies...'; (cd frontend && npm ci); fi",
       "echo 'Development environment ready!'",

--- a/devbox.json
+++ b/devbox.json
@@ -22,6 +22,8 @@
       "if ! command -v sqlx > /dev/null 2>&1; then echo 'Installing sqlx-cli (first time only)...'; cargo install sqlx-cli --no-default-features --features sqlite --locked; fi",
       "if ! command -v cargo-watch > /dev/null 2>&1; then echo 'Installing cargo-watch (first time only)...'; cargo install cargo-watch --locked; fi",
       "if ! command -v cargo-deny > /dev/null 2>&1; then echo 'Installing cargo-deny (first time only)...'; cargo install cargo-deny --locked; fi",
+      "if ! command -v cargo-llvm-cov > /dev/null 2>&1; then echo 'Installing cargo-llvm-cov (first time only)...'; cargo install cargo-llvm-cov --locked; fi",
+      "rustup component add llvm-tools-preview 2>/dev/null || true",
       "# Frontend dependencies",
       "if [ ! -d frontend/node_modules ]; then echo 'Installing frontend dependencies...'; (cd frontend && npm ci); fi",
       "echo 'Development environment ready!'",

--- a/devbox.json
+++ b/devbox.json
@@ -23,6 +23,8 @@
       "if ! command -v cargo-watch > /dev/null 2>&1; then echo 'Installing cargo-watch (first time only)...'; cargo install cargo-watch --locked; fi",
       "if ! command -v cargo-deny > /dev/null 2>&1; then echo 'Installing cargo-deny (first time only)...'; cargo install cargo-deny --locked; fi",
       "if ! command -v cargo-llvm-cov > /dev/null 2>&1; then echo 'Installing cargo-llvm-cov (first time only)...'; cargo install cargo-llvm-cov --locked; fi",
+      "if ! command -v cargo-outdated > /dev/null 2>&1; then echo 'Installing cargo-outdated (first time only)...'; cargo install cargo-outdated --locked; fi",
+      "if ! command -v cargo-machete > /dev/null 2>&1; then echo 'Installing cargo-machete (first time only)...'; cargo install cargo-machete --locked; fi",
       "rustup component add llvm-tools-preview 2>/dev/null || true",
       "# Frontend dependencies",
       "if [ ! -d frontend/node_modules ]; then echo 'Installing frontend dependencies...'; (cd frontend && npm ci); fi",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,13 +29,13 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^3.2.4",
-        "@vitest/ui": "^3.1.0",
+        "@vitest/ui": "^3.2.4",
         "jsdom": "^26.1.0",
         "orval": "^7.13.2",
         "tailwindcss": "^4.1.0",
         "typescript": "~5.9.3",
         "vite": "^7.2.4",
-        "vitest": "^3.1.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.1.0",
         "jsdom": "^26.1.0",
         "orval": "^7.13.2",
@@ -43,6 +44,20 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "14.0.1",
@@ -417,6 +432,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1257,6 +1282,119 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1999,6 +2137,17 @@
         "@orval/core": "7.21.0",
         "lodash.uniq": "^4.5.0",
         "openapi3-ts": "4.5.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -3337,6 +3486,40 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3681,6 +3864,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astring": {
       "version": "1.9.0",
@@ -4267,6 +4469,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
@@ -4754,6 +4963,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
@@ -4925,6 +5164,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -4936,6 +5197,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globalthis": {
@@ -5102,6 +5379,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5633,6 +5917,76 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -6218,6 +6572,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -6344,6 +6739,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mrmime": {
@@ -6774,6 +7179,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -6806,6 +7218,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7667,6 +8103,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -7727,6 +8179,20 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -7859,6 +8325,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -8632,6 +9129,25 @@
       }
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.1.0",
     "jsdom": "^26.1.0",
     "orval": "^7.13.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,12 +37,12 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^3.2.4",
-    "@vitest/ui": "^3.1.0",
+    "@vitest/ui": "^3.2.4",
     "jsdom": "^26.1.0",
     "orval": "^7.13.2",
     "tailwindcss": "^4.1.0",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
-    "vitest": "^3.1.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,5 +8,17 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     pool: 'forks',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/test/**',
+        'src/api/generated/**',
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.d.ts',
+      ],
+    },
   },
 });

--- a/taskfiles/api.yml
+++ b/taskfiles/api.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+tasks:
+  export:
+    desc: Export OpenAPI spec from Rust tests
+    dir: "{{.ROOT_DIR}}/backend"
+    cmd: cargo test --test export_openapi -- --nocapture
+    generates:
+      - openapi.json
+
+  generate:
+    desc: Generate TypeScript client from OpenAPI spec
+    deps: [export]
+    cmds:
+      - npx orval
+      - npx biome check --write src/api/generated/
+
+  diff:
+    desc: Check if generated API client is up to date
+    deps: [generate]
+    cmd: git diff --exit-code src/api/generated/

--- a/taskfiles/backend.yml
+++ b/taskfiles/backend.yml
@@ -65,3 +65,4 @@ tasks:
   machete:
     desc: Detect unused Rust dependencies
     cmd: cargo machete
+    dir: "{{.ROOT_DIR}}"

--- a/taskfiles/backend.yml
+++ b/taskfiles/backend.yml
@@ -1,0 +1,67 @@
+version: "3"
+
+tasks:
+  fmt:
+    desc: Format Rust code
+    cmd: cargo fmt
+
+  fmt:check:
+    desc: Check Rust formatting
+    cmd: cargo fmt --check
+
+  lint:
+    desc: Run clippy
+    cmd: cargo clippy --all-targets -- -D warnings
+
+  build:
+    desc: Build Rust backend
+    cmd: cargo build
+
+  test:
+    desc: Run all Rust tests (unit + integration)
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run{{else}}cargo test{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
+
+  test:unit:
+    desc: Run unit tests only (fast, no DB/HTTP)
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --lib{{else}}cargo test --lib{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
+
+  test:integration:
+    desc: Run integration tests only (API endpoints)
+    cmd: '{{if .HAS_NEXTEST}}cargo nextest run --test "*"{{else}}cargo test --test "*"{{end}}'
+    vars:
+      HAS_NEXTEST:
+        sh: command -v cargo-nextest >/dev/null 2>&1 && echo "true" || echo ""
+
+  run:
+    desc: Run backend server
+    cmd: cargo run
+    env:
+      RUST_LOG: info
+
+  coverage:
+    desc: Run Rust tests with code coverage (HTML report)
+    cmd: cargo llvm-cov nextest --html --open
+
+  coverage:lcov:
+    desc: Run Rust tests with code coverage (lcov output for CI)
+    cmd: cargo llvm-cov nextest --lcov --output-path lcov.info
+
+  deny:
+    desc: Run cargo-deny (advisories, licenses, bans, sources)
+    cmd: cargo deny check
+    dir: "{{.ROOT_DIR}}"
+
+  outdated:
+    desc: Check for outdated Rust dependencies
+    cmd: cargo outdated --workspace --root-deps-only
+    dir: "{{.ROOT_DIR}}"
+
+  machete:
+    desc: Detect unused Rust dependencies
+    cmd: cargo machete

--- a/taskfiles/db.yml
+++ b/taskfiles/db.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+tasks:
+  create:
+    desc: Create SQLite database
+    cmd: sqlx database create
+
+  migrate:
+    desc: Run database migrations
+    cmd: sqlx migrate run
+
+  migrate:add:
+    desc: "Create a new migration (usage: task db:migrate:add -- <name>)"
+    cmd: sqlx migrate add {{.CLI_ARGS}}
+
+  migrate:info:
+    desc: Show migration status
+    cmd: sqlx migrate info
+
+  reset:
+    desc: Drop and recreate database
+    cmds:
+      - sqlx database drop -y
+      - sqlx database create
+      - sqlx migrate run

--- a/taskfiles/frontend.yml
+++ b/taskfiles/frontend.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+tasks:
+  fmt:
+    desc: Format frontend code with Biome
+    cmd: npx biome format --write src/
+
+  fmt:check:
+    desc: Check frontend formatting
+    cmd: npx biome format src/
+
+  lint:
+    desc: Lint frontend code
+    cmd: npx biome lint src/
+
+  build:
+    desc: Build frontend
+    cmd: npm run build
+
+  test:
+    desc: Run frontend tests
+    cmd: npx vitest run
+
+  dev:
+    desc: Start Vite dev server
+    cmd: npm run dev
+
+  coverage:
+    desc: Run frontend tests with coverage
+    cmd: npx vitest run --coverage
+
+  audit:
+    desc: Run npm audit for frontend dependencies
+    cmd: npm audit --audit-level=moderate


### PR DESCRIPTION
## Summary

- **#181** cargo-deny + npm audit for security scanning (CI blocking + local tasks)
- **#182** Code coverage tooling: cargo-llvm-cov (backend) + @vitest/coverage-v8 (frontend), informational CI job
- **#183** Dependency health tools: cargo-outdated + cargo-machete (local only)
- **Bonus** Split Taskfile.yml (251→91 lines) into modular includes under `taskfiles/`

## Changes

### Security (#181)
- `deny.toml` — cargo-deny config (advisories, licenses, bans, sources)
- CI `security` job — cargo-deny (blocking) + npm audit (continue-on-error)
- `Cargo.lock` — bytes 1.11.0→1.11.1 (RUSTSEC-2026-0007 fix)

### Coverage (#182)
- `@vitest/coverage-v8` for frontend coverage with v8 provider
- `vitest.config.ts` coverage config (excludes test helpers, generated API, type files)
- CI `coverage` job (informational, continue-on-error) for backend cargo-llvm-cov
- `.gitignore` — coverage/ and lcov.info

### Dependency health (#183)
- `cargo-outdated --workspace --root-deps-only` — check outdated direct deps
- `cargo-machete` — detect unused Rust deps (heuristic-based, may have false positives)
- Local-only tasks, no CI integration

### Taskfile split
- Root `Taskfile.yml` — includes + orchestration only (91 lines)
- `taskfiles/backend.yml` — all backend:* tasks
- `taskfiles/frontend.yml` — all frontend:* tasks
- `taskfiles/db.yml` — all db:* tasks
- `taskfiles/api.yml` — all api:* tasks

### Documentation
- `.claude/skills/quality-checks/SKILL.md` — added security, coverage, dep health commands

## Test plan

- [x] `task check` — all 438 tests pass
- [x] `cargo deny check` — passes (2 ignored advisories with no fix available)
- [x] `npx vitest run --coverage` — coverage report generated
- [x] `cargo outdated --workspace --root-deps-only` — lists outdated deps
- [x] `cargo machete` — detects unused deps
- [x] `task --list` — all tasks visible after Taskfile split
- [x] `task api:export` — works through includes

Closes #181, closes #182, closes #183