### PR TITLE
test: ✅ unify arrange helpers and reduce test setup boilerplate

### DIFF
--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -120,32 +120,41 @@ pub async fn create_test_server_with_repo_and_pool() -> (tempfile::TempDir, Test
     (tmp, server, pool)
 }
 
-// ========== Common Test Helpers ==========
+// ========== Common Test Helpers (no-auth) ==========
 
-/// Create a project and a task in it, returning (project_id, task_id).
-/// Used by agent_sessions tests that don't require auth.
-pub async fn create_project_and_task(server: &TestServer) -> (String, String) {
+/// Create a project (no auth) and return its ID.
+pub async fn create_project_no_auth(server: &TestServer, name: &str) -> String {
     let response = server
         .post("/api/projects")
-        .json(&serde_json::json!({ "name": "Test Project" }))
+        .json(&serde_json::json!({ "name": name }))
         .await;
-    let project_id = response.json::<serde_json::Value>()["id"]
+    response.assert_status(axum::http::StatusCode::CREATED);
+    response.json::<serde_json::Value>()["id"]
         .as_str()
         .unwrap()
-        .to_string();
+        .to_string()
+}
 
+/// Create a task in a project (no auth) and return its ID.
+pub async fn create_task_no_auth(server: &TestServer, project_id: &str, title: &str) -> String {
     let response = server
         .post("/api/tasks")
         .json(&serde_json::json!({
             "project_id": project_id,
-            "title": "Test Task"
+            "title": title
         }))
         .await;
-    let task_id = response.json::<serde_json::Value>()["id"]
+    response.assert_status(axum::http::StatusCode::CREATED);
+    response.json::<serde_json::Value>()["id"]
         .as_str()
         .unwrap()
-        .to_string();
+        .to_string()
+}
 
+/// Create a project and a task in it, returning (project_id, task_id).
+pub async fn create_project_and_task(server: &TestServer) -> (String, String) {
+    let project_id = create_project_no_auth(server, "Test Project").await;
+    let task_id = create_task_no_auth(server, &project_id, "Test Task").await;
     (project_id, task_id)
 }
 

--- a/backend/tests/projects_api.rs
+++ b/backend/tests/projects_api.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::create_test_server;
+use common::{create_project_no_auth, create_test_server};
 use serde_json::json;
 
 #[tokio::test]
@@ -55,15 +55,7 @@ async fn test_create_project_validates_name() {
 #[tokio::test]
 async fn test_get_project_returns_existing() {
     let server = create_test_server().await;
-
-    let create_response = server
-        .post("/api/projects")
-        .json(&json!({
-            "name": "Test Project"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let id = created["id"].as_str().unwrap();
+    let id = create_project_no_auth(&server, "Test Project").await;
 
     let response = server.get(&format!("/api/projects/{}", id)).await;
 
@@ -86,15 +78,7 @@ async fn test_get_project_returns_not_found() {
 #[tokio::test]
 async fn test_update_project_changes_name() {
     let server = create_test_server().await;
-
-    let create_response = server
-        .post("/api/projects")
-        .json(&json!({
-            "name": "Original Name"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let id = created["id"].as_str().unwrap();
+    let id = create_project_no_auth(&server, "Original Name").await;
 
     let response = server
         .patch(&format!("/api/projects/{}", id))
@@ -111,15 +95,7 @@ async fn test_update_project_changes_name() {
 #[tokio::test]
 async fn test_delete_project_removes_from_db() {
     let server = create_test_server().await;
-
-    let create_response = server
-        .post("/api/projects")
-        .json(&json!({
-            "name": "To Be Deleted"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let id = created["id"].as_str().unwrap();
+    let id = create_project_no_auth(&server, "To Be Deleted").await;
 
     let delete_response = server.delete(&format!("/api/projects/{}", id)).await;
     delete_response.assert_status(axum::http::StatusCode::NO_CONTENT);
@@ -131,15 +107,8 @@ async fn test_delete_project_removes_from_db() {
 #[tokio::test]
 async fn test_list_projects_returns_created_projects() {
     let server = create_test_server().await;
-
-    server
-        .post("/api/projects")
-        .json(&json!({ "name": "Project 1" }))
-        .await;
-    server
-        .post("/api/projects")
-        .json(&json!({ "name": "Project 2" }))
-        .await;
+    create_project_no_auth(&server, "Project 1").await;
+    create_project_no_auth(&server, "Project 2").await;
 
     let response = server.get("/api/projects").await;
 
@@ -153,12 +122,8 @@ async fn test_list_projects_returns_created_projects() {
 #[tokio::test]
 async fn test_list_projects_respects_limit_and_offset() {
     let server = create_test_server().await;
-
     for i in 0..5 {
-        server
-            .post("/api/projects")
-            .json(&json!({ "name": format!("Project {}", i) }))
-            .await;
+        create_project_no_auth(&server, &format!("Project {}", i)).await;
     }
 
     let response = server.get("/api/projects?limit=2&offset=1").await;

--- a/backend/tests/task_comments_api.rs
+++ b/backend/tests/task_comments_api.rs
@@ -1,8 +1,9 @@
 mod common;
 
 use axum::http::StatusCode;
-use axum_test::TestServer;
-use common::{create_test_server_with_pool, SqlitePool};
+use common::{
+    create_project_no_auth, create_task_no_auth, create_test_server_with_pool, SqlitePool,
+};
 use serde_json::json;
 
 /// Seed a user with nil UUID so auth-disabled mode (user_id = Uuid::nil()) can
@@ -21,38 +22,12 @@ async fn seed_nil_user(pool: &SqlitePool) {
     .unwrap();
 }
 
-async fn create_test_project(server: &TestServer) -> String {
-    let response = server
-        .post("/api/projects")
-        .json(&json!({
-            "name": "Test Project",
-            "description": "A test project"
-        }))
-        .await;
-    response.assert_status(StatusCode::CREATED);
-    let body: serde_json::Value = response.json();
-    body["id"].as_str().unwrap().to_string()
-}
-
-async fn create_test_task(server: &TestServer, project_id: &str) -> String {
-    let response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Test Task"
-        }))
-        .await;
-    response.assert_status(StatusCode::CREATED);
-    let body: serde_json::Value = response.json();
-    body["id"].as_str().unwrap().to_string()
-}
-
 #[tokio::test]
 async fn test_create_comment_returns_created() {
     let (server, pool) = create_test_server_with_pool().await;
     seed_nil_user(&pool).await;
-    let project_id = create_test_project(&server).await;
-    let task_id = create_test_task(&server, &project_id).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Test Task").await;
 
     let response = server
         .post(&format!("/api/tasks/{}/comments", task_id))
@@ -72,8 +47,8 @@ async fn test_create_comment_returns_created() {
 async fn test_list_comments_returns_all() {
     let (server, pool) = create_test_server_with_pool().await;
     seed_nil_user(&pool).await;
-    let project_id = create_test_project(&server).await;
-    let task_id = create_test_task(&server, &project_id).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Test Task").await;
 
     server
         .post(&format!("/api/tasks/{}/comments", task_id))
@@ -102,8 +77,8 @@ async fn test_list_comments_returns_all() {
 async fn test_update_comment_by_author() {
     let (server, pool) = create_test_server_with_pool().await;
     seed_nil_user(&pool).await;
-    let project_id = create_test_project(&server).await;
-    let task_id = create_test_task(&server, &project_id).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Test Task").await;
 
     let create_resp = server
         .post(&format!("/api/tasks/{}/comments", task_id))
@@ -127,8 +102,8 @@ async fn test_update_comment_by_author() {
 async fn test_delete_comment_by_author() {
     let (server, pool) = create_test_server_with_pool().await;
     seed_nil_user(&pool).await;
-    let project_id = create_test_project(&server).await;
-    let task_id = create_test_task(&server, &project_id).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Test Task").await;
 
     let create_resp = server
         .post(&format!("/api/tasks/{}/comments", task_id))
@@ -162,8 +137,8 @@ async fn test_create_comment_on_nonexistent_task_returns_not_found() {
 async fn test_create_comment_empty_content_returns_validation_error() {
     let (server, pool) = create_test_server_with_pool().await;
     seed_nil_user(&pool).await;
-    let project_id = create_test_project(&server).await;
-    let task_id = create_test_task(&server, &project_id).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Test Task").await;
 
     let response = server
         .post(&format!("/api/tasks/{}/comments", task_id))

--- a/backend/tests/tasks_api.rs
+++ b/backend/tests/tasks_api.rs
@@ -1,28 +1,14 @@
 mod common;
 
 use axum::http::StatusCode;
-use axum_test::TestServer;
-use common::create_test_server;
+use common::{create_project_no_auth, create_task_no_auth, create_test_server};
 use serde_json::json;
 use uuid::Uuid;
-
-async fn create_test_project(server: &TestServer) -> String {
-    let response = server
-        .post("/api/projects")
-        .json(&json!({
-            "name": "Test Project"
-        }))
-        .await;
-
-    response.assert_status(StatusCode::CREATED);
-    let body: serde_json::Value = response.json();
-    body["id"].as_str().unwrap().to_string()
-}
 
 #[tokio::test]
 async fn test_list_tasks_returns_empty_initially() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
 
     let response = server
         .get(&format!("/api/tasks?project_id={}", project_id))
@@ -52,7 +38,7 @@ async fn test_list_tasks_returns_not_found_for_nonexistent_project() {
 #[tokio::test]
 async fn test_create_task_returns_created() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
 
     let response = server
         .post("/api/tasks")
@@ -75,7 +61,7 @@ async fn test_create_task_returns_created() {
 #[tokio::test]
 async fn test_create_task_validates_title() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
 
     let response = server
         .post("/api/tasks")
@@ -107,17 +93,8 @@ async fn test_create_task_returns_not_found_for_nonexistent_project() {
 #[tokio::test]
 async fn test_get_task_returns_existing() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    let create_response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Get Me"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let task_id = created["id"].as_str().unwrap();
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Get Me").await;
 
     let response = server.get(&format!("/api/tasks/{}", task_id)).await;
 
@@ -139,17 +116,8 @@ async fn test_get_task_returns_not_found() {
 #[tokio::test]
 async fn test_update_task_changes_title() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    let create_response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Original"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let task_id = created["id"].as_str().unwrap();
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Original").await;
 
     let response = server
         .patch(&format!("/api/tasks/{}", task_id))
@@ -166,17 +134,8 @@ async fn test_update_task_changes_title() {
 #[tokio::test]
 async fn test_update_task_changes_status() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    let create_response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Task"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let task_id = created["id"].as_str().unwrap();
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Task").await;
 
     let response = server
         .patch(&format!("/api/tasks/{}", task_id))
@@ -193,17 +152,8 @@ async fn test_update_task_changes_status() {
 #[tokio::test]
 async fn test_delete_task_removes_from_db() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    let create_response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "To Delete"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let task_id = created["id"].as_str().unwrap();
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "To Delete").await;
 
     let delete_response = server.delete(&format!("/api/tasks/{}", task_id)).await;
     delete_response.assert_status(StatusCode::NO_CONTENT);
@@ -215,22 +165,9 @@ async fn test_delete_task_removes_from_db() {
 #[tokio::test]
 async fn test_list_tasks_returns_created_tasks() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Task 1"
-        }))
-        .await;
-    server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Task 2"
-        }))
-        .await;
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    create_task_no_auth(&server, &project_id, "Task 1").await;
+    create_task_no_auth(&server, &project_id, "Task 2").await;
 
     let response = server
         .get(&format!("/api/tasks?project_id={}", project_id))
@@ -246,16 +183,9 @@ async fn test_list_tasks_returns_created_tasks() {
 #[tokio::test]
 async fn test_list_tasks_respects_limit_and_offset() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
+    let project_id = create_project_no_auth(&server, "Test Project").await;
     for i in 0..5 {
-        server
-            .post("/api/tasks")
-            .json(&json!({
-                "project_id": project_id,
-                "title": format!("Task {}", i)
-            }))
-            .await;
+        create_task_no_auth(&server, &project_id, &format!("Task {}", i)).await;
     }
 
     let response = server
@@ -277,17 +207,8 @@ async fn test_list_tasks_respects_limit_and_offset() {
 #[tokio::test]
 async fn test_update_task_validates_empty_title() {
     let server = create_test_server().await;
-    let project_id = create_test_project(&server).await;
-
-    let create_response = server
-        .post("/api/tasks")
-        .json(&json!({
-            "project_id": project_id,
-            "title": "Valid Title"
-        }))
-        .await;
-    let created: serde_json::Value = create_response.json();
-    let task_id = created["id"].as_str().unwrap();
+    let project_id = create_project_no_auth(&server, "Test Project").await;
+    let task_id = create_task_no_auth(&server, &project_id, "Valid Title").await;
 
     let response = server
         .patch(&format!("/api/tasks/{}", task_id))


### PR DESCRIPTION
## Summary
- Add `create_project_no_auth()` and `create_task_no_auth()` to `common/mod.rs`
- Simplify `create_project_and_task()` to use the new helpers
- Refactor `tasks_api.rs`: remove local `create_test_project`, use common helpers (Arrange ≤ 3 lines)
- Refactor `task_comments_api.rs`: remove local project/task helpers, use common
- Refactor `projects_api.rs`: replace inline project creation with `create_project_no_auth`
- Net reduction: ~130 lines of duplicated test setup code

## Test plan
- [x] All 14 tasks_api tests pass
- [x] All 6 task_comments_api tests pass
- [x] All 9 projects_api tests pass

Closes #231