### PR TITLE
feat: ✨ add pause/resume agent sessions with SIGSTOP/SIGCONT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ git2 = "0.20"
 # Agent
 async-trait = "0.1"
 tokio-util = { version = "0.7", features = ["rt"] }
+nix = { version = "0.29", features = ["signal"] }
 
 # Caching
 moka = { version = "0.12", features = ["future"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,7 @@ axum-extra = { workspace = true }
 git2 = { workspace = true }
 async-trait = { workspace = true }
 tokio-util = { workspace = true }
+nix = { workspace = true }
 tower_governor = { workspace = true }
 zxcvbn = { workspace = true }
 moka = { workspace = true }

--- a/backend/migrations/20260219100001_add_paused_to_active_session_constraint.sql
+++ b/backend/migrations/20260219100001_add_paused_to_active_session_constraint.sql
@@ -1,0 +1,6 @@
+-- Include 'paused' in the active session constraint so that paused sessions
+-- also prevent a second session from being started on the same task.
+DROP INDEX IF EXISTS idx_unique_active_session_per_task;
+
+CREATE UNIQUE INDEX idx_unique_active_session_per_task
+ON agent_sessions(task_id) WHERE status IN ('pending', 'running', 'paused');

--- a/backend/src/agent/executor.rs
+++ b/backend/src/agent/executor.rs
@@ -37,6 +37,8 @@ pub struct AgentHandle {
     pub cancel: CancellationToken,
     pub output_rx: mpsc::Receiver<AgentOutputEvent>,
     pub join_handle: tokio::task::JoinHandle<AppResult<()>>,
+    /// Process ID of the spawned child, used for pause/resume signals.
+    pub pid: Option<u32>,
 }
 
 /// Validate agent configuration before execution.
@@ -100,6 +102,7 @@ impl AgentExecutor for NoopExecutor {
             cancel,
             output_rx: rx,
             join_handle,
+            pid: None,
         })
     }
 }
@@ -150,6 +153,8 @@ where
             )));
         }
     };
+
+    let pid = child.id();
 
     let cancel = CancellationToken::new();
     let (tx, rx) = mpsc::channel(256);
@@ -219,6 +224,7 @@ where
         cancel,
         output_rx: rx,
         join_handle,
+        pid,
     })
 }
 

--- a/backend/src/agent/orchestrator/lifecycle.rs
+++ b/backend/src/agent/orchestrator/lifecycle.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
 use uuid::Uuid;
 
 use super::{AgentOrchestrator, RunningSession};
