### PR TITLE
test: ✅ add Playwright E2E testing infrastructure

### DIFF
--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -1,0 +1,34 @@
+import { test as base, type Page } from '@playwright/test';
+import { ApiHelper } from '../helpers/api';
+import { type TestUser, createTestUser } from '../helpers/auth';
+
+type Fixtures = {
+  apiHelper: ApiHelper;
+  testUser: TestUser;
+  authenticatedPage: Page;
+};
+
+export const test = base.extend<Fixtures>({
+  apiHelper: async ({ request }, use) => {
+    await use(new ApiHelper(request));
+  },
+
+  testUser: async ({ request }, use) => {
+    const user = await createTestUser(request);
+    await use(user);
+  },
+
+  authenticatedPage: async ({ page, testUser }, use) => {
+    await page.context().addCookies([
+      {
+        name: testUser.cookie.split('=')[0],
+        value: testUser.cookie.split('=')[1],
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -18,12 +18,13 @@ export const test = base.extend<Fixtures>({
     await use(user);
   },
 
-  authenticatedPage: async ({ page, testUser }, use) => {
+  authenticatedPage: async ({ page, testUser, baseURL }, use) => {
+    const domain = new URL(baseURL ?? 'http://localhost:5173').hostname;
     await page.context().addCookies([
       {
         name: testUser.cookie.split('=')[0],
         value: testUser.cookie.split('=')[1],
-        domain: 'localhost',
+        domain,
         path: '/',
       },
     ]);

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,6 +1,13 @@
-import type { APIRequestContext } from '@playwright/test';
+import type { APIRequestContext, APIResponse } from '@playwright/test';
 
 const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000';
+
+async function assertOk(response: APIResponse, context: string): Promise<APIResponse> {
+  if (!response.ok()) {
+    throw new Error(`${context} failed: ${response.status()} ${await response.text()}`);
+  }
+  return response;
+}
 
 export class ApiHelper {
   constructor(private request: APIRequestContext) {}
@@ -10,7 +17,7 @@ export class ApiHelper {
       data: { email, name, password },
       headers: { 'x-requested-with': 'XMLHttpRequest' },
     });
-    return response.json();
+    return (await assertOk(response, 'registerUser')).json();
   }
 
   async createProject(cookie: string, name: string) {
@@ -21,7 +28,7 @@ export class ApiHelper {
         'x-requested-with': 'XMLHttpRequest',
       },
     });
-    return response.json();
+    return (await assertOk(response, 'createProject')).json();
   }
 
   async healthCheck() {

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,0 +1,31 @@
+import type { APIRequestContext } from '@playwright/test';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000';
+
+export class ApiHelper {
+  constructor(private request: APIRequestContext) {}
+
+  async registerUser(email: string, name: string, password: string) {
+    const response = await this.request.post(`${API_BASE}/api/auth/register`, {
+      data: { email, name, password },
+      headers: { 'x-requested-with': 'XMLHttpRequest' },
+    });
+    return response.json();
+  }
+
+  async createProject(cookie: string, name: string) {
+    const response = await this.request.post(`${API_BASE}/api/projects`, {
+      data: { name },
+      headers: {
+        cookie,
+        'x-requested-with': 'XMLHttpRequest',
+      },
+    });
+    return response.json();
+  }
+
+  async healthCheck() {
+    const response = await this.request.get(`${API_BASE}/health`);
+    return response;
+  }
+}

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,0 +1,38 @@
+import type { APIRequestContext } from '@playwright/test';
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000';
+
+export interface TestUser {
+  id: string;
+  email: string;
+  name: string;
+  cookie: string;
+}
+
+let userCounter = 0;
+
+export async function createTestUser(
+  request: APIRequestContext,
+  overrides?: { email?: string; name?: string },
+): Promise<TestUser> {
+  userCounter++;
+  const email = overrides?.email ?? `e2e-user-${userCounter}-${Date.now()}@test.local`;
+  const name = overrides?.name ?? `E2E User ${userCounter}`;
+  const password = 'Tr0ub4dor&3-e2e-test';
+
+  const response = await request.post(`${API_BASE}/api/auth/register`, {
+    data: { email, name, password },
+    headers: { 'x-requested-with': 'XMLHttpRequest' },
+  });
+
+  const setCookie = response.headers()['set-cookie'] ?? '';
+  const cookie = setCookie.split(';')[0];
+  const body = await response.json();
+
+  return {
+    id: body.user.id,
+    email,
+    name,
+    cookie,
+  };
+}

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -25,6 +25,10 @@ export async function createTestUser(
     headers: { 'x-requested-with': 'XMLHttpRequest' },
   });
 
+  if (!response.ok()) {
+    throw new Error(`createTestUser failed: ${response.status()} ${await response.text()}`);
+  }
+
   const setCookie = response.headers()['set-cookie'] ?? '';
   const cookie = setCookie.split(';')[0];
   const body = await response.json();

--- a/frontend/e2e/tests/health.spec.ts
+++ b/frontend/e2e/tests/health.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Health Check', () => {
+  test('backend health endpoint returns ok', async ({ apiHelper }) => {
+    const response = await apiHelper.healthCheck();
+    expect(response.ok()).toBeTruthy();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.14",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/vite": "^4.1.0",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.3.0",
@@ -2155,6 +2156,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7419,6 +7436,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pony-cause": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.14",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.1.0",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : [['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
@@ -14,7 +14,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     pool: 'forks',
-    exclude: ['e2e/**', 'node_modules/**'],
+    exclude: [...configDefaults.exclude, 'e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     pool: 'forks',
+    exclude: ['e2e/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],

--- a/taskfiles/frontend.yml
+++ b/taskfiles/frontend.yml
@@ -32,3 +32,15 @@ tasks:
   audit:
     desc: Run npm audit for frontend dependencies
     cmd: npm audit --audit-level=moderate
+
+  e2e:
+    desc: Run Playwright E2E tests
+    cmd: npx playwright test
+
+  e2e:ui:
+    desc: Run Playwright E2E tests with UI
+    cmd: npx playwright test --ui
+
+  e2e:report:
+    desc: Show Playwright HTML report
+    cmd: npx playwright show-report


### PR DESCRIPTION
## Summary
- Install `@playwright/test` and configure Playwright for E2E testing (Chromium only)
- Create `e2e/` directory structure with custom fixtures, API helper, and auth helper
- Add health check smoke test as initial E2E test
- Exclude `e2e/` from Vitest to prevent conflicts
- Add `e2e`, `e2e:ui`, `e2e:report` tasks to Taskfile

Closes #243

## Test plan
- [x] `task frontend:test` — all 333 unit tests pass
- [x] `task check` — quality checks pass
- [ ] `task frontend:e2e` — health check E2E test passes (requires running backend)