### PR TITLE
fix: 🐛 validate project membership on task assignment

### DIFF
--- a/backend/migrations/20260218000001_add_tasks_assigned_to_fk.sql
+++ b/backend/migrations/20260218000001_add_tasks_assigned_to_fk.sql
@@ -30,6 +30,7 @@ CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned_to ON tasks(assigned_to);
 
 -- Recreate composite indexes from migration 20260216000001
+CREATE INDEX IF NOT EXISTS idx_tasks_project_position ON tasks(project_id, position, created_at);
 CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_project_assigned ON tasks(project_id, assigned_to);
 

--- a/backend/migrations/20260218000001_add_tasks_assigned_to_fk.sql
+++ b/backend/migrations/20260218000001_add_tasks_assigned_to_fk.sql
@@ -1,0 +1,36 @@
+-- Add foreign key constraint on tasks.assigned_to -> users.id
+-- SQLite does not support ALTER TABLE ADD FOREIGN KEY, so we recreate the table.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE tasks_new (
+    id TEXT PRIMARY KEY NOT NULL,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'backlog',
+    priority TEXT NOT NULL DEFAULT 'medium',
+    parent_id TEXT REFERENCES tasks_new(id) ON DELETE SET NULL,
+    assigned_to TEXT REFERENCES users(id) ON DELETE SET NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+INSERT INTO tasks_new SELECT * FROM tasks;
+
+DROP TABLE tasks;
+
+ALTER TABLE tasks_new RENAME TO tasks;
+
+-- Recreate indexes that existed on the original table
+CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks(project_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_assigned_to ON tasks(assigned_to);
+
+-- Recreate composite indexes from migration 20260216000001
+CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_tasks_project_assigned ON tasks(project_id, assigned_to);
+
+PRAGMA foreign_keys = ON;

--- a/backend/src/services/task_service/mod.rs
+++ b/backend/src/services/task_service/mod.rs
@@ -50,7 +50,7 @@ impl TryFrom<TaskRow> for Task {
 pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 
-    validate_assigned_to_tx(&mut *tx, req.assigned_to).await?;
+    validate_assigned_to_tx(&mut *tx, req.assigned_to, req.project_id).await?;
     validate_parent_project_tx(&mut *tx, req.parent_id, req.project_id).await?;
 
     let id = Uuid::new_v4();
@@ -178,7 +178,7 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
 
     let existing = get_task_tx(&mut *tx, id).await?;
 
-    validate_assigned_to_tx(&mut *tx, req.assigned_to).await?;
+    validate_assigned_to_tx(&mut *tx, req.assigned_to, existing.project_id).await?;
     validate_parent_project_tx(&mut *tx, req.parent_id, existing.project_id).await?;
 
     let now = Utc::now();
@@ -248,6 +248,7 @@ async fn get_task_tx(conn: &mut SqliteConnection, id: Uuid) -> AppResult<Task> {
 async fn validate_assigned_to_tx(
     conn: &mut SqliteConnection,
     assigned_to: Option<Uuid>,
+    project_id: Uuid,
 ) -> AppResult<()> {
     if let Some(user_id) = assigned_to {
         let exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
@@ -258,6 +259,19 @@ async fn validate_assigned_to_tx(
             return Err(AppError::Validation(format!(
                 "assigned user {} does not exist",
                 user_id
+            )));
+        }
+
+        let is_member: Option<(i32,)> =
+            sqlx::query_as("SELECT 1 FROM project_members WHERE project_id = $1 AND user_id = $2")
+                .bind(project_id.to_string())
+                .bind(user_id.to_string())
+                .fetch_optional(&mut *conn)
+                .await?;
+        if is_member.is_none() {
+            return Err(AppError::Validation(format!(
+                "assigned user {} is not a member of project {}",
+                user_id, project_id
             )));
         }
     }

--- a/backend/src/services/task_service/tests.rs
+++ b/backend/src/services/task_service/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::models::project::CreateProjectRequest;
-use crate::services::project_service;
+use crate::models::project::{AddMemberRequest, CreateProjectRequest, MemberRole};
+use crate::models::user::RegisterRequest;
+use crate::services::{member_service, project_service, user_service};
 use crate::test_helpers::setup_test_db;
 
 async fn create_test_project(pool: &SqlitePool) -> Uuid {
@@ -12,6 +13,28 @@ async fn create_test_project(pool: &SqlitePool) -> Uuid {
         .await
         .expect("Failed to create project");
     project.id
+}
+
+async fn create_test_user(pool: &SqlitePool, email: &str) -> Uuid {
+    let req = RegisterRequest {
+        email: email.to_string(),
+        name: email.split('@').next().unwrap().to_string(),
+        password: "password123".to_string(),
+    };
+    user_service::create_user(pool, &req)
+        .await
+        .expect("Failed to create user")
+        .id
+}
+
+async fn add_project_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) {
+    let req = AddMemberRequest {
+        user_id,
+        role: MemberRole::Member,
+    };
+    member_service::add_member(pool, project_id, &req)
+        .await
+        .expect("Failed to add member");
 }
 
 #[tokio::test]
@@ -677,4 +700,93 @@ async fn test_update_task_with_parent_in_different_project_returns_validation_er
     .await;
 
     assert!(matches!(result, Err(AppError::Validation(_))));
+}
+
+#[tokio::test]
+async fn test_create_task_assigned_to_non_member_returns_validation_error() {
+    let pool = setup_test_db().await;
+    let project_id = create_test_project(&pool).await;
+    // User exists but is NOT a member of the project
+    let non_member = create_test_user(&pool, "outsider@test.com").await;
+
+    let req = CreateTaskRequest {
+        project_id,
+        title: "Task".to_string(),
+        description: None,
+        status: None,
+        priority: None,
+        parent_id: None,
+        assigned_to: Some(non_member),
+    };
+    let result = create_task(&pool, &req).await;
+
+    assert!(
+        matches!(result, Err(AppError::Validation(ref msg)) if msg.contains("not a member")),
+        "expected Validation error about non-member, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_create_task_assigned_to_project_member_succeeds() {
+    let pool = setup_test_db().await;
+    let project_id = create_test_project(&pool).await;
+    let member = create_test_user(&pool, "member@test.com").await;
+    add_project_member(&pool, project_id, member).await;
+
+    let req = CreateTaskRequest {
+        project_id,
+        title: "Task".to_string(),
+        description: None,
+        status: None,
+        priority: None,
+        parent_id: None,
+        assigned_to: Some(member),
+    };
+    let task = create_task(&pool, &req)
+        .await
+        .expect("assigning to project member should succeed");
+
+    assert_eq!(task.assigned_to, Some(member));
+}
+
+#[tokio::test]
+async fn test_update_task_assigned_to_non_member_returns_validation_error() {
+    let pool = setup_test_db().await;
+    let project_id = create_test_project(&pool).await;
+    let non_member = create_test_user(&pool, "outsider@test.com").await;
+
+    let created = create_task(
+        &pool,
+        &CreateTaskRequest {
+            project_id,
+            title: "Task".to_string(),
+            description: None,
+            status: None,
+            priority: None,
+            parent_id: None,
+            assigned_to: None,
+        },
+    )
+    .await
+    .expect("task creation should succeed");
+
+    let result = update_task(
+        &pool,
+        created.id,
+        &UpdateTaskRequest {
+            title: None,
+            description: None,
+            status: None,
+            priority: None,
+            parent_id: None,
+            assigned_to: Some(non_member),
+            position: None,
+        },
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(AppError::Validation(ref msg)) if msg.contains("not a member")),
+        "expected Validation error about non-member, got: {result:?}"
+    );
 }


### PR DESCRIPTION
## Summary
- Add project membership validation in `validate_assigned_to_tx` — users must be a member of the project to be assigned to a task (#218)
- Add FK constraint on `tasks.assigned_to` → `users.id` via table recreation migration (#216)
- Add TDD tests for non-member assignment rejection and member assignment success

## Closes
- Closes #218
- Closes #216

## Test plan
- [x] `test_create_task_assigned_to_non_member_returns_validation_error` — verify non-member assignment is rejected
- [x] `test_create_task_assigned_to_project_member_succeeds` — verify member assignment works
- [x] `test_update_task_assigned_to_non_member_returns_validation_error` — verify non-member update is rejected
- [x] All 24 existing task_service tests pass