### PR TITLE
test: ✅ add why-comments to security and business rule tests

### DIFF
--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -4,6 +4,7 @@ use axum::http::{header, StatusCode};
 use common::create_auth_test_server as create_test_server;
 use serde_json::json;
 
+// Why: Session cookies must have HttpOnly to prevent XSS-based session theft.
 #[tokio::test]
 async fn test_register_creates_user_and_returns_session_cookie() {
     let server = create_test_server().await;
@@ -48,6 +49,8 @@ async fn test_register_validates_email() {
     response.assert_status(StatusCode::BAD_REQUEST);
 }
 
+// Why: Short passwords are trivially brute-forced; enforcing minimum length
+// raises the cost of offline attacks on leaked hashes.
 #[tokio::test]
 async fn test_register_validates_password_length() {
     let server = create_test_server().await;
@@ -64,6 +67,8 @@ async fn test_register_validates_password_length() {
     response.assert_status(StatusCode::BAD_REQUEST);
 }
 
+// Why: Returning a specific "email already exists" error enables user enumeration
+// attacks — attackers can probe the registration endpoint to discover valid accounts.
 #[tokio::test]
 async fn test_register_duplicate_email_returns_generic_error() {
     let server = create_test_server().await;
@@ -128,6 +133,8 @@ async fn test_login_with_valid_credentials() {
     assert!(cookies.is_some(), "Should set session cookie");
 }
 
+// Why: Invalid credentials must return UNAUTHORIZED (not a specific "wrong password"
+// message) to prevent credential-stuffing bots from distinguishing valid accounts.
 #[tokio::test]
 async fn test_login_with_wrong_password() {
     let server = create_test_server().await;
@@ -154,6 +161,8 @@ async fn test_login_with_wrong_password() {
     response.assert_status(StatusCode::UNAUTHORIZED);
 }
 
+// Why: Must return the same status code as wrong-password to prevent user enumeration
+// via timing or response differences (constant-time comparison in Argon2 handles timing).
 #[tokio::test]
 async fn test_login_with_nonexistent_email() {
     let server = create_test_server().await;
@@ -169,6 +178,8 @@ async fn test_login_with_nonexistent_email() {
     response.assert_status(StatusCode::UNAUTHORIZED);
 }
 
+// Why: Unauthenticated requests to user-specific endpoints must be rejected to enforce
+// the authentication boundary and prevent information leakage.
 #[tokio::test]
 async fn test_me_without_auth() {
     let server = create_test_server().await;
@@ -216,6 +227,8 @@ async fn test_me_with_auth() {
     assert_eq!(body["name"], "Test User");
 }
 
+// Why: Logout must invalidate the server-side session AND set Max-Age=0 on the cookie.
+// Without both, a stolen cookie could remain valid after the user logs out.
 #[tokio::test]
 async fn test_logout_clears_session() {
     let server = create_test_server().await;
@@ -272,6 +285,8 @@ async fn test_logout_without_auth() {
     response.assert_status(StatusCode::UNAUTHORIZED);
 }
 
+// Why: When a user logs in again, old sessions must be invalidated to limit the
+// window of exposure if a session token was compromised (session fixation prevention).
 #[tokio::test]
 async fn test_login_invalidates_previous_sessions() {
     let server = create_test_server().await;
@@ -315,6 +330,8 @@ async fn test_login_invalidates_previous_sessions() {
     me_response.assert_status(StatusCode::UNAUTHORIZED);
 }
 
+// Why: Rate limiting on login prevents brute-force and credential-stuffing attacks
+// by throttling the number of attempts per time window.
 #[tokio::test]
 async fn test_login_rate_limit_returns_429_after_burst() {
     let server = create_test_server().await;
@@ -334,6 +351,8 @@ async fn test_login_rate_limit_returns_429_after_burst() {
     response.assert_status(StatusCode::TOO_MANY_REQUESTS);
 }
 
+// Why: Rate limiting on registration prevents automated mass account creation
+// and abuse of the signup endpoint as an email oracle.
 #[tokio::test]
 async fn test_register_rate_limit_returns_429_after_burst() {
     let server = create_test_server().await;

--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -162,7 +162,7 @@ async fn test_login_with_wrong_password() {
 }
 
 // Why: Must return the same status code as wrong-password to prevent user enumeration
-// via timing or response differences (constant-time comparison in Argon2 handles timing).
+// via response differences (no distinct error for unknown email vs wrong password).
 #[tokio::test]
 async fn test_login_with_nonexistent_email() {
     let server = create_test_server().await;

--- a/backend/tests/authorization/owner_protection.rs
+++ b/backend/tests/authorization/owner_protection.rs
@@ -10,6 +10,8 @@ use crate::common::{
 // Phase 6: Owner protection rules
 // =============================================================
 
+// Why: Removing the last owner would leave the project in an unmanageable state —
+// no one could add members, change settings, or delete the project.
 #[tokio::test]
 async fn test_cannot_remove_last_owner() {
     let server = create_test_server().await;
@@ -46,6 +48,8 @@ async fn test_can_remove_owner_if_another_owner_exists() {
     response.assert_status(StatusCode::NO_CONTENT);
 }
 
+// Why: Downgrading the last owner to admin/member has the same effect as removal —
+// the project loses its ability to perform owner-only operations.
 #[tokio::test]
 async fn test_cannot_downgrade_last_owner_role() {
     let server = create_test_server().await;
@@ -88,6 +92,8 @@ async fn test_can_downgrade_owner_if_another_owner_exists() {
 // Phase 7: Session outputs endpoint authorization
 // =============================================================
 
+// Why: Agent session outputs may contain secrets (env vars, API keys) from the
+// execution environment — non-members must never access them.
 #[tokio::test]
 async fn test_session_outputs_forbidden_for_non_member() {
     let server = create_test_server().await;

--- a/backend/tests/authorization/projects.rs
+++ b/backend/tests/authorization/projects.rs
@@ -9,6 +9,8 @@ use crate::common::{
 // Phase 2: create_project auto-adds creator as Owner
 // =============================================================
 
+// Why: The creator must be auto-enrolled as owner so every project has at least one
+// user who can manage members and settings from the moment of creation.
 #[tokio::test]
 async fn test_create_project_auto_adds_creator_as_owner() {
     let server = create_test_server().await;
@@ -49,6 +51,8 @@ async fn test_create_project_creator_can_access_project() {
 // Phase 3: Project endpoint authorization
 // =============================================================
 
+// Why: Users must only see projects they belong to — leaking project existence or
+// metadata to non-members violates the multi-tenant isolation model.
 #[tokio::test]
 async fn test_list_projects_only_returns_member_projects() {
     let server = create_test_server().await;
@@ -78,6 +82,8 @@ async fn test_list_projects_only_returns_member_projects() {
     assert_eq!(projects.len(), 1);
 }
 
+// Why: Non-members must receive 403 (not 404) to maintain a clear authorization
+// boundary — 404 could be ambiguous between "doesn't exist" and "not allowed".
 #[tokio::test]
 async fn test_get_project_forbidden_for_non_member() {
     let server = create_test_server().await;
@@ -109,6 +115,8 @@ async fn test_get_project_allowed_for_member() {
     response.assert_status_ok();
 }
 
+// Why: Regular members must not be able to modify project settings (name, etc.) —
+// only admins and owners should have write access to project-level configuration.
 #[tokio::test]
 async fn test_update_project_forbidden_for_member_role() {
     let server = create_test_server().await;
@@ -145,6 +153,8 @@ async fn test_update_project_allowed_for_admin() {
     assert_eq!(body["name"], "Updated by Admin");
 }
 
+// Why: Project deletion is destructive and irreversible — restricting it to owner
+// prevents admins from accidentally or maliciously destroying the project.
 #[tokio::test]
 async fn test_delete_project_forbidden_for_admin() {
     let server = create_test_server().await;

--- a/backend/tests/authorization/tasks_members.rs
+++ b/backend/tests/authorization/tasks_members.rs
@@ -10,6 +10,8 @@ use crate::common::{
 // Phase 4: Task endpoint authorization
 // =============================================================
 
+// Why: All task CRUD endpoints must enforce project membership — without this,
+// any authenticated user could read/modify/delete tasks in projects they don't belong to.
 #[tokio::test]
 async fn test_task_endpoints_forbidden_for_non_member() {
     let server = create_test_server().await;
@@ -79,6 +81,8 @@ async fn test_task_endpoints_allowed_for_member() {
 // Phase 5: Member management authorization
 // =============================================================
 
+// Why: Member list reveals who works on a project — non-members must not access
+// this information to maintain organizational privacy.
 #[tokio::test]
 async fn test_list_members_forbidden_for_non_member() {
     let server = create_test_server().await;
@@ -110,6 +114,8 @@ async fn test_list_members_allowed_for_member() {
     response.assert_status_ok();
 }
 
+// Why: Only admins/owners should add members — allowing regular members to invite
+// would bypass the intended approval hierarchy and could lead to unauthorized access.
 #[tokio::test]
 async fn test_add_member_forbidden_for_member_role() {
     let server = create_test_server().await;

--- a/backend/tests/error_response.rs
+++ b/backend/tests/error_response.rs
@@ -111,6 +111,8 @@ async fn test_unauthorized_error_response_structure() {
     assert_error_response(&body, "UNAUTHORIZED");
 }
 
+// Why: Internal details (library names, stack traces) in error responses help attackers
+// fingerprint the tech stack and find known vulnerabilities — OWASP recommends generic messages.
 #[tokio::test]
 async fn test_error_response_does_not_leak_internal_details() {
     let server = create_test_server().await;

--- a/backend/tests/host_validation.rs
+++ b/backend/tests/host_validation.rs
@@ -86,6 +86,8 @@ async fn test_host_validation_allows_configured_host() {
     response.assert_status_ok();
 }
 
+// Why: Host header validation prevents DNS rebinding attacks where a malicious page
+// tricks the browser into sending requests to the local server via a crafted hostname.
 #[tokio::test]
 async fn test_host_validation_rejects_unknown_host() {
     let server = create_server_with_allowed_hosts(vec!["allowed.example.com".to_string()]).await;

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -49,6 +49,8 @@ async fn test_list_tasks_returns_not_found_for_nonexistent_project() {
     response.assert_status(StatusCode::NOT_FOUND);
 }
 
+// Why: Default status=backlog and priority=medium ensure new tasks appear in a
+// predictable location on the board without requiring the caller to set every field.
 #[tokio::test]
 async fn test_create_task_returns_created() {
     let server = create_test_server().await;
@@ -72,6 +74,8 @@ async fn test_create_task_returns_created() {
     assert_eq!(task["priority"], "medium");
 }
 
+// Why: Empty titles produce meaningless kanban cards — validation at the API layer
+// ensures every task has an identifiable label for the board UI.
 #[tokio::test]
 async fn test_create_task_validates_title() {
     let server = create_test_server().await;
@@ -299,6 +303,8 @@ async fn test_update_task_validates_empty_title() {
     response.assert_status(StatusCode::BAD_REQUEST);
 }
 
+// Why: Listing tasks without a project_id would return cross-project data, violating
+// the multi-tenant isolation boundary — the API must require explicit scoping.
 #[tokio::test]
 async fn test_list_tasks_requires_project_id() {
     let server = create_test_server().await;


### PR DESCRIPTION
## Summary
- Add `// Why:` comments to 25+ security/authorization/business rule tests
- Covers: auth (user enumeration, rate limiting, session management), host validation (DNS rebinding), RBAC (project/task/member authorization), owner protection, error response leakage
- All comments in English, explaining the attack vector or business reason

## Test plan
- [x] All affected backend tests pass
- [x] No code changes — comments only

Closes #236