### PR TITLE
fix: 🔒️ reorder HMAC computation to minimize timing leak

### DIFF
--- a/backend/src/handlers/webhooks.rs
+++ b/backend/src/handlers/webhooks.rs
@@ -14,7 +14,19 @@ use crate::AppState;
 type HmacSha256 = Hmac<Sha256>;
 
 /// Verify GitHub webhook signature (X-Hub-Signature-256).
+///
+/// HMAC computation is performed before parsing the signature header to avoid
+/// timing side-channels: an early return on format validation (before touching
+/// the secret) would leak whether the header *format* was valid, potentially
+/// aiding targeted attacks.
 fn verify_signature(secret: &str, payload: &[u8], signature_header: &str) -> bool {
+    // Compute HMAC first to ensure constant-time behaviour regardless of
+    // format-validation outcome.
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(payload);
+
     let Some(hex_sig) = signature_header.strip_prefix("sha256=") else {
         return false;
     };
@@ -23,11 +35,6 @@ fn verify_signature(secret: &str, payload: &[u8], signature_header: &str) -> boo
         return false;
     };
 
-    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
-        return false;
-    };
-
-    mac.update(payload);
     mac.verify_slice(&expected).is_ok()
 }
 

--- a/backend/src/handlers/webhooks.rs
+++ b/backend/src/handlers/webhooks.rs
@@ -167,4 +167,32 @@ mod tests {
     fn test_reject_missing_prefix() {
         assert!(!verify_signature("secret", b"payload", "invalid"));
     }
+
+    #[test]
+    fn test_reject_empty_signature_header() {
+        assert!(!verify_signature("secret", b"payload", ""));
+    }
+
+    #[test]
+    fn test_reject_invalid_hex_after_prefix() {
+        assert!(!verify_signature("secret", b"payload", "sha256=not-hex!!"));
+    }
+
+    #[test]
+    fn test_reject_truncated_signature() {
+        // Valid hex but wrong length — HMAC comparison should fail
+        assert!(!verify_signature("secret", b"payload", "sha256=abcd"));
+    }
+
+    #[test]
+    fn test_empty_payload_with_valid_signature() {
+        let secret = "test-secret";
+        let payload = b"";
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(payload);
+        let sig = hex::encode(mac.finalize().into_bytes());
+        let header = format!("sha256={sig}");
+
+        assert!(verify_signature(secret, payload, &header));
+    }
 }


### PR DESCRIPTION
## Summary
- Reorder `verify_signature` to compute HMAC before validating signature header format, preventing timing side-channels (#217)
- Add edge case tests: empty header, invalid hex, truncated signature, empty payload

## Closes
- Closes #217

## Test plan
- [x] `test_verify_valid_signature` — valid HMAC passes
- [x] `test_reject_invalid_signature` — wrong signature rejected
- [x] `test_reject_missing_prefix` — missing `sha256=` prefix rejected
- [x] `test_reject_empty_signature_header` — empty header rejected
- [x] `test_reject_invalid_hex_after_prefix` — invalid hex rejected
- [x] `test_reject_truncated_signature` — wrong length rejected
- [x] `test_empty_payload_with_valid_signature` — empty payload works