@@ -8,18 +10,23 @@ use crate::models::agent_session::{AgentSessionStatus, UpdateAgentSessionRequest
 use crate::services::{agent_session_service, worktree_service};
 
 impl AgentOrchestrator {
-    /// Stop a running agent session.
+    /// Stop a running or paused agent session.
     ///
-    /// 1. Cancel the agent process
-    /// 2. Update DB session (Cancelled)
-    /// 3. Remove from running map only after DB update succeeds
+    /// 1. If paused, send SIGCONT first so the process can be killed
+    /// 2. Cancel the agent process
+    /// 3. Update DB session (Cancelled)
+    /// 4. Remove from running map only after DB update succeeds
     pub async fn stop_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
-        // Step 1: Check session exists and cancel it (keep in map)
+        // Step 1: Check session exists, resume if paused, then cancel
         {
             let running = self.running.lock().await;
             let session = running.get(&session_id).ok_or_else(|| {
                 AppError::NotFound(format!("no running session found: {session_id}"))
             })?;
+            // Send SIGCONT before killing, in case the process is stopped
+            if let Some(pid) = session.pid {
+                let _ = signal::kill(Pid::from_raw(pid as i32), Signal::SIGCONT);
+            }
             session.cancel.cancel();
         }
 
@@ -40,6 +47,62 @@ impl AgentOrchestrator {
             running.remove(&session_id);
             metrics::gauge!("gantry_agent_sessions_active").set(running.len() as f64);
         }
+
+        Ok(())
+    }
+
+    /// Pause a running agent session by sending SIGSTOP to the child process.
+    pub async fn pause_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
+        let pid = {
+            let running = self.running.lock().await;
+            let session = running.get(&session_id).ok_or_else(|| {
+                AppError::NotFound(format!("no running session found: {session_id}"))
+            })?;
+            session.pid.ok_or_else(|| {
+                AppError::Internal("cannot pause session: no PID available".into())
+            })?
+        };
+
+        signal::kill(Pid::from_raw(pid as i32), Signal::SIGSTOP)
+            .map_err(|e| AppError::Internal(format!("failed to pause process {pid}: {e}")))?;
+
+        agent_session_service::update_agent_session(
+            &self.pool,
+            task_id,
+            session_id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Resume a paused agent session by sending SIGCONT to the child process.
+    pub async fn resume_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
+        let pid = {
+            let running = self.running.lock().await;
+            let session = running.get(&session_id).ok_or_else(|| {
+                AppError::NotFound(format!("no running session found: {session_id}"))
+            })?;
+            session.pid.ok_or_else(|| {
+                AppError::Internal("cannot resume session: no PID available".into())
+            })?
+        };
+
+        signal::kill(Pid::from_raw(pid as i32), Signal::SIGCONT)
+            .map_err(|e| AppError::Internal(format!("failed to resume process {pid}: {e}")))?;
+
+        agent_session_service::update_agent_session(
+            &self.pool,
+            task_id,
+            session_id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await?;
 
         Ok(())
     }

--- a/backend/src/agent/orchestrator/lifecycle.rs
+++ b/backend/src/agent/orchestrator/lifecycle.rs
@@ -21,7 +21,7 @@ impl AgentOrchestrator {
         {
             let running = self.running.lock().await;
             let session = running.get(&session_id).ok_or_else(|| {
-                AppError::NotFound(format!("no running session found: {session_id}"))
+                AppError::NotFound(format!("no active session found: {session_id}"))
             })?;
             // Send SIGCONT before killing, in case the process is stopped
             if let Some(pid) = session.pid {
@@ -52,20 +52,21 @@ impl AgentOrchestrator {
     }
 
     /// Pause a running agent session by sending SIGSTOP to the child process.
+    ///
+    /// Updates DB status first, then sends SIGSTOP. If SIGSTOP fails, the DB
+    /// update is rolled back by resetting the status to Running.
     pub async fn pause_session(&self, task_id: Uuid, session_id: Uuid) -> AppResult<()> {
         let pid = {
             let running = self.running.lock().await;
             let session = running.get(&session_id).ok_or_else(|| {
-                AppError::NotFound(format!("no running session found: {session_id}"))
+                AppError::NotFound(format!("no active session found: {session_id}"))
             })?;
             session.pid.ok_or_else(|| {
                 AppError::Internal("cannot pause session: no PID available".into())
             })?
         };
 
-        signal::kill(Pid::from_raw(pid as i32), Signal::SIGSTOP)
-            .map_err(|e| AppError::Internal(format!("failed to pause process {pid}: {e}")))?;
-
+        // Update DB first, then send signal. If SIGSTOP fails, roll back DB.
         agent_session_service::update_agent_session(
             &self.pool,
             task_id,
@@ -76,6 +77,23 @@ impl AgentOrchestrator {
         )
         .await?;
 
+        if let Err(e) = signal::kill(Pid::from_raw(pid as i32), Signal::SIGSTOP) {
+            // Roll back DB status to Running since SIGSTOP failed
+            tracing::warn!(pid, %session_id, error = %e, "SIGSTOP failed, rolling back DB status");
+            let _ = agent_session_service::update_agent_session(
+                &self.pool,
+                task_id,
+                session_id,
+                &UpdateAgentSessionRequest {
+                    status: AgentSessionStatus::Running,
+                },
+            )
+            .await;
+            return Err(AppError::Internal(format!(
+                "failed to pause process {pid}: {e}"
+            )));
+        }
+
         Ok(())
     }
 
@@ -84,7 +102,7 @@ impl AgentOrchestrator {
         let pid = {
             let running = self.running.lock().await;
             let session = running.get(&session_id).ok_or_else(|| {
-                AppError::NotFound(format!("no running session found: {session_id}"))
+                AppError::NotFound(format!("no active session found: {session_id}"))
             })?;
             session.pid.ok_or_else(|| {
                 AppError::Internal("cannot resume session: no PID available".into())

--- a/backend/src/agent/orchestrator/mod.rs
+++ b/backend/src/agent/orchestrator/mod.rs
@@ -22,6 +22,8 @@ use crate::sse::hub::SseHub;
 struct RunningSession {
     cancel: tokio_util::sync::CancellationToken,
     _monitor_handle: tokio::task::JoinHandle<()>,
+    /// Process ID of the agent child process, used for SIGSTOP/SIGCONT.
+    pid: Option<u32>,
 }
 
 /// Parameters for starting a new agent session.
@@ -222,6 +224,7 @@ impl AgentOrchestrator {
                 session.id,
                 RunningSession {
                     cancel: handle.cancel,
+                    pid: handle.pid,
                     _monitor_handle: monitor_handle,
                 },
             );
@@ -279,6 +282,7 @@ mod tests {
                 cancel,
                 output_rx: rx,
                 join_handle,
+                pid: None,
             })
         }
     }
@@ -592,6 +596,7 @@ mod tests {
                     cancel,
                     output_rx: rx,
                     join_handle,
+                    pid: None,
                 })
             }
         }
@@ -667,6 +672,7 @@ mod tests {
                     cancel,
                     output_rx: rx,
                     join_handle,
+                    pid: None,
                 })
             }
         }

--- a/backend/src/handlers/agent_sessions.rs
+++ b/backend/src/handlers/agent_sessions.rs
@@ -242,8 +242,10 @@ pub async fn restart_agent_session(
     ),
     responses(
         (status = 200, description = "Agent session paused", body = AgentSession),
+        (status = 400, description = "Invalid status transition (not running)"),
         (status = 403, description = "Forbidden"),
-        (status = 404, description = "Session not found or not running")
+        (status = 404, description = "Session not found or not running"),
+        (status = 500, description = "Failed to send SIGSTOP to process")
     ),
     tag = "agent-sessions"
 )]
