### PR TITLE
test: ✅ add custom assertion messages for business rules and security

### DIFF
--- a/backend/tests/auth_api.rs
+++ b/backend/tests/auth_api.rs
@@ -28,8 +28,14 @@ async fn test_register_creates_user_and_returns_session_cookie() {
     let cookies = response.headers().get("set-cookie");
     assert!(cookies.is_some(), "Should set session cookie");
     let cookie_str = cookies.unwrap().to_str().unwrap();
-    assert!(cookie_str.contains("gantry_session="));
-    assert!(cookie_str.contains("HttpOnly"));
+    assert!(
+        cookie_str.contains("gantry_session="),
+        "session cookie must use gantry_session name"
+    );
+    assert!(
+        cookie_str.contains("HttpOnly"),
+        "session cookie must be HttpOnly to prevent XSS theft"
+    );
 }
 
 #[tokio::test]
@@ -252,7 +258,10 @@ async fn test_logout_clears_session() {
     let clear_cookie = logout_response.headers().get("set-cookie");
     assert!(clear_cookie.is_some());
     let clear_cookie_str = clear_cookie.unwrap().to_str().unwrap();
-    assert!(clear_cookie_str.contains("Max-Age=0"));
+    assert!(
+        clear_cookie_str.contains("Max-Age=0"),
+        "logout must expire the cookie to prevent reuse"
+    );
 
     // Try to access /me with the old cookie - should fail
     let me_response = server

--- a/backend/tests/authorization/projects.rs
+++ b/backend/tests/authorization/projects.rs
@@ -23,9 +23,12 @@ async fn test_create_project_auto_adds_creator_as_owner() {
     response.assert_status_ok();
 
     let members: Vec<serde_json::Value> = response.json();
-    assert_eq!(members.len(), 1);
+    assert_eq!(members.len(), 1, "creator must be the only initial member");
     assert_eq!(members[0]["user_id"], user_id);
-    assert_eq!(members[0]["role"], "owner");
+    assert_eq!(
+        members[0]["role"], "owner",
+        "creator must be auto-assigned the owner role"
+    );
 }
 
 #[tokio::test]
@@ -66,7 +69,11 @@ async fn test_list_projects_only_returns_member_projects() {
     response.assert_status_ok();
     let body: serde_json::Value = response.json();
     let projects = body["data"].as_array().unwrap();
-    assert_eq!(projects.len(), 2);
+    assert_eq!(
+        projects.len(),
+        2,
+        "User A must see only their own 2 projects"
+    );
 
     let response = server
         .get("/api/projects")
@@ -75,7 +82,11 @@ async fn test_list_projects_only_returns_member_projects() {
     response.assert_status_ok();
     let body: serde_json::Value = response.json();
     let projects = body["data"].as_array().unwrap();
-    assert_eq!(projects.len(), 1);
+    assert_eq!(
+        projects.len(),
+        1,
+        "User B must see only their own 1 project"
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -33,7 +33,7 @@ async fn test_list_tasks_returns_empty_initially() {
     let tasks = body["data"].as_array().unwrap();
     assert!(tasks.is_empty());
     assert_eq!(body["total"], 0);
-    assert_eq!(body["limit"], 50);
+    assert_eq!(body["limit"], 50, "default page size must be 50");
     assert_eq!(body["offset"], 0);
 }
 
@@ -68,8 +68,14 @@ async fn test_create_task_returns_created() {
     assert_eq!(task["title"], "Test Task");
     assert_eq!(task["description"], "A test task");
     assert_eq!(task["project_id"], project_id);
-    assert_eq!(task["status"], "backlog");
-    assert_eq!(task["priority"], "medium");
+    assert_eq!(
+        task["status"], "backlog",
+        "new tasks must default to backlog status"
+    );
+    assert_eq!(
+        task["priority"], "medium",
+        "new tasks must default to medium priority"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add descriptive messages to business-rule assertions (default status/priority, page size)
- Add security assertion messages (HttpOnly cookie, Max-Age=0 on logout)
- Add authorization assertion messages (owner auto-assign, project isolation)

## Test plan
- [x] All affected backend tests pass
- [x] No behavior changes — assertion messages only

Closes #235