### PR TITLE
test: ✅ add E2E scenarios for auth, projects, tasks, and agents

### DIFF
--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -20,15 +20,46 @@ export class ApiHelper {
     return (await assertOk(response, 'registerUser')).json();
   }
 
-  async createProject(cookie: string, name: string) {
+  async createProject(cookie: string, name: string, description?: string) {
     const response = await this.request.post(`${API_BASE}/api/projects`, {
-      data: { name },
+      data: { name, description },
       headers: {
         cookie,
         'x-requested-with': 'XMLHttpRequest',
       },
     });
     return (await assertOk(response, 'createProject')).json();
+  }
+
+  async createTask(
+    cookie: string,
+    projectId: string,
+    title: string,
+    options?: { description?: string; status?: string; priority?: string },
+  ) {
+    const response = await this.request.post(`${API_BASE}/api/tasks`, {
+      data: {
+        project_id: projectId,
+        title,
+        ...options,
+      },
+      headers: {
+        cookie,
+        'x-requested-with': 'XMLHttpRequest',
+      },
+    });
+    return (await assertOk(response, 'createTask')).json();
+  }
+
+  async createComment(cookie: string, taskId: string, content: string) {
+    const response = await this.request.post(`${API_BASE}/api/tasks/${taskId}/comments`, {
+      data: { content },
+      headers: {
+        cookie,
+        'x-requested-with': 'XMLHttpRequest',
+      },
+    });
+    return (await assertOk(response, 'createComment')).json();
   }
 
   async healthCheck() {

--- a/frontend/e2e/tests/agent-sessions.spec.ts
+++ b/frontend/e2e/tests/agent-sessions.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Agent Session UI', () => {
+  test('shows agent controls in the task detail modal', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Agent Project ${Date.now()}`);
+    await apiHelper.createTask(testUser.cookie, project.id, 'Agent Test Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail
+    await page.getByTestId('task-card').getByText('Agent Test Task').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Agent controls should be visible in the Activity section
+    await expect(dialog.getByLabel('Agent Type')).toBeVisible();
+    await expect(dialog.getByPlaceholder('Enter prompt for the agent...')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Start' })).toBeVisible();
+  });
+
+  test('agent type selector has expected options', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Agent Options Project ${Date.now()}`,
+    );
+    await apiHelper.createTask(testUser.cookie, project.id, 'Agent Options Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail
+    await page.getByTestId('task-card').getByText('Agent Options Task').click();
+    const dialog = page.getByRole('dialog');
+
+    // Agent type selector should have Claude Code and Gemini CLI options
+    const agentSelect = dialog.locator('#timeline-agent-type');
+    await expect(agentSelect.locator('option', { hasText: 'Claude Code' })).toBeAttached();
+    await expect(agentSelect.locator('option', { hasText: 'Gemini CLI' })).toBeAttached();
+  });
+
+  test('start button is disabled when prompt is empty', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Start Disable Project ${Date.now()}`,
+    );
+    await apiHelper.createTask(testUser.cookie, project.id, 'Start Disable Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    await page.getByTestId('task-card').getByText('Start Disable Task').click();
+    const dialog = page.getByRole('dialog');
+
+    // Start button should be disabled when prompt is empty
+    await expect(dialog.getByRole('button', { name: 'Start' })).toBeDisabled();
+
+    // Fill in a prompt — start button should become enabled
+    await dialog.getByPlaceholder('Enter prompt for the agent...').fill('Test prompt');
+    await expect(dialog.getByRole('button', { name: 'Start' })).toBeEnabled();
+  });
+
+  test('shows "No activity yet" when task has no sessions or comments', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Empty Activity Project ${Date.now()}`,
+    );
+    await apiHelper.createTask(testUser.cookie, project.id, 'Empty Activity Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    await page.getByTestId('task-card').getByText('Empty Activity Task').click();
+    const dialog = page.getByRole('dialog');
+
+    await expect(dialog.getByText('No activity yet.')).toBeVisible();
+  });
+});

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Authentication Flow', () => {
+  test('registers a new user and redirects to board', async ({ page }) => {
+    const email = `e2e-reg-${Date.now()}@test.local`;
+
+    await page.goto('/register');
+    await page.getByLabel('Name').fill('E2E Test User');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill('Tr0ub4dor&3-e2e-test');
+    await page.getByRole('button', { name: /register/i }).click();
+
+    // Should redirect to board
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Gantry Board')).toBeVisible();
+  });
+
+  test('logs in with valid credentials', async ({ page }) => {
+    const email = `e2e-login-${Date.now()}@test.local`;
+    const password = 'Tr0ub4dor&3-e2e-test';
+
+    // Register first via API
+    await page.request.post('/api/auth/register', {
+      data: { email, name: 'Login Test', password },
+      headers: { 'x-requested-with': 'XMLHttpRequest' },
+    });
+
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Gantry Board')).toBeVisible();
+  });
+
+  test('shows error on invalid credentials', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill('nonexistent@test.local');
+    await page.getByLabel('Password').fill('wrongpassword');
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    await expect(page.getByText(/invalid|incorrect|unauthorized/i)).toBeVisible();
+  });
+
+  test('redirects unauthenticated user to login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('logs out successfully', async ({ authenticatedPage: page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /logout/i }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -15,15 +15,12 @@ test.describe('Authentication Flow', () => {
     await expect(page.getByText('Gantry Board')).toBeVisible();
   });
 
