### PR TITLE
chore: 🙈 add .serena/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 # claude-mem auto-generated CLAUDE.md (subdirectories only; root CLAUDE.md is tracked)
 **/CLAUDE.md
 !CLAUDE.md
+
+# Serena
+.serena/


### PR DESCRIPTION
## Summary
- Add `.serena/` to `.gitignore` to prevent accidental commits of Serena configuration files

## Test plan
- [ ] Verify `.serena/` no longer appears as untracked in `git status`