### PR TITLE
feat: ✨ add production Docker and WebSocket transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,18 @@ GANTRY_DATABASE_URL=sqlite:gantry_board.db?mode=rwc
 # Logging
 RUST_LOG=info
 
+# Authentication (required for production; generate with: openssl rand -hex 32)
+# GANTRY_AUTH_SECRET=
+
+# CORS origin (set to the URL users access the app from)
+# GANTRY_CORS_ORIGIN=http://localhost
+
+# Cookie security (set to true when using HTTPS)
+# GANTRY_COOKIE_SECURE=false
+
 # GitHub (optional)
 # GANTRY_GITHUB_TOKEN=
 # GANTRY_GITHUB_WEBHOOK_SECRET=
+
+# Production Docker (used by docker-compose.prod.yml)
+# GANTRY_PORT=80

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,46 @@
+# Stage 1: Build
+FROM rust:1.85-slim-bookworm AS builder
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy workspace manifests for dependency caching
+COPY Cargo.toml Cargo.lock ./
+COPY backend/Cargo.toml backend/
+
+# Create dummy src to build dependencies
+RUN mkdir -p backend/src && echo "fn main() {}" > backend/src/main.rs
+RUN cargo build --release -p gantry-board || true
+RUN rm -rf backend/src
+
+# Copy source code
+COPY backend/src backend/src
+COPY backend/migrations backend/migrations
+
+# Build release binary
+RUN cargo build --release -p gantry-board
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /workspace/target/release/gantry-board /usr/local/bin/gantry-board
+
+# Create data directory
+RUN mkdir -p /data
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=10s \
+    CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["gantry-board"]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -75,8 +75,9 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
     let agent_start_governor = governor!(10, 3)?;
     // Rate limit: agent restart — same as start.
     let agent_restart_governor = governor!(10, 3)?;
-    // Rate limit: SSE connections — 5 connections per 10 seconds per IP.
+    // Rate limit: SSE/WebSocket connections — 5 connections per 10 seconds per IP.
     let sse_governor = governor!(10, 5)?;
+    let ws_governor = governor!(10, 5)?;
 
     let api_routes = Router::new()
         // Auth endpoints (rate-limited)
@@ -241,6 +242,11 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         .merge(Router::new().route(
             "/events",
             get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
+        ))
+        // WebSocket route: no timeout (long-lived), own rate limit only
+        .merge(Router::new().route(
+            "/ws",
+            get(sse::ws_handler::ws_handler).layer(GovernorLayer::new(ws_governor)),
         ));
 
     let metric_handle = init_metrics();

--- a/backend/src/sse/mod.rs
+++ b/backend/src/sse/mod.rs
@@ -1,3 +1,4 @@
 pub mod event;
 pub mod handler;
 pub mod hub;
+pub mod ws_handler;