-  test('logs in with valid credentials', async ({ page }) => {
+  test('logs in with valid credentials', async ({ page, apiHelper }) => {
     const email = `e2e-login-${Date.now()}@test.local`;
     const password = 'Tr0ub4dor&3-e2e-test';
 
-    // Register first via API
-    await page.request.post('/api/auth/register', {
-      data: { email, name: 'Login Test', password },
-      headers: { 'x-requested-with': 'XMLHttpRequest' },
-    });
+    // Register first via API (use apiHelper to target backend directly)
+    await apiHelper.registerUser(email, 'Login Test', password);
 
     await page.goto('/login');
     await page.getByLabel('Email').fill(email);

--- a/frontend/e2e/tests/projects.spec.ts
+++ b/frontend/e2e/tests/projects.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Project CRUD', () => {
+  test('creates a new project via UI', async ({ authenticatedPage: page }) => {
+    await page.goto('/');
+
+    // Open the create project dialog
+    await page.getByRole('button', { name: 'New Project' }).click();
+
+    // Fill in project details
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel('Name').fill('E2E Test Project');
+    await dialog.getByLabel('Description').fill('Created by E2E test');
+    await dialog.getByRole('button', { name: 'Create' }).click();
+
+    // Dialog should close and project should appear in the selector
+    await expect(dialog).not.toBeVisible();
+    await expect(page.locator('#project-select')).toContainText('E2E Test Project');
+  });
+
+  test('selects a project and displays kanban board', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    // Create a project via API
+    const project = await apiHelper.createProject(testUser.cookie, `Board Project ${Date.now()}`);
+
+    await page.goto('/');
+
+    // Select the project
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Kanban columns should be visible
+    await expect(page.getByText('Backlog')).toBeVisible();
+    await expect(page.getByText('To Do')).toBeVisible();
+    await expect(page.getByText('In Progress')).toBeVisible();
+    await expect(page.getByText('In Review')).toBeVisible();
+    await expect(page.getByText('Done')).toBeVisible();
+  });
+
+  test('shows empty state when no project is selected', async ({ authenticatedPage: page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Select a project to view its tasks')).toBeVisible();
+  });
+
+  test('opens project settings for selected project', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Settings Project ${Date.now()}`,
+    );
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Settings button should appear
+    await page.getByRole('button', { name: 'Settings' }).click();
+
+    // Settings modal should be visible
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+  });
+});

--- a/frontend/e2e/tests/tasks.spec.ts
+++ b/frontend/e2e/tests/tasks.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Task CRUD', () => {
+  test('creates a task via the kanban column button', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Task Project ${Date.now()}`);
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Click "Add Task" in the Backlog column
+    await page.getByRole('button', { name: '+ Add Task' }).first().click();
+
+    // Fill in the create task dialog
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel('Title').fill('E2E Test Task');
+    await dialog.getByLabel('Description').fill('Created by E2E test');
+    await dialog.getByRole('button', { name: 'Create' }).click();
+
+    // Dialog should close and task card should appear
+    await expect(dialog).not.toBeVisible();
+    await expect(page.getByTestId('task-card').getByText('E2E Test Task')).toBeVisible();
+  });
+
+  test('opens task detail modal by clicking a task card', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Detail Project ${Date.now()}`);
+    await apiHelper.createTask(testUser.cookie, project.id, 'Detail Test Task', {
+      description: 'Task with description',
+    });
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Click the task card
+    await page.getByTestId('task-card').getByText('Detail Test Task').click();
+
+    // Task detail modal should open
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Detail Test Task')).toBeVisible();
+    await expect(dialog.getByText('Task with description')).toBeVisible();
+  });
+
+  test('updates task status from the detail modal', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Update Project ${Date.now()}`);
+    await apiHelper.createTask(testUser.cookie, project.id, 'Status Change Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail
+    await page.getByTestId('task-card').getByText('Status Change Task').click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Change status to "in_progress"
+    await dialog.locator('#task-detail-status').selectOption('in_progress');
+
+    // Close the modal
+    await dialog.getByRole('button', { name: 'Close' }).click();
+
+    // Task should now appear in the "In Progress" column
+    await expect(
+      page
+        .locator('.flex-shrink-0', { hasText: 'In Progress' })
+        .getByText('Status Change Task'),
+    ).toBeVisible();
+  });
+
+  test('deletes a task from the detail modal', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Delete Project ${Date.now()}`);
+    await apiHelper.createTask(testUser.cookie, project.id, 'Task To Delete');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail and delete
+    await page.getByTestId('task-card').getByText('Task To Delete').click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('button', { name: 'Delete' }).click();
+    await dialog.getByRole('button', { name: 'Confirm' }).click();
+
+    // Modal should close and task should be gone
+    await expect(dialog).not.toBeVisible();
+    await expect(page.getByText('Task To Delete')).not.toBeVisible();
+  });
+});
+
+test.describe('Task Comments', () => {
+  test('adds a comment to a task', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Comment Project ${Date.now()}`,
+    );
+    await apiHelper.createTask(testUser.cookie, project.id, 'Commentable Task');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail
+    await page.getByTestId('task-card').getByText('Commentable Task').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Add a comment
+    await dialog.getByPlaceholder('Add a comment...').fill('E2E test comment');
+    await dialog.getByRole('button', { name: 'Post' }).click();
+
+    // Comment should appear in the timeline
+    await expect(dialog.getByText('E2E test comment')).toBeVisible();
+  });
+
+  test('displays existing comments', async ({
+    authenticatedPage: page,
+    apiHelper,
+    testUser,
+  }) => {
+    const project = await apiHelper.createProject(
+      testUser.cookie,
+      `Pre-Comment Project ${Date.now()}`,
+    );
+    const task = await apiHelper.createTask(testUser.cookie, project.id, 'Pre-Commented Task');
+    await apiHelper.createComment(testUser.cookie, task.id, 'Pre-existing comment');
+
+    await page.goto('/');
+    await page.locator('#project-select').selectOption(project.id);
+
+    // Open task detail
+    await page.getByTestId('task-card').getByText('Pre-Commented Task').click();
+    const dialog = page.getByRole('dialog');
+
+    // Pre-existing comment should be visible
+    await expect(dialog.getByText('Pre-existing comment')).toBeVisible();
+  });
+});