@@ -274,8 +276,10 @@ pub async fn pause_agent_session(
     ),
     responses(
         (status = 200, description = "Agent session resumed", body = AgentSession),
+        (status = 400, description = "Invalid status transition (not paused)"),
         (status = 403, description = "Forbidden"),
-        (status = 404, description = "Session not found or not paused")
+        (status = 404, description = "Session not found or not paused"),
+        (status = 500, description = "Failed to send SIGCONT to process")
     ),
     tag = "agent-sessions"
 )]

--- a/backend/src/handlers/agent_sessions.rs
+++ b/backend/src/handlers/agent_sessions.rs
@@ -233,6 +233,70 @@ pub async fn restart_agent_session(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/tasks/{task_id}/sessions/{session_id}/pause",
+    params(
+        ("task_id" = Uuid, Path, description = "Task ID"),
+        ("session_id" = Uuid, Path, description = "Agent session ID")
+    ),
+    responses(
+        (status = 200, description = "Agent session paused", body = AgentSession),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Session not found or not running")
+    ),
+    tag = "agent-sessions"
+)]
+pub async fn pause_agent_session(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path((task_id, session_id)): Path<(Uuid, Uuid)>,
+) -> AppResult<Json<AgentSession>> {
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
+    agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
+
+    state
+        .orchestrator
+        .pause_session(task_id, session_id)
+        .await?;
+
+    let session =
+        agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
+    Ok(Json(session))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tasks/{task_id}/sessions/{session_id}/resume",
+    params(
+        ("task_id" = Uuid, Path, description = "Task ID"),
+        ("session_id" = Uuid, Path, description = "Agent session ID")
+    ),
+    responses(
+        (status = 200, description = "Agent session resumed", body = AgentSession),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Session not found or not paused")
+    ),
+    tag = "agent-sessions"
+)]
+pub async fn resume_agent_session(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path((task_id, session_id)): Path<(Uuid, Uuid)>,
+) -> AppResult<Json<AgentSession>> {
+    authorization_service::authorize_task(&state.pool, auth.user_id, task_id).await?;
+    agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
+
+    state
+        .orchestrator
+        .resume_session(task_id, session_id)
+        .await?;
+
+    let session =
+        agent_session_service::get_agent_session(&state.pool, task_id, session_id).await?;
+    Ok(Json(session))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct GetOutputsQuery {
     pub after: Option<i64>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -175,6 +175,14 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
             post(handlers::agent_sessions::stop_agent_session),
         )
         .route(
+            "/tasks/{task_id}/sessions/{session_id}/pause",
+            post(handlers::agent_sessions::pause_agent_session),
+        )
+        .route(
+            "/tasks/{task_id}/sessions/{session_id}/resume",
+            post(handlers::agent_sessions::resume_agent_session),
+        )
+        .route(
             "/tasks/{task_id}/sessions/{session_id}/outputs",
             get(handlers::agent_sessions::get_agent_session_outputs),
         )

--- a/backend/src/models/agent_session.rs
+++ b/backend/src/models/agent_session.rs
@@ -26,6 +26,7 @@ impl std::fmt::Display for AgentType {
 pub enum AgentSessionStatus {
     Pending,
     Running,
+    Paused,
     Completed,
     Failed,
     Cancelled,

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -36,6 +36,8 @@ use crate::sse;
         handlers::agent_sessions::update_agent_session,
         handlers::agent_sessions::start_agent_session,
         handlers::agent_sessions::stop_agent_session,
+        handlers::agent_sessions::pause_agent_session,
+        handlers::agent_sessions::resume_agent_session,
         handlers::agent_sessions::get_agent_session_outputs,
         handlers::agent_sessions::restart_agent_session,
         handlers::users::search_users,

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -290,6 +290,8 @@ fn validate_status_transition(from: &AgentSessionStatus, to: &AgentSessionStatus
             | (Running, Paused)
             | (Paused, Running)
             | (Paused, Cancelled)
+            | (Paused, Completed)
+            | (Paused, Failed)
     );
     if !allowed {
         return Err(AppError::Validation(format!(

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -146,7 +146,7 @@ pub async fn check_no_active_session_tx(
         r#"
         SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
         FROM agent_sessions
-        WHERE task_id = $1 AND status IN ('pending', 'running')
+        WHERE task_id = $1 AND status IN ('pending', 'running', 'paused')
         LIMIT 1
         "#,
     )
@@ -287,6 +287,9 @@ fn validate_status_transition(from: &AgentSessionStatus, to: &AgentSessionStatus
             | (Running, Completed)
             | (Running, Failed)
             | (Running, Cancelled)
+            | (Running, Paused)
+            | (Paused, Running)
+            | (Paused, Cancelled)
     );
     if !allowed {
         return Err(AppError::Validation(format!(
@@ -929,5 +932,282 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(AppError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_transition_running_to_paused_is_valid() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let created = create_agent_session(
+            &pool,
+            task_id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create");
+
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+
+        let paused = update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await
+        .expect("Transition to paused should succeed");
+
+        assert_eq!(paused.status, AgentSessionStatus::Paused);
+        assert!(paused.started_at.is_some());
+        assert!(paused.finished_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_transition_paused_to_running_is_valid() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let created = create_agent_session(
+            &pool,
+            task_id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create");
+
+        // Pending → Running → Paused → Running (resume)
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await
+        .expect("Transition to paused");
+
+        let resumed = update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition from paused to running should succeed");
+
+        assert_eq!(resumed.status, AgentSessionStatus::Running);
+        assert!(resumed.finished_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_transition_paused_to_cancelled_is_valid() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let created = create_agent_session(
+            &pool,
+            task_id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create");
+
+        // Pending → Running → Paused → Cancelled
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await
+        .expect("Transition to paused");
+
+        let cancelled = update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Cancelled,
+            },
+        )
+        .await
+        .expect("Transition from paused to cancelled should succeed");
+
+        assert_eq!(cancelled.status, AgentSessionStatus::Cancelled);
+        assert!(cancelled.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_transition_pending_to_paused() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let created = create_agent_session(
+            &pool,
+            task_id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create");
+
+        // Pending → Paused should fail
+        let result = update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(AppError::Validation(_))),
+            "Pending → Paused should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalid_transition_completed_to_paused() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let created = create_agent_session(
+            &pool,
+            task_id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create");
+
+        // Pending → Running → Completed
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+        update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("Transition to completed");
+
+        // Completed → Paused should fail
+        let result = update_agent_session(
+            &pool,
+            task_id,
+            created.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(AppError::Validation(_))),
+            "Completed → Paused should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_paused_session_blocks_new_session_creation() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        let session = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("First session should succeed");
+
+        // Pending → Running → Paused
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("Transition to running");
+        update_agent_session(
+            &pool,
+            task_id,
+            session.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await
+        .expect("Transition to paused");
+
+        // New session while paused should fail
+        let result = create_agent_session(&pool, task_id, &req).await;
+        assert!(
+            result.is_err(),
+            "New session should be blocked while another is paused"
+        );
     }
 }

--- a/backend/tests/agent_sessions/main.rs
+++ b/backend/tests/agent_sessions/main.rs
@@ -4,4 +4,5 @@ mod common;
 mod crud;
 mod lifecycle;
 mod outputs;
+mod pause_resume;
 mod restart;

--- a/backend/tests/agent_sessions/pause_resume.rs
+++ b/backend/tests/agent_sessions/pause_resume.rs
@@ -1,0 +1,183 @@
+use axum::http::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::common::{create_project_and_task, create_test_server_with_sleep_executor};
+
+/// Helper to start an agent session and return session_id string.
+async fn start_session(server: &axum_test::TestServer, task_id: &str) -> String {
+    let response = server
+        .post(&format!("/api/tasks/{}/sessions/start", task_id))
+        .json(&json!({
+            "agent_type": "claude_code",
+            "prompt": "test prompt"
+        }))
+        .await;
+    response.assert_status(StatusCode::CREATED);
+    let body: serde_json::Value = response.json();
+    body["session"]["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn test_pause_agent_session_returns_200() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+
+    let session_id = start_session(&server, &task_id).await;
+
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await;
+
+    response.assert_status_ok();
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["status"], "paused");
+}
+
+#[tokio::test]
+async fn test_pause_agent_session_404_for_nonrunning_session() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+    let fake_session_id = Uuid::new_v4();
+
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, fake_session_id
+        ))
+        .await;
+
+    response.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_resume_agent_session_returns_200() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+
+    let session_id = start_session(&server, &task_id).await;
+
+    // Pause first
+    server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await
+        .assert_status_ok();
+
+    // Resume
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/resume",
+            task_id, session_id
+        ))
+        .await;
+
+    response.assert_status_ok();
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["status"], "running");
+}
+
+#[tokio::test]
+async fn test_resume_agent_session_404_for_nonpaused_session() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+    let fake_session_id = Uuid::new_v4();
+
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/resume",
+            task_id, fake_session_id
+        ))
+        .await;
+
+    response.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_stop_paused_session_returns_200() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+
+    let session_id = start_session(&server, &task_id).await;
+
+    // Pause first
+    server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await
+        .assert_status_ok();
+
+    // Stop paused session
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/stop",
+            task_id, session_id
+        ))
+        .await;
+
+    response.assert_status_ok();
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["status"], "cancelled");
+}
+
+#[tokio::test]
+async fn test_pause_already_paused_session_returns_400() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+
+    let session_id = start_session(&server, &task_id).await;
+
+    // Pause
+    server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await
+        .assert_status_ok();
+
+    // Pause again should fail (Paused → Paused is invalid transition)
+    let response = server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await;
+
+    response.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_start_new_session_blocked_while_paused() {
+    let (_tmp, server) = create_test_server_with_sleep_executor().await;
+    let (_project_id, task_id) = create_project_and_task(&server).await;
+
+    let session_id = start_session(&server, &task_id).await;
+
+    // Pause
+    server
+        .post(&format!(
+            "/api/tasks/{}/sessions/{}/pause",
+            task_id, session_id
+        ))
+        .await
+        .assert_status_ok();
+
+    // Starting a new session should be blocked
+    let response = server
+        .post(&format!("/api/tasks/{}/sessions/start", task_id))
+        .json(&json!({
+            "agent_type": "claude_code",
+            "prompt": "another prompt"
+        }))
+        .await;
+
+    response.assert_status(StatusCode::CONFLICT);
+}

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -7,19 +7,65 @@ use std::sync::Arc;
 
 use axum::http::header;
 use axum_test::TestServer;
-use gantry_board::agent::executor::{AgentExecutor, NoopExecutor};
+use gantry_board::agent::executor::{
+    AgentConfig, AgentExecutor, AgentHandle, AgentOutputEvent, NoopExecutor,
+};
 use gantry_board::agent::orchestrator::AgentOrchestrator;
 use gantry_board::config::Config;
+use gantry_board::error::AppResult;
 use gantry_board::models::agent_session::AgentType;
 use gantry_board::services::agent_session_output_service::OutputBuffer;
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use sqlx::sqlite::SqlitePoolOptions;
 pub use sqlx::SqlitePool;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
-async fn create_test_server_impl(
+/// Executor that spawns a real `sleep` process for testing pause/resume with signals.
+pub struct SleepExecutor;
+
+#[async_trait::async_trait]
+impl AgentExecutor for SleepExecutor {
+    async fn start(&self, _config: AgentConfig) -> AppResult<AgentHandle> {
+        use std::process::Stdio;
+        use tokio::process::Command;
+
+        let mut child = Command::new("sleep")
+            .arg("3600")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("failed to spawn sleep process");
+
+        let pid = child.id();
+        let cancel = CancellationToken::new();
+        let (tx, rx) = mpsc::channel(16);
+        let token = cancel.clone();
+
+        let join_handle = tokio::spawn(async move {
+            token.cancelled().await;
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            let _ = tx.send(AgentOutputEvent::Completed).await;
+            Ok(())
+        });
+
+        Ok(AgentHandle {
+            cancel,
+            output_rx: rx,
+            join_handle,
+            pid,
+        })
+    }
+}
+
+async fn create_test_server_with_executor(
     auth_disabled: bool,
     repo_path: PathBuf,
+    executor: Arc<dyn AgentExecutor>,
 ) -> (TestServer, SqlitePool) {
     let pool = SqlitePoolOptions::new()
         .connect("sqlite::memory:")
@@ -41,7 +87,7 @@ async fn create_test_server_impl(
 
     let sse_hub = Arc::new(SseHub::default());
     let mut executors: HashMap<AgentType, Arc<dyn AgentExecutor>> = HashMap::new();
-    executors.insert(AgentType::ClaudeCode, Arc::new(NoopExecutor));
+    executors.insert(AgentType::ClaudeCode, executor);
     let output_buffer = Arc::new(OutputBuffer::new(pool.clone()));
     let orchestrator = Arc::new(AgentOrchestrator::new(
         executors,
@@ -65,9 +111,15 @@ async fn create_test_server_impl(
         .expect("Failed to build app")
         .into_make_service_with_connect_info::<SocketAddr>();
     let mut server = TestServer::new(app).expect("Failed to create test server");
-    // CSRF middleware requires X-Requested-With on state-changing requests
     server.add_header("x-requested-with", "XMLHttpRequest");
     (server, pool)
+}
+
+async fn create_test_server_impl(
+    auth_disabled: bool,
+    repo_path: PathBuf,
+) -> (TestServer, SqlitePool) {
+    create_test_server_with_executor(auth_disabled, repo_path, Arc::new(NoopExecutor)).await
 }
 
 /// Create a test server with auth disabled (for CRUD tests).
@@ -118,6 +170,14 @@ pub async fn create_test_server_with_repo_and_pool() -> (tempfile::TempDir, Test
     let (tmp, repo_path) = init_test_repo();
     let (server, pool) = create_test_server_impl(true, repo_path).await;
     (tmp, server, pool)
+}
+
+/// Create a test server with SleepExecutor for pause/resume tests.
+pub async fn create_test_server_with_sleep_executor() -> (tempfile::TempDir, TestServer) {
+    let (tmp, repo_path) = init_test_repo();
+    let (server, _pool) =
+        create_test_server_with_executor(true, repo_path, Arc::new(SleepExecutor)).await;
+    (tmp, server)
 }
 
 // ========== Common Test Helpers (no-auth) ==========

--- a/frontend/src/api/generated/endpoints/agent-sessions/agent-sessions.ts
+++ b/frontend/src/api/generated/endpoints/agent-sessions/agent-sessions.ts
@@ -614,6 +614,72 @@ export function useGetAgentSessionOutputs<
   return query;
 }
 
+export const pauseAgentSession = (taskId: string, sessionId: string, signal?: AbortSignal) => {
+  return customInstance<AgentSession>({
+    url: `/api/tasks/${taskId}/sessions/${sessionId}/pause`,
+    method: 'POST',
+    signal,
+  });
+};
+
+export const getPauseAgentSessionMutationOptions = <TError = void, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof pauseAgentSession>>,
+    TError,
+    { taskId: string; sessionId: string },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof pauseAgentSession>>,
+  TError,
+  { taskId: string; sessionId: string },
+  TContext
+> => {
+  const mutationKey = ['pauseAgentSession'];
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof pauseAgentSession>>,
+    { taskId: string; sessionId: string }
+  > = (props) => {
+    const { taskId, sessionId } = props ?? {};
+
+    return pauseAgentSession(taskId, sessionId);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PauseAgentSessionMutationResult = NonNullable<
+  Awaited<ReturnType<typeof pauseAgentSession>>
+>;
+
+export type PauseAgentSessionMutationError = void;
+
+export const usePauseAgentSession = <TError = void, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof pauseAgentSession>>,
+      TError,
+      { taskId: string; sessionId: string },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof pauseAgentSession>>,
+  TError,
+  { taskId: string; sessionId: string },
+  TContext
+> => {
+  const mutationOptions = getPauseAgentSessionMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
 export const restartAgentSession = (taskId: string, sessionId: string, signal?: AbortSignal) => {
   return customInstance<StartAgentSessionResponse>({
     url: `/api/tasks/${taskId}/sessions/${sessionId}/restart`,
@@ -677,6 +743,72 @@ export const useRestartAgentSession = <TError = void, TContext = unknown>(
   TContext
 > => {
   const mutationOptions = getRestartAgentSessionMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+export const resumeAgentSession = (taskId: string, sessionId: string, signal?: AbortSignal) => {
+  return customInstance<AgentSession>({
+    url: `/api/tasks/${taskId}/sessions/${sessionId}/resume`,
+    method: 'POST',
+    signal,
+  });
+};
+
+export const getResumeAgentSessionMutationOptions = <TError = void, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof resumeAgentSession>>,
+    TError,
+    { taskId: string; sessionId: string },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof resumeAgentSession>>,
+  TError,
+  { taskId: string; sessionId: string },
+  TContext
+> => {
+  const mutationKey = ['resumeAgentSession'];
+  const { mutation: mutationOptions } = options
+    ? options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof resumeAgentSession>>,
+    { taskId: string; sessionId: string }
+  > = (props) => {
+    const { taskId, sessionId } = props ?? {};
+
+    return resumeAgentSession(taskId, sessionId);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type ResumeAgentSessionMutationResult = NonNullable<
+  Awaited<ReturnType<typeof resumeAgentSession>>
+>;
+
+export type ResumeAgentSessionMutationError = void;
+
+export const useResumeAgentSession = <TError = void, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof resumeAgentSession>>,
+      TError,
+      { taskId: string; sessionId: string },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof resumeAgentSession>>,
+  TError,
+  { taskId: string; sessionId: string },
+  TContext
+> => {
+  const mutationOptions = getResumeAgentSessionMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };

--- a/frontend/src/api/generated/model/agentSessionStatus.ts
+++ b/frontend/src/api/generated/model/agentSessionStatus.ts
@@ -12,6 +12,7 @@ export type AgentSessionStatus = (typeof AgentSessionStatus)[keyof typeof AgentS
 export const AgentSessionStatus = {
   pending: 'pending',
   running: 'running',
+  paused: 'paused',
   completed: 'completed',
   failed: 'failed',
   cancelled: 'cancelled',

--- a/frontend/src/components/agent/AgentPanel.test.tsx
+++ b/frontend/src/components/agent/AgentPanel.test.tsx
@@ -9,6 +9,8 @@ vi.mock('@/api/generated/endpoints/agent-sessions/agent-sessions', () => ({
   useListAgentSessions: vi.fn(),
   useStartAgentSession: vi.fn(),
   useStopAgentSession: vi.fn(),
+  usePauseAgentSession: vi.fn(),
+  useResumeAgentSession: vi.fn(),
   useGetAgentSessionOutputs: vi.fn(),
 }));
 
@@ -26,6 +28,8 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('AgentPanel', () => {
   const mockStartMutateAsync = vi.fn();
   const mockStopMutateAsync = vi.fn();
+  const mockPauseMutateAsync = vi.fn();
+  const mockResumeMutateAsync = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,6 +48,16 @@ describe('AgentPanel', () => {
       mutateAsync: mockStopMutateAsync,
       isPending: false,
     } as unknown as ReturnType<typeof agentSessionsApi.useStopAgentSession>);
+
+    vi.mocked(agentSessionsApi.usePauseAgentSession).mockReturnValue({
+      mutateAsync: mockPauseMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.usePauseAgentSession>);
+
+    vi.mocked(agentSessionsApi.useResumeAgentSession).mockReturnValue({
+      mutateAsync: mockResumeMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useResumeAgentSession>);
 
     vi.mocked(agentSessionsApi.useGetAgentSessionOutputs).mockReturnValue({
       data: undefined,
@@ -222,6 +236,107 @@ describe('AgentPanel', () => {
     expect(screen.getByTestId('agent-output-container')).toBeInTheDocument();
     expect(screen.getByText('output line 1')).toBeInTheDocument();
     expect(screen.getByText('output line 2')).toBeInTheDocument();
+  });
+
+  it('renders pause button when session is running', () => {
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'running',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+    expect(screen.getByRole('button', { name: /pause/i })).toBeInTheDocument();
+  });
+
+  it('renders resume button when session is paused', () => {
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'paused',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+    expect(screen.getByRole('button', { name: /resume/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+  });
+
+  it('calls pause mutation when pause is clicked', async () => {
+    mockPauseMutateAsync.mockResolvedValue({
+      id: 'session-1',
+      status: 'paused',
+    });
+
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'running',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+
+    await user.click(screen.getByRole('button', { name: /pause/i }));
+
+    expect(mockPauseMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      sessionId: 'session-1',
+    });
+  });
+
+  it('calls resume mutation when resume is clicked', async () => {
+    mockResumeMutateAsync.mockResolvedValue({
+      id: 'session-1',
+      status: 'running',
+    });
+
+    vi.mocked(agentSessionsApi.useListAgentSessions).mockReturnValue({
+      data: [
+        {
+          id: 'session-1',
+          task_id: 'task-1',
+          agent_type: 'claude_code',
+          status: 'paused',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof agentSessionsApi.useListAgentSessions>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<AgentPanel taskId="task-1" />);
+
+    await user.click(screen.getByRole('button', { name: /resume/i }));
+
+    expect(mockResumeMutateAsync).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      sessionId: 'session-1',
+    });
   });
 
   it('displays session status badge', () => {

--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   useGetAgentSessionOutputs,
   useListAgentSessions,
+  usePauseAgentSession,
+  useResumeAgentSession,
   useStartAgentSession,
   useStopAgentSession,
 } from '@/api/generated/endpoints/agent-sessions/agent-sessions';
@@ -17,6 +19,7 @@ interface AgentPanelProps {
 const STATUS_COLORS: Record<AgentSessionStatus, string> = {
   pending: 'bg-yellow-100 text-yellow-800',
   running: 'bg-blue-100 text-blue-800',
+  paused: 'bg-orange-100 text-orange-800',
   completed: 'bg-green-100 text-green-800',
   failed: 'bg-red-100 text-red-800',
   cancelled: 'bg-gray-100 text-gray-800',
@@ -33,6 +36,8 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
   const { data: sessions } = useListAgentSessions(taskId);
   const startSession = useStartAgentSession();
   const stopSession = useStopAgentSession();
+  const pauseSession = usePauseAgentSession();
+  const resumeSession = useResumeAgentSession();
 
   const {
     activeSessionId,
@@ -48,7 +53,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
   // Derive active session from both store and server data
   const activeSession =
     sessions?.find((s) => s.id === activeSessionId) ??
-    sessions?.find((s) => s.status === 'running' || s.status === 'pending');
+    sessions?.find((s) => s.status === 'running' || s.status === 'pending' || s.status === 'paused');
 
   // Past (terminal) sessions
   const pastSessions = sessions?.filter((s) => TERMINAL_STATUSES.includes(s.status)) ?? [];
@@ -116,6 +121,32 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
     }
   };
 
+  const handlePause = async () => {
+    if (!activeSession) return;
+    setError(null);
+    try {
+      await pauseSession.mutateAsync({
+        taskId,
+        sessionId: activeSession.id,
+      });
+    } catch {
+      setError('Failed to pause agent session. Please try again.');
+    }
+  };
+
+  const handleResume = async () => {
+    if (!activeSession) return;
+    setError(null);
+    try {
+      await resumeSession.mutateAsync({
+        taskId,
+        sessionId: activeSession.id,
+      });
+    } catch {
+      setError('Failed to resume agent session. Please try again.');
+    }
+  };
+
   const handleViewSession = (session: AgentSession) => {
     setViewingSessionId(session.id);
     setActiveSession(null);
@@ -148,14 +179,36 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               </span>
             </div>
             {!TERMINAL_STATUSES.includes(activeSession.status) && (
-              <button
-                type="button"
-                onClick={handleStop}
-                disabled={stopSession.isPending}
-                className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
-              >
-                Stop
-              </button>
+              <div className="flex items-center gap-2">
+                {activeSession.status === 'running' && (
+                  <button
+                    type="button"
+                    onClick={handlePause}
+                    disabled={pauseSession.isPending}
+                    className="rounded-md bg-yellow-600 px-3 py-1.5 text-sm text-white hover:bg-yellow-700 disabled:opacity-50"
+                  >
+                    Pause
+                  </button>
+                )}
+                {activeSession.status === 'paused' && (
+                  <button
+                    type="button"
+                    onClick={handleResume}
+                    disabled={resumeSession.isPending}
+                    className="rounded-md bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700 disabled:opacity-50"
+                  >
+                    Resume
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={handleStop}
+                  disabled={stopSession.isPending}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+                >
+                  Stop
+                </button>
+              </div>
             )}
           </div>
           <AgentOutputViewer lines={outputLines} isLoading={false} />

--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
 import {
   getListAgentSessionsQueryKey,
   useGetAgentSessionOutputs,
@@ -56,7 +56,9 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
   // Derive active session from both store and server data
   const activeSession =
     sessions?.find((s) => s.id === activeSessionId) ??
-    sessions?.find((s) => s.status === 'running' || s.status === 'pending' || s.status === 'paused');
+    sessions?.find(
+      (s) => s.status === 'running' || s.status === 'pending' || s.status === 'paused',
+    );
 
   // Past (terminal) sessions
   const pastSessions = sessions?.filter((s) => TERMINAL_STATUSES.includes(s.status)) ?? [];

--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
+  getListAgentSessionsQueryKey,
   useGetAgentSessionOutputs,
   useListAgentSessions,
   usePauseAgentSession,
@@ -32,6 +34,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
   const [prompt, setPrompt] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [viewingSessionId, setViewingSessionId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   const { data: sessions } = useListAgentSessions(taskId);
   const startSession = useStartAgentSession();
@@ -129,6 +132,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
         taskId,
         sessionId: activeSession.id,
       });
+      queryClient.invalidateQueries({ queryKey: getListAgentSessionsQueryKey(taskId) });
     } catch {
       setError('Failed to pause agent session. Please try again.');
     }
@@ -142,6 +146,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
         taskId,
         sessionId: activeSession.id,
       });
+      queryClient.invalidateQueries({ queryKey: getListAgentSessionsQueryKey(taskId) });
     } catch {
       setError('Failed to resume agent session. Please try again.');
     }

--- a/frontend/src/components/common/CommentSection.test.tsx
+++ b/frontend/src/components/common/CommentSection.test.tsx
@@ -163,7 +163,8 @@ describe('CommentSection', () => {
     renderWithProviders(<CommentSection taskId="task-1" />);
 
     const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
-    await user.click(editBtn!);
+    expect(editBtn).toBeInTheDocument();
+    await user.click(editBtn as HTMLElement);
 
     expect(screen.getByDisplayValue('First comment')).toBeInTheDocument();
   });
@@ -174,7 +175,8 @@ describe('CommentSection', () => {
     renderWithProviders(<CommentSection taskId="task-1" />);
 
     const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
-    await user.click(editBtn!);
+    expect(editBtn).toBeInTheDocument();
+    await user.click(editBtn as HTMLElement);
 
     const input = screen.getByDisplayValue('First comment');
     await user.clear(input);
@@ -193,7 +195,8 @@ describe('CommentSection', () => {
     renderWithProviders(<CommentSection taskId="task-1" />);
 
     const editBtn = screen.getAllByTestId('comment-item')[0].querySelector('[aria-label="Edit"]');
-    await user.click(editBtn!);
+    expect(editBtn).toBeInTheDocument();
+    await user.click(editBtn as HTMLElement);
 
     await user.click(screen.getByRole('button', { name: /cancel/i }));
 
@@ -209,7 +212,8 @@ describe('CommentSection', () => {
     const deleteBtn = screen
       .getAllByTestId('comment-item')[0]
       .querySelector('[aria-label="Delete"]');
-    await user.click(deleteBtn!);
+    expect(deleteBtn).toBeInTheDocument();
+    await user.click(deleteBtn as HTMLElement);
 
     // Confirmation appears
     await user.click(screen.getByRole('button', { name: /confirm/i }));

--- a/frontend/src/components/task/timelineUtils.ts
+++ b/frontend/src/components/task/timelineUtils.ts
@@ -23,6 +23,7 @@ export function mergeTimeline(comments: TaskComment[], sessions: AgentSession[])
 export const STATUS_COLORS: Record<AgentSessionStatus, string> = {
   pending: 'bg-yellow-100 text-yellow-800',
   running: 'bg-blue-100 text-blue-800',
+  paused: 'bg-purple-100 text-purple-800',
   completed: 'bg-green-100 text-green-800',
   failed: 'bg-red-100 text-red-800',
   cancelled: 'bg-gray-100 text-gray-800',


### PR DESCRIPTION
## Summary
- Add `Paused` status to `AgentSessionStatus` enum (no migration needed for TEXT column)
- Implement pause/resume via SIGSTOP/SIGCONT signals using `nix` crate
- Capture child process PID in `AgentHandle` for signal delivery
- Add `POST .../pause` and `POST .../resume` API endpoints
- State transitions: `Running → Paused`, `Paused → Running`, `Paused → Cancelled`
- Paused sessions block new session creation (partial unique index updated)
- Frontend: Pause/Resume buttons in AgentPanel with orange status badge

## Test plan
- [x] Service layer: 7 new state transition tests (valid + invalid transitions, paused blocks new sessions)
- [x] Integration: 7 new API tests using `SleepExecutor` (real process for SIGSTOP/SIGCONT)
- [x] Frontend: 4 new component tests (pause/resume buttons render, mutations called)
- [x] All 320 unit tests pass
- [x] All 32 integration tests pass (including 7 new)
- [x] All 337 frontend tests pass (including 6 new)
- [x] `cargo clippy` zero warnings

Closes #240