--- a/backend/src/sse/ws_handler.rs
+++ b/backend/src/sse/ws_handler.rs
@@ -1,0 +1,197 @@
+use std::time::Duration;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::IntoResponse;
+use tokio::sync::broadcast;
+
+use super::event::SseEvent;
+use crate::auth::middleware::AuthUser;
+use crate::AppState;
+
+/// WebSocket endpoint for real-time updates (alternative to SSE).
+///
+/// Subscribes to the same broadcast hub as the SSE handler and forwards
+/// events as JSON text frames. Clients that cannot use SSE (e.g. behind
+/// certain proxies) can connect here instead.
+pub async fn ws_handler(
+    _auth: AuthUser,
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let rx = state.sse_hub.subscribe();
+    ws.on_upgrade(move |socket| handle_socket(socket, rx))
+}
+
+/// Convert an SseEvent into a WebSocket JSON text message.
+///
+/// Format: `{"event": "<event_type>", "data": <serialized_event>}`
+/// The `data` field matches the JSON payload sent via SSE `data:` lines,
+/// allowing the frontend to parse both transports identically.
+fn event_to_ws_message(event: &SseEvent) -> Option<Message> {
+    let data = serde_json::to_value(event).ok()?;
+    let msg = serde_json::json!({
+        "event": event.event_type(),
+        "data": data,
+    });
+    Some(Message::Text(msg.to_string().into()))
+}
+
+async fn handle_socket(mut socket: WebSocket, mut rx: broadcast::Receiver<SseEvent>) {
+    metrics::gauge!("gantry_ws_connections_active").increment(1.0);
+
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            event = rx.recv() => {
+                match event {
+                    Ok(event) => {
+                        if let Some(msg) = event_to_ws_message(&event) {
+                            if socket.send(msg).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "WebSocket client lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            _ = ping_interval.tick() => {
+                if socket.send(Message::Ping(vec![].into())).await.is_err() {
+                    break;
+                }
+            }
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) => break,
+                }
+            }
+        }
+    }
+
+    metrics::gauge!("gantry_ws_connections_active").decrement(1.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::task::{Task, TaskPriority, TaskStatus};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn create_test_task() -> Task {
+        Task {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            title: "Test Task".to_string(),
+            description: None,
+            status: TaskStatus::Todo,
+            priority: TaskPriority::Medium,
+            parent_id: None,
+            assigned_to: None,
+            position: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_event_to_ws_message_task_created() {
+        let task = create_test_task();
+        let task_id = task.id;
+        let event = SseEvent::task_created(task);
+
+        let msg = event_to_ws_message(&event).expect("should serialize");
+
+        if let Message::Text(text) = msg {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&text).expect("should be valid JSON");
+            assert_eq!(parsed["event"], "task_created");
+            assert_eq!(parsed["data"]["type"], "TaskCreated");
+            assert_eq!(parsed["data"]["task"]["id"], task_id.to_string());
+        } else {
+            panic!("Expected Text message");
+        }
+    }
+
+    #[test]
+    fn test_event_to_ws_message_agent_output() {
+        let session_id = Uuid::new_v4();
+        let event = SseEvent::agent_output(session_id, "Hello from agent".to_string());
+
+        let msg = event_to_ws_message(&event).expect("should serialize");
+
+        if let Message::Text(text) = msg {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&text).expect("should be valid JSON");
+            assert_eq!(parsed["event"], "agent_output");
+            assert_eq!(parsed["data"]["session_id"], session_id.to_string());
+            assert_eq!(parsed["data"]["text"], "Hello from agent");
+        } else {
+            panic!("Expected Text message");
+        }
+    }
+
+    #[test]
+    fn test_event_to_ws_message_task_deleted() {
+        let task_id = Uuid::new_v4();
+        let event = SseEvent::task_deleted(task_id);
+
+        let msg = event_to_ws_message(&event).expect("should serialize");
+
+        if let Message::Text(text) = msg {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&text).expect("should be valid JSON");
+            assert_eq!(parsed["event"], "task_deleted");
+            assert_eq!(parsed["data"]["task_id"], task_id.to_string());
+        } else {
+            panic!("Expected Text message");
+        }
+    }
+
+    #[test]
+    fn test_event_to_ws_message_all_event_types() {
+        let events = vec![
+            SseEvent::task_created(create_test_task()),
+            SseEvent::task_updated(create_test_task()),
+            SseEvent::task_deleted(Uuid::new_v4()),
+            SseEvent::agent_output(Uuid::new_v4(), "test".to_string()),
+            SseEvent::comment_deleted(Uuid::new_v4(), Uuid::new_v4()),
+            SseEvent::preview_deleted(Uuid::new_v4()),
+            SseEvent::github_sync_failed(Uuid::new_v4(), "error".to_string()),
+        ];
+
+        for event in &events {
+            let msg = event_to_ws_message(event);
+            assert!(
+                msg.is_some(),
+                "Failed to serialize event type: {}",
+                event.event_type()
+            );
+        }
+    }
+
+    #[test]
+    fn test_event_to_ws_message_json_structure() {
+        let task = create_test_task();
+        let event = SseEvent::task_created(task);
+
+        let msg = event_to_ws_message(&event).expect("should serialize");
+
+        if let Message::Text(text) = msg {
+            let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+            let obj = parsed.as_object().expect("should be an object");
+            assert!(obj.contains_key("event"), "missing 'event' key");
+            assert!(obj.contains_key("data"), "missing 'data' key");
+            assert_eq!(obj.len(), 2, "should have exactly 2 keys");
+        } else {
+            panic!("Expected Text message");
+        }
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.prod
+    environment:
+      - GANTRY_BIND_ADDR=0.0.0.0:3000
+      - GANTRY_DATABASE_URL=sqlite:/data/gantry_board.db?mode=rwc
+      - GANTRY_CORS_ORIGIN=${GANTRY_CORS_ORIGIN:-http://localhost}
+      - GANTRY_AUTH_SECRET=${GANTRY_AUTH_SECRET}
+      - GANTRY_COOKIE_SECURE=${GANTRY_COOKIE_SECURE:-true}
+      - GANTRY_GITHUB_TOKEN=${GANTRY_GITHUB_TOKEN:-}
+    volumes:
+      - gantry-data:/data
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+    ports:
+      - "${GANTRY_PORT:-80}:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  gantry-data:

--- a/docs/DOCKER_SECURITY.md
+++ b/docs/DOCKER_SECURITY.md
@@ -1,0 +1,86 @@
+# Docker Socket Security
+
+## Overview
+
+Gantry Board uses the Docker daemon to manage preview environments for agent worktrees. By default, it connects to the Docker socket at `/var/run/docker.sock`.
+
+## Security Implications
+
+Mounting `/var/run/docker.sock` gives the application **full control over the Docker daemon**, which is equivalent to root access on the host machine. If the application is compromised, an attacker could:
+
+- Create privileged containers
+- Mount host filesystems
+- Access the host network
+- Execute commands on the host
+
+## Recommendations
+
+### Development
+
+The default socket mounting is acceptable for local development:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Ensure the Docker daemon is only accessible locally and the development machine is trusted.
+
+### Production
+
+For production deployments, consider these alternatives (in order of preference):
+
+1. **Rootless Docker** — Run the Docker daemon without root privileges. This limits the blast radius of a compromised socket.
+
+   ```bash
+   # Install rootless Docker
+   dockerd-rootless-setuptool.sh install
+   ```
+
+2. **Docker-in-Docker (DinD) with TLS** — Run a separate Docker daemon inside a container with TLS authentication, isolating the host daemon.
+
+   ```yaml
+   services:
+     dind:
+       image: docker:dind
+       privileged: true
+       environment:
+         - DOCKER_TLS_CERTDIR=/certs
+       volumes:
+         - docker-certs:/certs
+     backend:
+       environment:
+         - GANTRY_DOCKER_HOST=tcp://dind:2376
+         - DOCKER_TLS_VERIFY=1
+   ```
+
+3. **Restricted Docker API proxy** — Use a proxy like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) that limits which Docker API endpoints are accessible.
+
+   ```yaml
+   services:
+     docker-proxy:
+       image: tecnativa/docker-socket-proxy
+       environment:
+         - CONTAINERS=1
+         - IMAGES=1
+         - NETWORKS=1
+       volumes:
+         - /var/run/docker.sock:/var/run/docker.sock:ro
+     backend:
+       environment:
+         - GANTRY_DOCKER_HOST=tcp://docker-proxy:2375
+   ```
+
+## Configuration
+
+The Docker host is configurable via:
+
+- **TOML config:** `docker.host` in `gantry.toml`
+- **Environment variable:** `GANTRY_DOCKER_HOST`
+- **Default:** `unix:///var/run/docker.sock`
+
+## References
+
+- [Docker daemon attack surface](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)
+- [Rootless Docker](https://docs.docker.com/engine/security/rootless/)
+- [Docker-in-Docker](https://hub.docker.com/_/docker)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,9 +90,9 @@
 - [x] Service 層 trait 化 + DI (#201)
 - [x] 大規模ファイル分割 (#191)
 - [x] unwrap() 削除 (#193)
-- [ ] 本番 Docker 設定 (#186)
-- [ ] WebSocket fallback for SSE (#203)
-- [ ] ドキュメント整備 (#187, #205)
+- [x] 本番 Docker 設定 (#186)
+- [x] WebSocket fallback for SSE (#203)
+- [x] ドキュメント整備 (#187, #205)
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,115 +1,108 @@
 # Gantry Board - 開発ロードマップ
 
-## Phase 0: 環境セットアップ ← 現在
+## Phase 0: 環境セットアップ ✅
 
 ### 成果物
 - [x] Rust バックエンド hello world (axum /health)
-- [ ] React フロントエンド hello world (Vite)
+- [x] React フロントエンド hello world (Vite)
 - [x] プロジェクト設定 (.gitignore, LICENSE, CLAUDE.md)
-- [ ] プラグイン・スキル・サブエージェント導入
-- [ ] GitHub Actions CI
-- [ ] docker-compose.yml
+- [x] プラグイン・スキル・サブエージェント導入
+- [x] GitHub Actions CI
+- [x] docker-compose.yml
 
 ### ドキュメント
 - [x] PRD (docs/PRD.md)
 - [x] ロードマップ (docs/ROADMAP.md)
 - [x] プロジェクト指示 (CLAUDE.md)
-- [ ] アーキテクチャ詳細 (docs/ARCHITECTURE.md)
 
 ---
 
-## Phase 1: コアカンバン
+## Phase 1: コアカンバン ✅
 
 ### 成果物
-- データモデル: projects, tasks, users (SQLite + sqlx)
-- Task CRUD API (REST)
-- カンバンボード UI (React + @dnd-kit)
-- ドラッグ&ドロップによるステータス変更
-- WebSocket によるリアルタイム同期
-
-### 依存
-- Phase 0 完了
+- [x] データモデル: projects, tasks, users (SQLite + sqlx)
+- [x] Task CRUD API (REST)
+- [x] カンバンボード UI (React + @dnd-kit)
+- [x] ドラッグ&ドロップによるステータス変更
+- [x] SSE によるリアルタイム同期
 
 ---
 
-## Phase 2: 認証 + マルチユーザー
+## Phase 2: 認証 + マルチユーザー ✅
 
 ### 成果物
-- セッションベース認証
-- ログイン / 登録 UI
-- API ミドルウェア認証
-- ユーザー管理
-
-### 依存
-- Phase 1 完了
+- [x] セッションベース認証
+- [x] ログイン / 登録 UI
+- [x] API ミドルウェア認証
+- [x] ユーザー管理
 
 ---
 
-## Phase 3: エージェントオーケストレーション
+## Phase 3: エージェントオーケストレーション ✅
 
 ### 成果物
-- Git worktree CRUD (git2)
-- Claude Code CLI executor (tokio::process + stream-json)
-- Gemini CLI executor
-- エージェント出力 WebSocket ストリーミング
-- エージェント起動・停止・再開 UI
-
-### 依存
-- Phase 1 完了 (タスクモデル)
-- Phase 2 推奨 (認証)
+- [x] Git worktree CRUD (git2)
+- [x] Claude Code CLI executor (tokio::process + stream-json)
+- [x] Gemini CLI executor
+- [x] エージェント出力 SSE ストリーミング
+- [x] エージェント起動・停止 UI
 
 ---
 
-## Phase 4: チャット / ディスカッション
+## Phase 4: コメント / タイムライン ✅
 
 ### 成果物
-- チャットデータモデル + API
-- WebSocket チャットハンドラ
-- タスクスレッド + プロジェクトチャンネル UI
-- エージェント出力との統合タイムライン
-
-### 依存
-- Phase 1 完了
-- Phase 2 完了
+- [x] コメントデータモデル + API
+- [x] タスクタイムライン UI (コメント + エージェントセッション)
+- [x] エージェント出力ビューア
 
 ---
 
-## Phase 5: Docker プレビュー環境
+## Phase 5: Docker プレビュー環境 ✅
 
 ### 成果物
-- Docker コンテナライフサイクル管理 (bollard)
-- ポート自動割り当て・衝突回避
-- プレビュー URL 生成
-- Worktree 変更検知 → 自動プレビュー更新
-- プレビュー UI (iframe or リンク)
-
-### 依存
-- Phase 3 完了 (worktree)
+- [x] Docker コンテナライフサイクル管理 (bollard)
+- [x] ポート自動割り当て・衝突回避 (#198)
+- [x] プレビュー URL 生成
+- [x] Docker 操作 circuit breaker (#204)
+- [x] プレビュー UI
 
 ---
 
-## Phase 6: GitHub Projects 同期
+## Phase 6: GitHub Projects 同期 ✅
 
 ### 成果物
-- GitHub OAuth + API 設定
-- GitHub Projects V2 GraphQL 統合
-- Issue / PR 双方向同期
-- Webhook 受信
-
-### 依存
-- Phase 1 完了
-- Phase 2 完了
+- [x] GitHub OAuth + API 設定 (#143)
+- [x] Issue 双方向同期 + Label マッピング (#144)
+- [x] PR リンク検出 (#145)
+- [x] GitHub 連携 UI (#146)
+- [x] GitHub API キャッシュ層 (#195)
+- [x] Webhook 受信 (#185)
 
 ---
 
-## Phase 7: 仕上げ
+## Phase 7: 仕上げ ← 進行中
 
 ### 成果物
-- エラーハンドリング強化
-- ログ管理
-- 本番 Docker 設定 (docker-compose.prod.yml)
-- パフォーマンス最適化
-- ドキュメント整備
+- [x] エラーハンドリング強化 (#199, #207)
+- [x] 構造化ログ管理 — Backend + Frontend pino (#200)
+- [x] パフォーマンス最適化 — DB PRAGMA + 複合インデックス (#189, #194)
+- [x] Service 層 trait 化 + DI (#201)
+- [x] 大規模ファイル分割 (#191)
+- [x] unwrap() 削除 (#193)
+- [ ] 本番 Docker 設定 (#186)
+- [ ] WebSocket fallback for SSE (#203)
+- [ ] ドキュメント整備 (#187, #205)
 
-### 依存
-- Phase 1〜6 完了
+---
+
+## セキュリティ・品質改善 (横断)
+
+- [x] CORS origin 強制検証 (#206)
+- [x] Host header バリデーション (#208)
+- [x] Rate limiting (tower-governor)
+- [x] npm audit fix (#192)
+- [x] docker-compose セキュリティ設定 (#190)
+- [x] Frontend Services 層 + エラーハンドラ (#196)
+- [x] 正規化状態管理 (#202)
+- [x] Agent 出力バッファリング (#197)

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -12,6 +12,8 @@ RUN npm run build
 # Stage 2: Serve
 FROM nginx:1.27-alpine
 
+RUN apk add --no-cache wget
+
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,21 @@
+# Stage 1: Build
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD wget -q --spider http://localhost/health || exit 1

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+    gzip_min_length 256;
+
+    # API reverse proxy
+    location /api/ {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SSE endpoint (disable buffering)
+    location /events {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    # Health check passthrough
+    location = /health {
+        proxy_pass http://backend:3000;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -35,6 +35,8 @@ server {
         proxy_pass http://backend:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_http_version 1.1;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,7 +19,7 @@ server {
     }
 
     # SSE endpoint (disable buffering)
-    location /events {
+    location /api/events {
         proxy_pass http://backend:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -28,6 +28,17 @@ server {
         chunked_transfer_encoding off;
         proxy_buffering off;
         proxy_cache off;
+    }
+
+    # WebSocket endpoint
+    location /api/ws {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_read_timeout 86400s;
     }
 
     # Health check passthrough

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ function KanbanApp() {
   const openProjectSettings = useUiStore((s) => s.openProjectSettings);
   const openProjectMembers = useUiStore((s) => s.openProjectMembers);
 
-  // Connect to SSE for real-time updates
+  // Connect to real-time updates (WebSocket with SSE fallback)
   // biome-ignore lint/correctness/useExhaustiveDependencies: queryClient is stable from provider
   useEffect(() => {
     const cleanup = connectEventSource(queryClient);

--- a/frontend/src/hooks/useAgentEvents.test.ts
+++ b/frontend/src/hooks/useAgentEvents.test.ts
@@ -2,6 +2,22 @@ import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _resetSharedEventSource, useAgentEvents } from './useAgentEvents';
 
+// Mock WebSocket (immediately fails → transport stays on SSE)
+class MockWebSocket {
+  readyState = 0;
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  constructor(_url: string) {
+    setTimeout(() => this.onerror?.(new Event('error')), 0);
+  }
+  close() {
+    this.readyState = 3;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+}
+
 class MockEventSource {
   static instances: MockEventSource[] = [];
   static CLOSED = 2;
@@ -43,6 +59,7 @@ class MockEventSource {
 describe('useAgentEvents', () => {
   beforeEach(() => {
     MockEventSource.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
     vi.stubGlobal('EventSource', MockEventSource);
     _resetSharedEventSource();
   });

--- a/frontend/src/hooks/useAgentEvents.ts
+++ b/frontend/src/hooks/useAgentEvents.ts
@@ -1,32 +1,35 @@
 import { useEffect, useRef } from 'react';
+import { createRealtimeTransport, type EventSourceLike } from '../lib/realtimeTransport';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
 
-// Module-level shared EventSource with reference counting
-let sharedEventSource: EventSource | null = null;
+const CLOSED = 2;
+
+// Module-level shared transport with reference counting
+let sharedTransport: EventSourceLike | null = null;
 let listenerCount = 0;
 
-function acquireEventSource(): EventSource {
-  if (!sharedEventSource || sharedEventSource.readyState === EventSource.CLOSED) {
-    sharedEventSource = new EventSource(`${API_BASE_URL}/api/events`);
+function acquireTransport(): EventSourceLike {
+  if (!sharedTransport || sharedTransport.readyState === CLOSED) {
+    sharedTransport = createRealtimeTransport(`${API_BASE_URL}/api/events`);
   }
   listenerCount++;
-  return sharedEventSource;
+  return sharedTransport;
 }
 
-function releaseEventSource(): void {
+function releaseTransport(): void {
   listenerCount--;
   if (listenerCount <= 0) {
-    sharedEventSource?.close();
-    sharedEventSource = null;
+    sharedTransport?.close();
+    sharedTransport = null;
     listenerCount = 0;
   }
 }
 
 /** Reset shared state — only for testing. */
 export function _resetSharedEventSource(): void {
-  sharedEventSource?.close();
-  sharedEventSource = null;
+  sharedTransport?.close();
+  sharedTransport = null;
   listenerCount = 0;
 }
 
@@ -37,7 +40,7 @@ export function useAgentEvents(sessionId: string | null, onOutput: (text: string
   useEffect(() => {
     if (!sessionId) return;
 
-    const es = acquireEventSource();
+    const es = acquireTransport();
 
     const handler = (event: MessageEvent) => {
       try {
@@ -54,7 +57,7 @@ export function useAgentEvents(sessionId: string | null, onOutput: (text: string
 
     return () => {
       es.removeEventListener('agent_output', handler);
-      releaseEventSource();
+      releaseTransport();
     };
   }, [sessionId]);
 }

--- a/frontend/src/hooks/useEventSource.test.ts
+++ b/frontend/src/hooks/useEventSource.test.ts
@@ -3,6 +3,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SseEvent } from './useEventSource';
 import { connectEventSource } from './useEventSource';
 
+// Mock WebSocket (immediately fails → transport stays on SSE)
+class MockWebSocket {
+  readyState = 0;
+  onopen: ((e: Event) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  constructor(_url: string) {
+    setTimeout(() => this.onerror?.(new Event('error')), 0);
+  }
+  close() {
+    this.readyState = 3;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+}
+
 // Mock EventSource
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -48,6 +64,7 @@ describe('connectEventSource', () => {
 
   beforeEach(() => {
     MockEventSource.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
     vi.stubGlobal('EventSource', MockEventSource);
     queryClient = new QueryClient({
       defaultOptions: {

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -7,6 +7,7 @@ import type {
   TaskComment,
 } from '../api/generated/model';
 import { logger } from '../lib/logger';
+import { createRealtimeTransport } from '../lib/realtimeTransport';
 import {
   invalidateComments,
   invalidatePreviews,
@@ -32,7 +33,7 @@ export type SseEvent =
   | { type: 'GitHubSyncFailed'; project_id: string; error: string };
 
 export function connectEventSource(queryClient: QueryClient): () => void {
-  const eventSource = new EventSource(`${API_BASE_URL}/api/events`);
+  const eventSource = createRealtimeTransport(`${API_BASE_URL}/api/events`);
 
   const handleSseMessage = (event: MessageEvent) => {
     try {
@@ -108,8 +109,7 @@ export function connectEventSource(queryClient: QueryClient): () => void {
   eventSource.addEventListener('github_sync_failed', handleGithubSyncEvent);
 
   eventSource.onerror = (event: Event) => {
-    const source = event.currentTarget as EventSource | null;
-    sseLog.error({ type: event.type, readyState: source?.readyState }, 'SSE connection error');
+    sseLog.error({ type: event.type }, 'Realtime connection error');
   };
 
   return () => {

--- a/frontend/src/lib/realtimeTransport.test.ts
+++ b/frontend/src/lib/realtimeTransport.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRealtimeTransport } from './realtimeTransport';
+
+// --- Mock WebSocket ---
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  readyState = 0;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  addEventListener(_type: string, _handler: unknown) {}
+  removeEventListener(_type: string, _handler: unknown) {}
+  send(_data: unknown) {}
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = 1;
+    this.onopen?.(new Event('open'));
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'));
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }));
+  }
+}
+
+// --- Mock EventSource ---
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  static CLOSED = 2;
+  url: string;
+  readyState = 0;
+  onerror: ((event: Event) => void) | null = null;
+  private handlers: Record<string, Set<(event: MessageEvent) => void>> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.readyState = 2;
+  }
+
+  addEventListener(type: string, handler: (event: MessageEvent) => void) {
+    if (!this.handlers[type]) this.handlers[type] = new Set();
+    this.handlers[type].add(handler);
+  }
+
+  removeEventListener(type: string, handler: (event: MessageEvent) => void) {
+    this.handlers[type]?.delete(handler);
+  }
+
+  simulateEvent(type: string, data: unknown) {
+    const handlers = this.handlers[type];
+    if (handlers) {
+      for (const handler of handlers) {
+        handler(new MessageEvent(type, { data: JSON.stringify(data) }));
+      }
+    }
+  }
+}
+
+describe('createRealtimeTransport', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    MockEventSource.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    vi.stubGlobal('EventSource', MockEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('creates EventSource as initial transport', () => {
+    createRealtimeTransport('http://localhost:3000/api/events');
+
+    expect(MockEventSource.instances.length).toBe(1);
+    expect(MockEventSource.instances[0].url).toBe('http://localhost:3000/api/events');
+  });
+
+  it('attempts WebSocket upgrade in background', () => {
+    createRealtimeTransport('http://localhost:3000/api/events');
+
+    expect(MockWebSocket.instances.length).toBe(1);
+    expect(MockWebSocket.instances[0].url).toBe('ws://localhost:3000/api/ws');
+  });
+
+  it('converts https to wss for WebSocket URL', () => {
+    createRealtimeTransport('https://example.com/api/events');
+
+    expect(MockWebSocket.instances[0].url).toBe('wss://example.com/api/ws');
+  });
+
+  it('closes SSE and switches to WebSocket on successful upgrade', () => {
+    createRealtimeTransport('http://localhost:3000/api/events');
+
+    const es = MockEventSource.instances[0];
+    const ws = MockWebSocket.instances[0];
+
+    ws.simulateOpen();
+
+    expect(es.readyState).toBe(2); // SSE closed
+  });
+
+  it('stays on SSE when WebSocket fails', () => {
+    createRealtimeTransport('http://localhost:3000/api/events');
+
+    const es = MockEventSource.instances[0];
+    const ws = MockWebSocket.instances[0];
+
+    ws.simulateError();
+
+    expect(es.readyState).toBe(0); // SSE still open
+    expect(ws.readyState).toBe(3); // WS closed
+  });
+
+  it('delivers events via SSE before upgrade', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const handler = vi.fn();
+
+    transport.addEventListener('task_created', handler);
+
+    const es = MockEventSource.instances[0];
+    es.simulateEvent('task_created', { type: 'TaskCreated', task: { id: '123' } });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers events via WebSocket after upgrade', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const handler = vi.fn();
+
+    transport.addEventListener('task_created', handler);
+
+    // Upgrade to WebSocket
+    const ws = MockWebSocket.instances[0];
+    ws.simulateOpen();
+
+    // Send event via WebSocket
+    ws.simulateMessage({
+      event: 'task_created',
+      data: { type: 'TaskCreated', task: { id: '456' } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0] as MessageEvent;
+    expect(JSON.parse(event.data).task.id).toBe('456');
+  });
+
+  it('re-registers all handlers after WebSocket upgrade', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    transport.addEventListener('task_created', handler1);
+    transport.addEventListener('agent_output', handler2);
+
+    // Upgrade to WebSocket
+    const ws = MockWebSocket.instances[0];
+    ws.simulateOpen();
+
+    ws.simulateMessage({ event: 'task_created', data: { type: 'TaskCreated' } });
+    ws.simulateMessage({
+      event: 'agent_output',
+      data: { type: 'AgentOutput', session_id: 'abc', text: 'hi' },
+    });
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes both transports on close()', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+
+    const es = MockEventSource.instances[0];
+    const ws = MockWebSocket.instances[0];
+
+    transport.close();
+
+    expect(es.readyState).toBe(2);
+    expect(ws.readyState).toBe(3);
+  });
+
+  it('removes event listeners correctly', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const handler = vi.fn();
+
+    transport.addEventListener('task_created', handler);
+    transport.removeEventListener('task_created', handler);
+
+    const es = MockEventSource.instances[0];
+    es.simulateEvent('task_created', { type: 'TaskCreated', task: { id: '123' } });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not re-register removed handlers after upgrade', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const handler = vi.fn();
+
+    transport.addEventListener('task_created', handler);
+    transport.removeEventListener('task_created', handler);
+
+    // Upgrade to WebSocket
+    const ws = MockWebSocket.instances[0];
+    ws.simulateOpen();
+
+    ws.simulateMessage({ event: 'task_created', data: { type: 'TaskCreated' } });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('propagates onerror to active transport', () => {
+    const transport = createRealtimeTransport('http://localhost:3000/api/events');
+    const errorHandler = vi.fn();
+
+    transport.onerror = errorHandler;
+
+    const es = MockEventSource.instances[0];
+    es.onerror?.(new Event('error'));
+
+    expect(errorHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/realtimeTransport.ts
+++ b/frontend/src/lib/realtimeTransport.ts
@@ -1,0 +1,176 @@
+import { logger } from './logger';
+
+const rtLog = logger.child({ module: 'realtime' });
+
+type EventHandler = (event: MessageEvent) => void;
+
+/** EventSource-compatible interface for both SSE and WebSocket transports. */
+export interface EventSourceLike {
+  addEventListener(type: string, handler: EventHandler): void;
+  removeEventListener(type: string, handler: EventHandler): void;
+  close(): void;
+  readonly readyState: number;
+  onerror: ((event: Event) => void) | null;
+}
+
+/** WebSocket adapter that dispatches events in the same format as EventSource. */
+class WebSocketAdapter implements EventSourceLike {
+  private ws: WebSocket;
+  private listeners = new Map<string, Set<EventHandler>>();
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(ws: WebSocket) {
+    this.ws = ws;
+    this.ws.onmessage = (event) => this.dispatch(event);
+    this.ws.onerror = (e) => this.onerror?.(e);
+  }
+
+  private dispatch(event: MessageEvent) {
+    try {
+      const msg = JSON.parse(event.data as string) as { event: string; data: unknown };
+      const handlers = this.listeners.get(msg.event);
+      if (handlers) {
+        const synthetic = new MessageEvent(msg.event, {
+          data: JSON.stringify(msg.data),
+        });
+        for (const handler of handlers) {
+          handler(synthetic);
+        }
+      }
+    } catch {
+      rtLog.error({ data: event.data }, 'failed to parse WebSocket message');
+    }
+  }
+
+  addEventListener(type: string, handler: EventHandler): void {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(handler);
+  }
+
+  removeEventListener(type: string, handler: EventHandler): void {
+    this.listeners.get(type)?.delete(handler);
+  }
+
+  close(): void {
+    this.ws.close();
+  }
+
+  get readyState(): number {
+    // Normalize: WS uses 2=CLOSING,3=CLOSED; EventSource uses 2=CLOSED
+    return this.ws.readyState >= 2 ? 2 : this.ws.readyState;
+  }
+}
+
+const WS_CONNECT_TIMEOUT_MS = 3000;
+
+/**
+ * Create a realtime transport that tries WebSocket first with SSE fallback.
+ *
+ * Starts with EventSource immediately, then attempts a WebSocket upgrade
+ * in the background. If the WebSocket connects within the timeout, all
+ * event handlers are transparently migrated to the WebSocket transport.
+ */
+export function createRealtimeTransport(sseUrl: string): EventSourceLike {
+  const wsUrl = sseUrl
+    .replace(/^http:/, 'ws:')
+    .replace(/^https:/, 'wss:')
+    .replace('/events', '/ws');
+
+  return new RealtimeProxy(sseUrl, wsUrl);
+}
+
+class RealtimeProxy implements EventSourceLike {
+  private inner: EventSourceLike;
+  private handlers = new Map<string, Set<EventHandler>>();
+  private _onerror: ((event: Event) => void) | null = null;
+  private pendingWs: WebSocket | null = null;
+  private upgradeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(sseUrl: string, wsUrl: string) {
+    this.inner = new EventSource(sseUrl);
+    this.tryUpgrade(wsUrl);
+  }
+
+  private tryUpgrade(wsUrl: string) {
+    if (typeof WebSocket === 'undefined') return;
+
+    try {
+      const ws = new WebSocket(wsUrl);
+      this.pendingWs = ws;
+
+      this.upgradeTimer = setTimeout(() => {
+        ws.close();
+        this.pendingWs = null;
+        this.upgradeTimer = null;
+        rtLog.debug('WebSocket upgrade timed out, staying on SSE');
+      }, WS_CONNECT_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        if (this.upgradeTimer) {
+          clearTimeout(this.upgradeTimer);
+          this.upgradeTimer = null;
+        }
+        this.pendingWs = null;
+
+        // Close SSE and switch to WebSocket
+        this.inner.close();
+        const adapter = new WebSocketAdapter(ws);
+
+        // Re-register all handlers on new transport
+        for (const [type, handlerSet] of this.handlers) {
+          for (const handler of handlerSet) {
+            adapter.addEventListener(type, handler);
+          }
+        }
+        if (this._onerror) adapter.onerror = this._onerror;
+        this.inner = adapter;
+        rtLog.info('Upgraded to WebSocket transport');
+      };
+
+      ws.onerror = () => {
+        if (this.upgradeTimer) {
+          clearTimeout(this.upgradeTimer);
+          this.upgradeTimer = null;
+        }
+        ws.close();
+        this.pendingWs = null;
+        rtLog.debug('WebSocket upgrade failed, staying on SSE');
+      };
+    } catch {
+      // WebSocket constructor failed, stay on SSE
+    }
+  }
+
+  addEventListener(type: string, handler: EventHandler): void {
+    if (!this.handlers.has(type)) this.handlers.set(type, new Set());
+    this.handlers.get(type)!.add(handler);
+    this.inner.addEventListener(type, handler);
+  }
+
+  removeEventListener(type: string, handler: EventHandler): void {
+    this.handlers.get(type)?.delete(handler);
+    this.inner.removeEventListener(type, handler);
+  }
+
+  close(): void {
+    if (this.upgradeTimer) {
+      clearTimeout(this.upgradeTimer);
+      this.upgradeTimer = null;
+    }
+    this.pendingWs?.close();
+    this.inner.close();
+  }
+
+  get readyState(): number {
+    return this.inner.readyState;
+  }
+
+  set onerror(handler: ((event: Event) => void) | null) {
+    this._onerror = handler;
+    this.inner.onerror = handler;
+  }
+
+  get onerror(): ((event: Event) => void) | null {
+    return this._onerror;
+  }
+}

--- a/frontend/src/lib/realtimeTransport.ts
+++ b/frontend/src/lib/realtimeTransport.ts
@@ -44,7 +44,7 @@ class WebSocketAdapter implements EventSourceLike {
 
   addEventListener(type: string, handler: EventHandler): void {
     if (!this.listeners.has(type)) this.listeners.set(type, new Set());
-    this.listeners.get(type)!.add(handler);
+    this.listeners.get(type)?.add(handler);
   }
 
   removeEventListener(type: string, handler: EventHandler): void {
@@ -143,7 +143,7 @@ class RealtimeProxy implements EventSourceLike {
 
   addEventListener(type: string, handler: EventHandler): void {
     if (!this.handlers.has(type)) this.handlers.set(type, new Set());
-    this.handlers.get(type)!.add(handler);
+    this.handlers.get(type)?.add(handler);
     this.inner.addEventListener(type, handler);
   }
 


### PR DESCRIPTION
## Summary

DevOps and documentation improvements from the architecture review (#209). Depends on PR #212.

### Documentation
- **#187**: Update ROADMAP.md to reflect current project state
- **#205**: Document Docker socket security implications

### Production Docker (#186)
- Add multi-stage production Dockerfiles for backend and frontend
- Add `docker-compose.prod.yml` with nginx reverse proxy
- Update `.env.example` with production configuration

### WebSocket Transport (#203)
- **Backend**: Add `/api/ws` WebSocket endpoint sharing the same `SseHub` broadcast channel
- **Frontend**: Add `RealtimeProxy` transport — tries WebSocket first with 3s timeout, falls back to SSE
- **nginx**: Add WebSocket proxy configuration with upgrade headers
- All existing SSE event handlers work transparently over both transports

## Test plan

- [x] `task backend:test` — all tests pass (460 tests)
- [x] `task frontend:test` — all tests pass (321 tests)
- [x] `task check` — fmt + lint + build all clear

Resolves #187, #205, #186, #203
Part 4/4 of #209