--- a/frontend/src/components/layout/LoginPage.tsx
+++ b/frontend/src/components/layout/LoginPage.tsx
@@ -34,9 +34,16 @@ export function LoginPage() {
           Sign in to Gantry Board
         </h1>
 
-        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        {error && (
+          <div
+            data-testid="login-error"
+            className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} data-testid="login-form" className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700">
               Email

--- a/frontend/src/components/layout/RegisterPage.tsx
+++ b/frontend/src/components/layout/RegisterPage.tsx
@@ -38,9 +38,16 @@ export function RegisterPage() {
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">Create your account</h1>
 
-        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        {error && (
+          <div
+            data-testid="register-error"
+            className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700"
+          >
+            {error}
+          </div>
+        )}
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} data-testid="register-form" className="space-y-4">
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-gray-700">
               Name

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -49,7 +49,10 @@ function ProjectCreateForm() {
         if (e.target === e.currentTarget) closeProjectModal();
       }}
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div
+        data-testid="project-create-dialog"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+      >
         <h2 id="project-create-title" className="mb-4 text-lg font-semibold">
           Create Project
         </h2>

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -70,7 +70,10 @@ function TaskCreateForm({
         if (e.target === e.currentTarget) closeTaskModal();
       }}
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div
+        data-testid="task-create-dialog"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+      >
         <h2 id="task-create-title" className="mb-4 text-lg font-semibold">
           Create Task
         </h2>

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -108,7 +108,10 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         if (e.target === e.currentTarget) closeTaskDetail();
       }}
     >
-      <div className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl">
+      <div
+        data-testid="task-detail-modal"
+        className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl"
+      >
         {isLoading ? (
           <p className="text-sm text-gray-500">Loading...</p>
         ) : isError || !task ? (


### PR DESCRIPTION
## Summary
- Add comprehensive E2E test scenarios covering auth flow, project CRUD, task CRUD + comments, and agent session UI
- Extend `ApiHelper` with `createTask` and `createComment` methods for test data setup
- Add strategic `data-testid` attributes to key components (login/register forms, dialog containers, task detail modal)

### E2E Test Coverage
- **Auth** (5 tests): register, login, invalid credentials, unauthenticated redirect, logout
- **Projects** (4 tests): create via UI, select + kanban display, empty state, settings modal
- **Tasks** (6 tests): create via column button, open detail modal, update status, delete, add comment, display existing comments
- **Agent Sessions** (4 tests): agent controls visibility, type selector options, disabled start button, empty activity state

Closes #244

## Test plan
- [ ] `task frontend:test` passes (333 unit tests)
- [ ] TypeScript type check (`tsc --noEmit`) passes
- [ ] E2E tests pass against running backend + frontend (`npx playwright test`)