### PR TITLE
refactor: ♻️ split preview_service into focused modules

### DIFF
--- a/backend/src/handlers/previews.rs
+++ b/backend/src/handlers/previews.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, AppResult};
 use crate::models::docker_preview::{CreatePreviewRequest, DockerPreview};
-use crate::services::{preview_service, worktree_service};
+use crate::services::{preview_repository, worktree_service};
 use crate::sse::event::SseEvent;
 use crate::AppState;
 
@@ -35,7 +35,7 @@ pub async fn create_preview(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))??;
 
-    let preview = preview_service::create_preview(&state.pool, &worktree_name).await?;
+    let preview = preview_repository::create_preview(&state.pool, &worktree_name).await?;
 
     state
         .sse_hub
@@ -56,7 +56,7 @@ pub async fn list_previews(
     State(state): State<AppState>,
     _auth: AuthUser,
 ) -> AppResult<Json<Vec<DockerPreview>>> {
-    let previews = preview_service::list_previews(&state.pool).await?;
+    let previews = preview_repository::list_previews(&state.pool).await?;
     Ok(Json(previews))
 }
 
@@ -75,7 +75,7 @@ pub async fn get_preview(
     _auth: AuthUser,
     Path(id): Path<Uuid>,
 ) -> AppResult<Json<DockerPreview>> {
-    let preview = preview_service::get_preview(&state.pool, id).await?;
+    let preview = preview_repository::get_preview(&state.pool, id).await?;
     Ok(Json(preview))
 }
 
@@ -99,7 +99,7 @@ pub async fn delete_preview(
         let _ = pm.cleanup(id).await;
     }
 
-    preview_service::delete_preview(&state.pool, id).await?;
+    preview_repository::delete_preview(&state.pool, id).await?;
 
     state.sse_hub.broadcast(SseEvent::preview_deleted(id));
 
@@ -122,7 +122,7 @@ pub async fn start_preview(
     Path(id): Path<Uuid>,
 ) -> AppResult<StatusCode> {
     // Verify preview exists
-    preview_service::get_preview(&state.pool, id).await?;
+    preview_repository::get_preview(&state.pool, id).await?;
 
     let pm = state
         .preview_manager
@@ -159,7 +159,7 @@ pub async fn stop_preview(
     } else {
         // No Docker available: just update status in DB
         let mut conn = state.pool.acquire().await?;
-        let preview = preview_service::update_status_tx(
+        let preview = preview_repository::update_status_tx(
             &mut conn,
             id,
             crate::models::docker_preview::PreviewStatus::Stopped,
@@ -189,7 +189,7 @@ pub async fn restart_preview(
     Path(id): Path<Uuid>,
 ) -> AppResult<StatusCode> {
     // Verify preview exists
-    preview_service::get_preview(&state.pool, id).await?;
+    preview_repository::get_preview(&state.pool, id).await?;
 
     let pm = state
         .preview_manager

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -5,6 +5,7 @@ pub mod github_link_service;
 pub mod github_pr_service;
 pub mod github_sync_service;
 pub mod member_service;
+pub mod preview_repository;
 pub mod preview_service;
 pub mod project_service;
 pub mod session_service;

--- a/backend/src/services/preview_repository.rs
+++ b/backend/src/services/preview_repository.rs
@@ -157,8 +157,9 @@ pub async fn update_container_id_tx(
     Ok(())
 }
 
-/// Atomically allocate the next available port within the configured range.
-/// Uses BEGIN IMMEDIATE to prevent concurrent allocations of the same port.
+/// Allocate the next available port within the configured range.
+/// Callers should start a BEGIN IMMEDIATE transaction before calling this
+/// function to prevent concurrent allocations of the same port.
 pub async fn allocate_port_tx(
     conn: &mut SqliteConnection,
     preview_id: Uuid,
@@ -182,7 +183,7 @@ pub async fn allocate_port_tx(
     // Immediately claim the port in the same transaction
     let preview_url = format!("{base_url}:{port}");
     let now = Utc::now();
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE docker_previews SET port = $1, preview_url = $2, updated_at = $3 WHERE id = $4",
     )
     .bind(port)
@@ -191,6 +192,12 @@ pub async fn allocate_port_tx(
     .bind(preview_id.to_string())
     .execute(&mut *conn)
     .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!(
+            "preview {preview_id} not found"
+        )));
+    }
 
     Ok(port)
 }

--- a/backend/src/services/preview_repository.rs
+++ b/backend/src/services/preview_repository.rs
@@ -1,0 +1,273 @@
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::{SqliteConnection, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::docker_preview::{DockerPreview, PreviewStatus};
+
+#[derive(FromRow)]
+struct DockerPreviewRow {
+    id: String,
+    worktree_name: String,
+    container_id: Option<String>,
+    port: Option<i32>,
+    status: PreviewStatus,
+    preview_url: Option<String>,
+    error_message: Option<String>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<DockerPreviewRow> for DockerPreview {
+    type Error = uuid::Error;
+
+    fn try_from(row: DockerPreviewRow) -> Result<Self, Self::Error> {
+        Ok(DockerPreview {
+            id: row.id.parse()?,
+            worktree_name: row.worktree_name,
+            container_id: row.container_id,
+            port: row.port,
+            status: row.status,
+            preview_url: row.preview_url,
+            error_message: row.error_message,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+pub async fn create_preview(pool: &SqlitePool, worktree_name: &str) -> AppResult<DockerPreview> {
+    let id = Uuid::new_v4();
+    let now = Utc::now();
+
+    sqlx::query(
+        r#"
+        INSERT INTO docker_previews (id, worktree_name, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(worktree_name)
+    .bind(PreviewStatus::Pending)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    get_preview(pool, id).await
+}
+
+pub async fn get_preview(pool: &SqlitePool, id: Uuid) -> AppResult<DockerPreview> {
+    let row = sqlx::query_as::<_, DockerPreviewRow>(
+        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews WHERE id = $1",
+    )
+    .bind(id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(|r| r.try_into())
+        .transpose()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("preview {id} not found")))
+}
+
+pub async fn list_previews(pool: &SqlitePool) -> AppResult<Vec<DockerPreview>> {
+    let rows = sqlx::query_as::<_, DockerPreviewRow>(
+        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| {
+            r.try_into()
+                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+        })
+        .collect()
+}
+
+pub async fn delete_preview(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
+    let result = sqlx::query("DELETE FROM docker_previews WHERE id = $1")
+        .bind(id.to_string())
+        .execute(pool)
+        .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!("preview {id} not found")));
+    }
+
+    Ok(())
+}
+
+pub async fn update_status_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    status: PreviewStatus,
+    error_message: Option<String>,
+) -> AppResult<DockerPreview> {
+    let now = Utc::now();
+    let result = sqlx::query(
+        r#"
+        UPDATE docker_previews
+        SET status = $1, error_message = $2, updated_at = $3
+        WHERE id = $4
+        "#,
+    )
+    .bind(&status)
+    .bind(&error_message)
+    .bind(now)
+    .bind(id.to_string())
+    .execute(&mut *conn)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!("preview {id} not found")));
+    }
+
+    let row = sqlx::query_as::<_, DockerPreviewRow>(
+        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews WHERE id = $1",
+    )
+    .bind(id.to_string())
+    .fetch_one(&mut *conn)
+    .await?;
+
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+pub async fn update_container_id_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    container_id: &str,
+) -> AppResult<()> {
+    let now = Utc::now();
+    let result =
+        sqlx::query("UPDATE docker_previews SET container_id = $1, updated_at = $2 WHERE id = $3")
+            .bind(container_id)
+            .bind(now)
+            .bind(id.to_string())
+            .execute(&mut *conn)
+            .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!("preview {id} not found")));
+    }
+
+    Ok(())
+}
+
+/// Atomically allocate the next available port within the configured range.
+/// Uses BEGIN IMMEDIATE to prevent concurrent allocations of the same port.
+pub async fn allocate_port_tx(
+    conn: &mut SqliteConnection,
+    preview_id: Uuid,
+    range_start: u16,
+    range_end: u16,
+    base_url: &str,
+) -> AppResult<i32> {
+    let allocated: Vec<(i32,)> = sqlx::query_as(
+        "SELECT port FROM docker_previews WHERE port IS NOT NULL AND status IN ('pending', 'building', 'running')",
+    )
+    .fetch_all(&mut *conn)
+    .await?;
+
+    let allocated_ports: std::collections::HashSet<i32> =
+        allocated.into_iter().map(|(p,)| p).collect();
+
+    let port = (i32::from(range_start)..=i32::from(range_end))
+        .find(|p| !allocated_ports.contains(p))
+        .ok_or_else(|| AppError::Conflict("no available ports in configured range".to_string()))?;
+
+    // Immediately claim the port in the same transaction
+    let preview_url = format!("{base_url}:{port}");
+    let now = Utc::now();
+    sqlx::query(
+        "UPDATE docker_previews SET port = $1, preview_url = $2, updated_at = $3 WHERE id = $4",
+    )
+    .bind(port)
+    .bind(&preview_url)
+    .bind(now)
+    .bind(preview_id.to_string())
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::setup_test_db;
+
+    async fn insert_preview(pool: &SqlitePool, worktree_name: &str) -> Uuid {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        sqlx::query(
+            "INSERT INTO docker_previews (id, worktree_name, status, created_at, updated_at) VALUES ($1, $2, 'pending', $3, $4)",
+        )
+        .bind(id.to_string())
+        .bind(worktree_name)
+        .bind(now)
+        .bind(now)
+        .execute(pool)
+        .await
+        .expect("insert preview");
+        id
+    }
+
+    #[tokio::test]
+    async fn test_allocate_port_assigns_first_available() {
+        let pool = setup_test_db().await;
+        let id = insert_preview(&pool, "wt-1").await;
+
+        let mut conn = pool.acquire().await.unwrap();
+        let port = allocate_port_tx(&mut conn, id, 9000, 9010, "http://localhost")
+            .await
+            .expect("port allocation should succeed");
+
+        assert_eq!(port, 9000);
+    }
+
+    #[tokio::test]
+    async fn test_allocate_port_skips_already_allocated() {
+        let pool = setup_test_db().await;
+        let id1 = insert_preview(&pool, "wt-1").await;
+        let id2 = insert_preview(&pool, "wt-2").await;
+
+        let mut conn = pool.acquire().await.unwrap();
+        let port1 = allocate_port_tx(&mut conn, id1, 9000, 9010, "http://localhost")
+            .await
+            .expect("first allocation should succeed");
+        assert_eq!(port1, 9000);
+
+        let port2 = allocate_port_tx(&mut conn, id2, 9000, 9010, "http://localhost")
+            .await
+            .expect("second allocation should succeed");
+        assert_eq!(port2, 9001);
+    }
+
+    #[tokio::test]
+    async fn test_port_unique_constraint_prevents_duplicate() {
+        let pool = setup_test_db().await;
+        let id1 = insert_preview(&pool, "wt-1").await;
+        let id2 = insert_preview(&pool, "wt-2").await;
+
+        // Allocate port 9000 to id1
+        let mut conn = pool.acquire().await.unwrap();
+        allocate_port_tx(&mut conn, id1, 9000, 9010, "http://localhost")
+            .await
+            .expect("first allocation should succeed");
+
+        // Directly try to set id2's port to 9000 — should fail due to UNIQUE index
+        let result = sqlx::query("UPDATE docker_previews SET port = 9000 WHERE id = $1")
+            .bind(id2.to_string())
+            .execute(&pool)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "duplicate port should be rejected by UNIQUE constraint"
+        );
+    }
+}

--- a/backend/src/services/preview_service.rs
+++ b/backend/src/services/preview_service.rs
@@ -13,11 +13,8 @@ use bollard::image::BuildImageOptions;
 use bollard::secret::{HostConfig, PortBinding, PortMap};
 use bollard::Docker;
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use http_body_util::Full;
-use sqlx::prelude::FromRow;
-use sqlx::{SqliteConnection, SqlitePool};
 use tokio::sync::Semaphore;
 use tracing::info;
 use uuid::Uuid;
@@ -25,13 +22,16 @@ use uuid::Uuid;
 use crate::config::Config;
 use crate::error::{AppError, AppResult};
 use crate::models::docker_preview::{DockerPreview, PreviewStatus};
+use crate::services::preview_repository::{
+    allocate_port_tx, get_preview, update_container_id_tx, update_status_tx,
+};
 use crate::sse::event::SseEvent;
 use crate::sse::hub::SseHub;
 
 /// Circuit breaker for Docker operations.
 /// Opens after `FAILURE_THRESHOLD` consecutive failures and stays open
 /// for `RECOVERY_WINDOW` seconds before allowing a single probe request.
-pub struct DockerCircuitBreaker {
+struct DockerCircuitBreaker {
     consecutive_failures: AtomicU32,
     last_failure_epoch: std::sync::atomic::AtomicU64,
 }
@@ -40,21 +40,21 @@ const FAILURE_THRESHOLD: u32 = 3;
 const RECOVERY_WINDOW_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CircuitState {
+enum CircuitState {
     Closed,
     Open,
     HalfOpen,
 }
 
 impl DockerCircuitBreaker {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             consecutive_failures: AtomicU32::new(0),
             last_failure_epoch: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
-    pub fn state(&self) -> CircuitState {
+    fn state(&self) -> CircuitState {
         let failures = self.consecutive_failures.load(Ordering::Relaxed);
         if failures < FAILURE_THRESHOLD {
             return CircuitState::Closed;
@@ -71,7 +71,7 @@ impl DockerCircuitBreaker {
         }
     }
 
-    pub fn check(&self) -> AppResult<()> {
+    fn check(&self) -> AppResult<()> {
         match self.state() {
             CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
             CircuitState::Open => Err(AppError::Internal(
@@ -80,11 +80,11 @@ impl DockerCircuitBreaker {
         }
     }
 
-    pub fn record_success(&self) {
+    fn record_success(&self) {
         self.consecutive_failures.store(0, Ordering::Relaxed);
     }
 
-    pub fn record_failure(&self) {
+    fn record_failure(&self) {
         self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -100,202 +100,13 @@ impl Default for DockerCircuitBreaker {
     }
 }
 
-#[derive(FromRow)]
-struct DockerPreviewRow {
-    id: String,
-    worktree_name: String,
-    container_id: Option<String>,
-    port: Option<i32>,
-    status: PreviewStatus,
-    preview_url: Option<String>,
-    error_message: Option<String>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<DockerPreviewRow> for DockerPreview {
-    type Error = uuid::Error;
-
-    fn try_from(row: DockerPreviewRow) -> Result<Self, Self::Error> {
-        Ok(DockerPreview {
-            id: row.id.parse()?,
-            worktree_name: row.worktree_name,
-            container_id: row.container_id,
-            port: row.port,
-            status: row.status,
-            preview_url: row.preview_url,
-            error_message: row.error_message,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
-
-pub async fn create_preview(pool: &SqlitePool, worktree_name: &str) -> AppResult<DockerPreview> {
-    let id = Uuid::new_v4();
-    let now = Utc::now();
-
-    sqlx::query(
-        r#"
-        INSERT INTO docker_previews (id, worktree_name, status, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(worktree_name)
-    .bind(PreviewStatus::Pending)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
-    .await?;
-
-    get_preview(pool, id).await
-}
-
-pub async fn get_preview(pool: &SqlitePool, id: Uuid) -> AppResult<DockerPreview> {
-    let row = sqlx::query_as::<_, DockerPreviewRow>(
-        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews WHERE id = $1",
-    )
-    .bind(id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound(format!("preview {id} not found")))
-}
-
-pub async fn list_previews(pool: &SqlitePool) -> AppResult<Vec<DockerPreview>> {
-    let rows = sqlx::query_as::<_, DockerPreviewRow>(
-        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews ORDER BY created_at DESC",
-    )
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| {
-            r.try_into()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-        })
-        .collect()
-}
-
-pub async fn delete_preview(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
-    let result = sqlx::query("DELETE FROM docker_previews WHERE id = $1")
-        .bind(id.to_string())
-        .execute(pool)
-        .await?;
-
-    if result.rows_affected() == 0 {
-        return Err(AppError::NotFound(format!("preview {id} not found")));
-    }
-
-    Ok(())
-}
-
-pub async fn update_status_tx(
-    conn: &mut SqliteConnection,
-    id: Uuid,
-    status: PreviewStatus,
-    error_message: Option<String>,
-) -> AppResult<DockerPreview> {
-    let now = Utc::now();
-    let result = sqlx::query(
-        r#"
-        UPDATE docker_previews
-        SET status = $1, error_message = $2, updated_at = $3
-        WHERE id = $4
-        "#,
-    )
-    .bind(&status)
-    .bind(&error_message)
-    .bind(now)
-    .bind(id.to_string())
-    .execute(&mut *conn)
-    .await?;
-
-    if result.rows_affected() == 0 {
-        return Err(AppError::NotFound(format!("preview {id} not found")));
-    }
-
-    let row = sqlx::query_as::<_, DockerPreviewRow>(
-        "SELECT id, worktree_name, container_id, port, status, preview_url, error_message, created_at, updated_at FROM docker_previews WHERE id = $1",
-    )
-    .bind(id.to_string())
-    .fetch_one(&mut *conn)
-    .await?;
-
-    row.try_into()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-}
-
-pub async fn update_container_id_tx(
-    conn: &mut SqliteConnection,
-    id: Uuid,
-    container_id: &str,
-) -> AppResult<()> {
-    let now = Utc::now();
-    let result =
-        sqlx::query("UPDATE docker_previews SET container_id = $1, updated_at = $2 WHERE id = $3")
-            .bind(container_id)
-            .bind(now)
-            .bind(id.to_string())
-            .execute(&mut *conn)
-            .await?;
-
-    if result.rows_affected() == 0 {
-        return Err(AppError::NotFound(format!("preview {id} not found")));
-    }
-
-    Ok(())
-}
-
-/// Atomically allocate the next available port within the configured range.
-/// Uses BEGIN IMMEDIATE to prevent concurrent allocations of the same port.
-pub async fn allocate_port_tx(
-    conn: &mut SqliteConnection,
-    preview_id: Uuid,
-    range_start: u16,
-    range_end: u16,
-    base_url: &str,
-) -> AppResult<i32> {
-    let allocated: Vec<(i32,)> = sqlx::query_as(
-        "SELECT port FROM docker_previews WHERE port IS NOT NULL AND status IN ('pending', 'building', 'running')",
-    )
-    .fetch_all(&mut *conn)
-    .await?;
-
-    let allocated_ports: std::collections::HashSet<i32> =
-        allocated.into_iter().map(|(p,)| p).collect();
-
-    let port = (i32::from(range_start)..=i32::from(range_end))
-        .find(|p| !allocated_ports.contains(p))
-        .ok_or_else(|| AppError::Conflict("no available ports in configured range".to_string()))?;
-
-    // Immediately claim the port in the same transaction
-    let preview_url = format!("{base_url}:{port}");
-    let now = Utc::now();
-    sqlx::query(
-        "UPDATE docker_previews SET port = $1, preview_url = $2, updated_at = $3 WHERE id = $4",
-    )
-    .bind(port)
-    .bind(&preview_url)
-    .bind(now)
-    .bind(preview_id.to_string())
-    .execute(&mut *conn)
-    .await?;
-
-    Ok(port)
-}
-
 /// Maximum concurrent Docker operations.
 const MAX_CONCURRENT_DOCKER_OPS: usize = 3;
 
 /// Manages Docker container lifecycle for preview environments.
 pub struct PreviewManager {
     docker: Docker,
-    pool: SqlitePool,
+    pool: sqlx::SqlitePool,
     sse_hub: Arc<SseHub>,
     config: Arc<Config>,
     repo_path: PathBuf,
@@ -306,7 +117,7 @@ pub struct PreviewManager {
 impl PreviewManager {
     pub fn new(
         config: Arc<Config>,
-        pool: SqlitePool,
+        pool: sqlx::SqlitePool,
         sse_hub: Arc<SseHub>,
         repo_path: PathBuf,
     ) -> AppResult<Self> {
@@ -329,13 +140,13 @@ impl PreviewManager {
         })
     }
 
-    /// Build and start a Docker container for a preview.
-    /// This runs as a background task; callers should `tokio::spawn` it.
     /// Check Docker circuit breaker state. Returns `true` if Docker is healthy.
     pub fn is_docker_healthy(&self) -> bool {
         self.circuit_breaker.state() != CircuitState::Open
     }
 
+    /// Build and start a Docker container for a preview.
+    /// This runs as a background task; callers should `tokio::spawn` it.
     #[tracing::instrument(skip(self), fields(%preview_id))]
     pub async fn build_and_start(&self, preview_id: Uuid) -> AppResult<()> {
         // Check circuit breaker before starting
@@ -628,81 +439,4 @@ fn create_tar_context(dir: &std::path::Path) -> AppResult<Vec<u8>> {
     buf.flush()
         .map_err(|e| AppError::Internal(format!("tar flush error: {e}")))?;
     Ok(buf)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_helpers::setup_test_db;
-
-    async fn insert_preview(pool: &SqlitePool, worktree_name: &str) -> Uuid {
-        let id = Uuid::new_v4();
-        let now = Utc::now();
-        sqlx::query(
-            "INSERT INTO docker_previews (id, worktree_name, status, created_at, updated_at) VALUES ($1, $2, 'pending', $3, $4)",
-        )
-        .bind(id.to_string())
-        .bind(worktree_name)
-        .bind(now)
-        .bind(now)
-        .execute(pool)
-        .await
-        .expect("insert preview");
-        id
-    }
-
-    #[tokio::test]
-    async fn test_allocate_port_assigns_first_available() {
-        let pool = setup_test_db().await;
-        let id = insert_preview(&pool, "wt-1").await;
-
-        let mut conn = pool.acquire().await.unwrap();
-        let port = allocate_port_tx(&mut conn, id, 9000, 9010, "http://localhost")
-            .await
-            .expect("port allocation should succeed");
-
-        assert_eq!(port, 9000);
-    }
-
-    #[tokio::test]
-    async fn test_allocate_port_skips_already_allocated() {
-        let pool = setup_test_db().await;
-        let id1 = insert_preview(&pool, "wt-1").await;
-        let id2 = insert_preview(&pool, "wt-2").await;
-
-        let mut conn = pool.acquire().await.unwrap();
-        let port1 = allocate_port_tx(&mut conn, id1, 9000, 9010, "http://localhost")
-            .await
-            .expect("first allocation should succeed");
-        assert_eq!(port1, 9000);
-
-        let port2 = allocate_port_tx(&mut conn, id2, 9000, 9010, "http://localhost")
-            .await
-            .expect("second allocation should succeed");
-        assert_eq!(port2, 9001);
-    }
-
-    #[tokio::test]
-    async fn test_port_unique_constraint_prevents_duplicate() {
-        let pool = setup_test_db().await;
-        let id1 = insert_preview(&pool, "wt-1").await;
-        let id2 = insert_preview(&pool, "wt-2").await;
-
-        // Allocate port 9000 to id1
-        let mut conn = pool.acquire().await.unwrap();
-        allocate_port_tx(&mut conn, id1, 9000, 9010, "http://localhost")
-            .await
-            .expect("first allocation should succeed");
-
-        // Directly try to set id2's port to 9000 — should fail due to UNIQUE index
-        let result = sqlx::query("UPDATE docker_previews SET port = 9000 WHERE id = $1")
-            .bind(id2.to_string())
-            .execute(&pool)
-            .await;
-
-        assert!(
-            result.is_err(),
-            "duplicate port should be rejected by UNIQUE constraint"
-        );
-    }
 }


### PR DESCRIPTION
## Summary
- Extract DB access layer (CRUD, port allocation) into `preview_repository.rs`
- `preview_service.rs` now contains only Docker orchestration (`PreviewManager`) and circuit breaker (made private)
- Update `handlers/previews.rs` to import from `preview_repository`

Closes #221

## Test plan
- [x] `cargo clippy` passes with zero warnings
- [x] All 314 unit tests pass (3 preview repository tests moved correctly)
- [x] All integration tests pass
- [x] `task check` passes on each commit