### PR TITLE
perf: 🚀 optimize Playwright E2E test speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,10 @@ jobs:
         env:
           GANTRY_COOKIE_SECURE: "false"
           GANTRY_CORS_ORIGIN: "http://localhost:5173"
+          GANTRY_REGISTER_RATE_LIMIT_PER_SECOND: "1"
+          GANTRY_REGISTER_RATE_LIMIT_BURST: "100"
+          GANTRY_LOGIN_RATE_LIMIT_PER_SECOND: "1"
+          GANTRY_LOGIN_RATE_LIMIT_BURST: "100"
 
       # Start frontend dev server
       - name: Start frontend dev server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,8 @@ jobs:
           GANTRY_REGISTER_RATE_LIMIT_BURST: "100"
           GANTRY_LOGIN_RATE_LIMIT_PER_SECOND: "1"
           GANTRY_LOGIN_RATE_LIMIT_BURST: "100"
+          GANTRY_GENERAL_RATE_LIMIT_PER_SECOND: "1"
+          GANTRY_GENERAL_RATE_LIMIT_BURST: "1000"
 
       # Start frontend dev server
       - name: Start frontend dev server

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1251,7 @@ dependencies = [
  "http-body-util",
  "metrics",
  "moka",
+ "nix",
  "octocrab",
  "rand 0.8.5",
  "serde",
@@ -2106,6 +2113,18 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -382,4 +382,37 @@ mod tests {
         let config = Config::default();
         assert!(config.allowed_hosts.is_empty());
     }
+
+    #[test]
+    fn test_register_rate_limit_defaults() {
+        let config = Config::default();
+        assert_eq!(config.register_rate_limit_per_second, 1200);
+        assert_eq!(config.register_rate_limit_burst, 3);
+    }
+
+    #[test]
+    fn test_login_rate_limit_defaults() {
+        let config = Config::default();
+        assert_eq!(config.login_rate_limit_per_second, 180);
+        assert_eq!(config.login_rate_limit_burst, 5);
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_rate_limit_per_second() {
+        let config = Config {
+            register_rate_limit_per_second: 0,
+            cors_origin: Some("http://localhost:5173".to_string()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("rate limit"));
+
+        let config = Config {
+            login_rate_limit_burst: 0,
+            cors_origin: Some("http://localhost:5173".to_string()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("rate limit"));
+    }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -116,6 +116,14 @@ pub struct Config {
     /// Login rate limit: burst size (default: 5)
     #[serde(default = "default_login_rate_limit_burst")]
     pub login_rate_limit_burst: u32,
+
+    /// General API rate limit: replenishment interval in seconds (default: 1)
+    #[serde(default = "default_general_rate_limit_per_second")]
+    pub general_rate_limit_per_second: u64,
+
+    /// General API rate limit: burst size (default: 60)
+    #[serde(default = "default_general_rate_limit_burst")]
+    pub general_rate_limit_burst: u32,
 }
 
 fn default_bind_addr() -> String {
@@ -194,6 +202,14 @@ fn default_login_rate_limit_burst() -> u32 {
     5
 }
 
+fn default_general_rate_limit_per_second() -> u64 {
+    1
+}
+
+fn default_general_rate_limit_burst() -> u32 {
+    60
+}
+
 impl Config {
     pub fn load() -> Result<Self, Box<figment::Error>> {
         dotenvy::dotenv().ok();
@@ -243,6 +259,11 @@ impl Config {
         if self.login_rate_limit_per_second == 0 || self.login_rate_limit_burst == 0 {
             return Err(ConfigError::RateLimiter(
                 "login rate limit per_second and burst must be > 0".to_string(),
+            ));
+        }
+        if self.general_rate_limit_per_second == 0 || self.general_rate_limit_burst == 0 {
+            return Err(ConfigError::RateLimiter(
+                "general rate limit per_second and burst must be > 0".to_string(),
             ));
         }
 
@@ -307,6 +328,8 @@ impl Default for Config {
             register_rate_limit_burst: default_register_rate_limit_burst(),
             login_rate_limit_per_second: default_login_rate_limit_per_second(),
             login_rate_limit_burst: default_login_rate_limit_burst(),
+            general_rate_limit_per_second: default_general_rate_limit_per_second(),
+            general_rate_limit_burst: default_general_rate_limit_burst(),
         }
     }
 }
@@ -443,6 +466,24 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.login_rate_limit_per_second, 180);
         assert_eq!(config.login_rate_limit_burst, 5);
+    }
+
+    #[test]
+    fn test_general_rate_limit_defaults() {
+        let config = Config::default();
+        assert_eq!(config.general_rate_limit_per_second, 1);
+        assert_eq!(config.general_rate_limit_burst, 60);
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_general_rate_limit() {
+        let config = Config {
+            general_rate_limit_burst: 0,
+            cors_origin: Some("http://localhost:5173".to_string()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("rate limit"));
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -100,6 +100,22 @@ pub struct Config {
     /// GitHub Webhook secret for signature verification (env: GANTRY_GITHUB_WEBHOOK_SECRET)
     #[serde(default)]
     pub github_webhook_secret: Option<String>,
+
+    /// Register rate limit: replenishment interval in seconds (default: 1200)
+    #[serde(default = "default_register_rate_limit_per_second")]
+    pub register_rate_limit_per_second: u64,
+
+    /// Register rate limit: burst size (default: 3)
+    #[serde(default = "default_register_rate_limit_burst")]
+    pub register_rate_limit_burst: u32,
+
+    /// Login rate limit: replenishment interval in seconds (default: 180)
+    #[serde(default = "default_login_rate_limit_per_second")]
+    pub login_rate_limit_per_second: u64,
+
+    /// Login rate limit: burst size (default: 5)
+    #[serde(default = "default_login_rate_limit_burst")]
+    pub login_rate_limit_burst: u32,
 }
 
 fn default_bind_addr() -> String {
@@ -162,6 +178,22 @@ fn default_github_sync_interval_secs() -> u64 {
     300 // 5 minutes
 }
 
+fn default_register_rate_limit_per_second() -> u64 {
+    1200
+}
+
+fn default_register_rate_limit_burst() -> u32 {
+    3
+}
+
+fn default_login_rate_limit_per_second() -> u64 {
+    180
+}
+
+fn default_login_rate_limit_burst() -> u32 {
+    5
+}
+
 impl Config {
     pub fn load() -> Result<Self, Box<figment::Error>> {
         dotenvy::dotenv().ok();
@@ -200,6 +232,18 @@ impl Config {
                  This is a security risk in production deployments. \
                  Set GANTRY_CORS_ORIGIN to your frontend URL."
             );
+        }
+
+        // Reject zero rate limit values
+        if self.register_rate_limit_per_second == 0 || self.register_rate_limit_burst == 0 {
+            return Err(ConfigError::RateLimiter(
+                "register rate limit per_second and burst must be > 0".to_string(),
+            ));
+        }
+        if self.login_rate_limit_per_second == 0 || self.login_rate_limit_burst == 0 {
+            return Err(ConfigError::RateLimiter(
+                "login rate limit per_second and burst must be > 0".to_string(),
+            ));
         }
 
         // Reject wildcard CORS origin
@@ -259,6 +303,10 @@ impl Default for Config {
             github_sync_interval_secs: default_github_sync_interval_secs(),
             allowed_hosts: Vec::new(),
             github_webhook_secret: None,
+            register_rate_limit_per_second: default_register_rate_limit_per_second(),
+            register_rate_limit_burst: default_register_rate_limit_burst(),
+            login_rate_limit_per_second: default_login_rate_limit_per_second(),
+            login_rate_limit_burst: default_login_rate_limit_burst(),
         }
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -75,8 +75,11 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         state.config.register_rate_limit_per_second,
         state.config.register_rate_limit_burst
     )?;
-    // General API rate limit: ~1 req/s sustained, 60-request burst capacity per IP.
-    let general_governor = governor!(1, 60)?;
+    // General API rate limit — configurable (default: ~1 req/s sustained, 60-burst per IP).
+    let general_governor = governor!(
+        state.config.general_rate_limit_per_second,
+        state.config.general_rate_limit_burst
+    )?;
     // Rate limit: agent start — 1 per 10 seconds, burst 3 per IP.
     let agent_start_governor = governor!(10, 3)?;
     // Rate limit: agent restart — same as start.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -64,11 +64,17 @@ macro_rules! governor {
 }
 
 pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
-    // Rate limit: login — 5 attempts per 15 min per IP.
+    // Rate limit: login — configurable (default: 5 attempts per 15 min per IP).
     // per_second(N) sets the replenishment *interval* to N seconds (NOT N req/sec).
-    let login_governor = governor!(180, 5)?;
-    // Rate limit: register — 3 attempts per hour per IP.
-    let register_governor = governor!(1200, 3)?;
+    let login_governor = governor!(
+        state.config.login_rate_limit_per_second,
+        state.config.login_rate_limit_burst
+    )?;
+    // Rate limit: register — configurable (default: 3 attempts per hour per IP).
+    let register_governor = governor!(
+        state.config.register_rate_limit_per_second,
+        state.config.register_rate_limit_burst
+    )?;
     // General API rate limit: ~1 req/s sustained, 60-request burst capacity per IP.
     let general_governor = governor!(1, 60)?;
     // Rate limit: agent start — 1 per 10 seconds, burst 3 per IP.

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -2,8 +2,6 @@ import { test as base, type Page, request as playwrightRequest } from '@playwrig
 import { ApiHelper } from '../helpers/api';
 import { createTestUser, type TestUser } from '../helpers/auth';
 
-const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000';
-
 type TestFixtures = {
   apiHelper: ApiHelper;
   authenticatedPage: Page;
@@ -32,19 +30,22 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     await use(new ApiHelper(request));
   },
 
-  authenticatedPage: async ({ page, testUser }, use) => {
-    // Login via page.request so the session cookie is stored in the browser context.
-    // This is more reliable than manually parsing Set-Cookie and calling addCookies.
-    const loginResponse = await page.request.post(`${API_BASE}/api/auth/login`, {
-      data: { email: testUser.email, password: testUser.password },
-      headers: { 'x-requested-with': 'XMLHttpRequest' },
-    });
-    if (!loginResponse.ok()) {
-      throw new Error(
-        `authenticatedPage login failed: ${loginResponse.status()} ${await loginResponse.text()}`,
-      );
-    }
-
+  authenticatedPage: async ({ page, testUser, baseURL }, use) => {
+    const base = baseURL ?? 'http://localhost:5173';
+    const domain = new URL(base).hostname;
+    // Set the register session cookie on the browser context.
+    // We intentionally do NOT call login (which rotates sessions) because
+    // parallel tests within the same worker share the testUser and login
+    // would invalidate other tests' sessions.
+    await page.context().addCookies([
+      {
+        name: testUser.cookie.split('=')[0],
+        value: testUser.cookie.split('=')[1],
+        domain,
+        path: '/',
+        sameSite: 'Lax',
+      },
+    ]);
     // Inject Zustand auth state into sessionStorage before any page script runs.
     // This prevents ProtectedRoute from redirecting to /login on the first navigation.
     const authState = JSON.stringify({

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -1,21 +1,29 @@
-import { test as base, type Page } from '@playwright/test';
+import { test as base, type Page, request as playwrightRequest } from '@playwright/test';
 import { ApiHelper } from '../helpers/api';
-import { type TestUser, createTestUser } from '../helpers/auth';
+import { createTestUser, type TestUser } from '../helpers/auth';
 
-type Fixtures = {
+type TestFixtures = {
   apiHelper: ApiHelper;
-  testUser: TestUser;
   authenticatedPage: Page;
 };
 
-export const test = base.extend<Fixtures>({
+type WorkerFixtures = {
+  testUser: TestUser;
+};
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
+  testUser: [
+    async (_deps, use) => {
+      const apiContext = await playwrightRequest.newContext();
+      const user = await createTestUser(apiContext);
+      await use(user);
+      await apiContext.dispose();
+    },
+    { scope: 'worker' },
+  ],
+
   apiHelper: async ({ request }, use) => {
     await use(new ApiHelper(request));
-  },
-
-  testUser: async ({ request }, use) => {
-    const user = await createTestUser(request);
-    await use(user);
   },
 
   authenticatedPage: async ({ page, testUser, baseURL }, use) => {

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -2,6 +2,8 @@ import { test as base, type Page, request as playwrightRequest } from '@playwrig
 import { ApiHelper } from '../helpers/api';
 import { createTestUser, type TestUser } from '../helpers/auth';
 
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000';
+
 type TestFixtures = {
   apiHelper: ApiHelper;
   authenticatedPage: Page;
@@ -30,17 +32,19 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     await use(new ApiHelper(request));
   },
 
-  authenticatedPage: async ({ page, testUser, baseURL }, use) => {
-    const base = baseURL ?? 'http://localhost:5173';
-    const domain = new URL(base).hostname;
-    await page.context().addCookies([
-      {
-        name: testUser.cookie.split('=')[0],
-        value: testUser.cookie.split('=')[1],
-        domain,
-        path: '/',
-      },
-    ]);
+  authenticatedPage: async ({ page, testUser }, use) => {
+    // Login via page.request so the session cookie is stored in the browser context.
+    // This is more reliable than manually parsing Set-Cookie and calling addCookies.
+    const loginResponse = await page.request.post(`${API_BASE}/api/auth/login`, {
+      data: { email: testUser.email, password: testUser.password },
+      headers: { 'x-requested-with': 'XMLHttpRequest' },
+    });
+    if (!loginResponse.ok()) {
+      throw new Error(
+        `authenticatedPage login failed: ${loginResponse.status()} ${await loginResponse.text()}`,
+      );
+    }
+
     // Inject Zustand auth state into sessionStorage before any page script runs.
     // This prevents ProtectedRoute from redirecting to /login on the first navigation.
     const authState = JSON.stringify({

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -15,9 +15,12 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   testUser: [
     async (_deps, use) => {
       const apiContext = await playwrightRequest.newContext();
-      const user = await createTestUser(apiContext);
-      await use(user);
-      await apiContext.dispose();
+      try {
+        const user = await createTestUser(apiContext);
+        await use(user);
+      } finally {
+        await apiContext.dispose();
+      }
     },
     { scope: 'worker' },
   ],

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -31,7 +31,8 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   },
 
   authenticatedPage: async ({ page, testUser, baseURL }, use) => {
-    const domain = new URL(baseURL ?? 'http://localhost:5173').hostname;
+    const base = baseURL ?? 'http://localhost:5173';
+    const domain = new URL(base).hostname;
     await page.context().addCookies([
       {
         name: testUser.cookie.split('=')[0],
@@ -40,6 +41,21 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         path: '/',
       },
     ]);
+    // Populate sessionStorage with Zustand auth state so ProtectedRoute
+    // doesn't redirect to /login before the app can mount.
+    await page.goto(base);
+    await page.evaluate(
+      (user) => {
+        sessionStorage.setItem(
+          'auth-storage',
+          JSON.stringify({
+            state: { user, isAuthenticated: true },
+            version: 0,
+          }),
+        );
+      },
+      { id: testUser.id, email: testUser.email, name: testUser.name },
+    );
     await use(page);
   },
 });

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -13,7 +13,8 @@ type WorkerFixtures = {
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   testUser: [
-    async (_deps, use) => {
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright requires object destructuring for worker fixtures
+    async ({}, use) => {
       const apiContext = await playwrightRequest.newContext();
       try {
         const user = await createTestUser(apiContext);

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -41,21 +41,18 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         path: '/',
       },
     ]);
-    // Populate sessionStorage with Zustand auth state so ProtectedRoute
-    // doesn't redirect to /login before the app can mount.
-    await page.goto(base);
-    await page.evaluate(
-      (user) => {
-        sessionStorage.setItem(
-          'auth-storage',
-          JSON.stringify({
-            state: { user, isAuthenticated: true },
-            version: 0,
-          }),
-        );
+    // Inject Zustand auth state into sessionStorage before any page script runs.
+    // This prevents ProtectedRoute from redirecting to /login on the first navigation.
+    const authState = JSON.stringify({
+      state: {
+        user: { id: testUser.id, email: testUser.email, name: testUser.name },
+        isAuthenticated: true,
       },
-      { id: testUser.id, email: testUser.email, name: testUser.name },
-    );
+      version: 0,
+    });
+    await page.addInitScript((state) => {
+      sessionStorage.setItem('auth-storage', state);
+    }, authState);
     await use(page);
   },
 });

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -33,10 +33,6 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   authenticatedPage: async ({ page, testUser, baseURL }, use) => {
     const base = baseURL ?? 'http://localhost:5173';
     const domain = new URL(base).hostname;
-    // Set the register session cookie on the browser context.
-    // We intentionally do NOT call login (which rotates sessions) because
-    // parallel tests within the same worker share the testUser and login
-    // would invalidate other tests' sessions.
     await page.context().addCookies([
       {
         name: testUser.cookie.split('=')[0],
@@ -46,18 +42,21 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         sameSite: 'Lax',
       },
     ]);
-    // Inject Zustand auth state into sessionStorage before any page script runs.
-    // This prevents ProtectedRoute from redirecting to /login on the first navigation.
-    const authState = JSON.stringify({
-      state: {
-        user: { id: testUser.id, email: testUser.email, name: testUser.name },
-        isAuthenticated: true,
+    // Navigate to /login (same origin, doesn't trigger ProtectedRoute redirect)
+    // to establish sessionStorage on the correct origin.
+    await page.goto(`${base}/login`);
+    await page.evaluate(
+      (user) => {
+        sessionStorage.setItem(
+          'auth-storage',
+          JSON.stringify({
+            state: { user, isAuthenticated: true },
+            version: 0,
+          }),
+        );
       },
-      version: 0,
-    });
-    await page.addInitScript((state) => {
-      sessionStorage.setItem('auth-storage', state);
-    }, authState);
+      { id: testUser.id, email: testUser.email, name: testUser.name },
+    );
     await use(page);
   },
 });

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -17,7 +17,7 @@ export async function createTestUser(
   overrides?: { email?: string; name?: string },
 ): Promise<TestUser> {
   userCounter++;
-  const uniqueId = `${userCounter}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const uniqueId = `${process.pid}-${userCounter}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   const email = overrides?.email ?? `e2e-user-${uniqueId}@test.local`;
   const name = overrides?.name ?? `E2E User ${userCounter}`;
   const password = 'Tr0ub4dor&3-e2e-test';

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -31,8 +31,15 @@ export async function createTestUser(
     throw new Error(`createTestUser failed: ${response.status()} ${await response.text()}`);
   }
 
-  const setCookie = response.headers()['set-cookie'] ?? '';
-  const cookie = setCookie.split(';')[0];
+  // Use headersArray() for reliable Set-Cookie retrieval
+  const headers = response.headersArray();
+  const setCookieHeader = headers.find((h) => h.name.toLowerCase() === 'set-cookie');
+  const cookie = setCookieHeader?.value.split(';')[0] ?? '';
+  if (!cookie || !cookie.includes('=')) {
+    throw new Error(
+      `createTestUser: no valid Set-Cookie header in register response (got: ${JSON.stringify(setCookieHeader)})`,
+    );
+  }
   const body = await response.json();
 
   return {

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -16,7 +16,8 @@ export async function createTestUser(
   overrides?: { email?: string; name?: string },
 ): Promise<TestUser> {
   userCounter++;
-  const email = overrides?.email ?? `e2e-user-${userCounter}-${Date.now()}@test.local`;
+  const uniqueId = `${userCounter}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const email = overrides?.email ?? `e2e-user-${uniqueId}@test.local`;
   const name = overrides?.name ?? `E2E User ${userCounter}`;
   const password = 'Tr0ub4dor&3-e2e-test';
 

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -6,6 +6,7 @@ export interface TestUser {
   id: string;
   email: string;
   name: string;
+  password: string;
   cookie: string;
 }
 
@@ -38,6 +39,7 @@ export async function createTestUser(
     id: body.user.id,
     email,
     name,
+    password,
     cookie,
   };
 }

--- a/frontend/e2e/tests/agent-sessions.spec.ts
+++ b/frontend/e2e/tests/agent-sessions.spec.ts
@@ -65,11 +65,11 @@ test.describe('Agent Session UI', () => {
     const dialog = page.getByRole('dialog');
 
     // Start button should be disabled when prompt is empty
-    await expect(dialog.getByRole('button', { name: 'Start' })).toBeDisabled();
+    await expect(dialog.getByRole('button', { name: 'Start', exact: true })).toBeDisabled();
 
     // Fill in a prompt — start button should become enabled
     await dialog.getByPlaceholder('Enter prompt for the agent...').fill('Test prompt');
-    await expect(dialog.getByRole('button', { name: 'Start' })).toBeEnabled();
+    await expect(dialog.getByRole('button', { name: 'Start', exact: true })).toBeEnabled();
   });
 
   test('shows "No activity yet" when task has no sessions or comments', async ({

--- a/frontend/e2e/tests/agent-sessions.spec.ts
+++ b/frontend/e2e/tests/agent-sessions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures';
+import { expect, test } from '../fixtures';
 
 test.describe('Agent Session UI', () => {
   test('shows agent controls in the task detail modal', async ({

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures';
+import { expect, test } from '../fixtures';
 
 test.describe('Authentication Flow', () => {
   test('registers a new user and redirects to board', async ({ page }) => {

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -8,7 +8,7 @@ test.describe('Authentication Flow', () => {
     await page.getByLabel('Name').fill('E2E Test User');
     await page.getByLabel('Email').fill(email);
     await page.getByLabel('Password').fill('Tr0ub4dor&3-e2e-test');
-    await page.getByRole('button', { name: /register/i }).click();
+    await page.getByRole('button', { name: /create account/i }).click();
 
     // Should redirect to board
     await expect(page).toHaveURL('/');
@@ -25,7 +25,7 @@ test.describe('Authentication Flow', () => {
     await page.goto('/login');
     await page.getByLabel('Email').fill(email);
     await page.getByLabel('Password').fill(password);
-    await page.getByRole('button', { name: /log in/i }).click();
+    await page.getByRole('button', { name: /sign in/i }).click();
 
     await expect(page).toHaveURL('/');
     await expect(page.getByText('Gantry Board')).toBeVisible();
@@ -35,7 +35,7 @@ test.describe('Authentication Flow', () => {
     await page.goto('/login');
     await page.getByLabel('Email').fill('nonexistent@test.local');
     await page.getByLabel('Password').fill('wrongpassword');
-    await page.getByRole('button', { name: /log in/i }).click();
+    await page.getByRole('button', { name: /sign in/i }).click();
 
     await expect(page.getByText(/invalid|incorrect|unauthorized/i)).toBeVisible();
   });

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -45,8 +45,18 @@ test.describe('Authentication Flow', () => {
     await expect(page).toHaveURL(/\/login/);
   });
 
-  test('logs out successfully', async ({ authenticatedPage: page }) => {
-    await page.goto('/');
+  test('logs out successfully', async ({ page, apiHelper }) => {
+    // Use a disposable user to avoid invalidating the shared testUser session
+    const email = `e2e-logout-${Date.now()}@test.local`;
+    const password = 'Tr0ub4dor&3-e2e-test';
+    await apiHelper.registerUser(email, 'Logout Test', password);
+
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page).toHaveURL('/');
     await page.getByRole('button', { name: /logout/i }).click();
 
     await expect(page).toHaveURL(/\/login/);

--- a/frontend/e2e/tests/health.spec.ts
+++ b/frontend/e2e/tests/health.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures';
+import { expect, test } from '../fixtures';
 
 test.describe('Health Check', () => {
   test('backend health endpoint returns ok', async ({ apiHelper }) => {

--- a/frontend/e2e/tests/projects.spec.ts
+++ b/frontend/e2e/tests/projects.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures';
+import { expect, test } from '../fixtures';
 
 test.describe('Project CRUD', () => {
   test('creates a new project via UI', async ({ authenticatedPage: page }) => {

--- a/frontend/e2e/tests/tasks.spec.ts
+++ b/frontend/e2e/tests/tasks.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures';
+import { expect, test } from '../fixtures';
 
 test.describe('Task CRUD', () => {
   test('creates a task via the kanban column button', async ({
@@ -74,9 +74,7 @@ test.describe('Task CRUD', () => {
 
     // Task should now appear in the "In Progress" column
     await expect(
-      page
-        .locator('.flex-shrink-0', { hasText: 'In Progress' })
-        .getByText('Status Change Task'),
+      page.locator('.flex-shrink-0', { hasText: 'In Progress' }).getByText('Status Change Task'),
     ).toBeVisible();
   });
 
@@ -105,15 +103,8 @@ test.describe('Task CRUD', () => {
 });
 
 test.describe('Task Comments', () => {
-  test('adds a comment to a task', async ({
-    authenticatedPage: page,
-    apiHelper,
-    testUser,
-  }) => {
-    const project = await apiHelper.createProject(
-      testUser.cookie,
-      `Comment Project ${Date.now()}`,
-    );
+  test('adds a comment to a task', async ({ authenticatedPage: page, apiHelper, testUser }) => {
+    const project = await apiHelper.createProject(testUser.cookie, `Comment Project ${Date.now()}`);
     await apiHelper.createTask(testUser.cookie, project.id, 'Commentable Task');
 
     await page.goto('/');
@@ -132,11 +123,7 @@ test.describe('Task Comments', () => {
     await expect(dialog.getByText('E2E test comment')).toBeVisible();
   });
 
-  test('displays existing comments', async ({
-    authenticatedPage: page,
-    apiHelper,
-    testUser,
-  }) => {
+  test('displays existing comments', async ({ authenticatedPage: page, apiHelper, testUser }) => {
     const project = await apiHelper.createProject(
       testUser.cookie,
       `Pre-Comment Project ${Date.now()}`,

--- a/frontend/e2e/tests/tasks.spec.ts
+++ b/frontend/e2e/tests/tasks.spec.ts
@@ -93,7 +93,7 @@ test.describe('Task CRUD', () => {
     await page.getByTestId('task-card').getByText('Task To Delete').click();
 
     const dialog = page.getByRole('dialog');
-    await dialog.getByRole('button', { name: 'Delete' }).click();
+    await dialog.getByRole('button', { name: 'Delete', exact: true }).click();
     await dialog.getByRole('button', { name: 'Confirm' }).click();
 
     // Modal should close and task should be gone

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 2 : 1,
   reporter: process.env.CI
     ? [['html', { open: 'never' }], ['github']]
     : [['html', { open: 'never' }]],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : 1,
+  workers: 1,
   reporter: process.env.CI
     ? [['html', { open: 'never' }], ['github']]
     : [['html', { open: 'never' }]],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,11 +2,13 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e/tests',
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
-  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : [['html', { open: 'never' }]],
+  workers: process.env.CI ? 2 : 1,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'never' }]],
   use: {
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
     trace: 'on-first-retry',

--- a/frontend/src/components/board/KanbanBoard.tsx
+++ b/frontend/src/components/board/KanbanBoard.tsx
@@ -44,7 +44,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const assigneeFilter = useBoardStore((s) => s.assigneeFilter);
   const priorityFilter = useBoardStore((s) => s.priorityFilter);
 
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor),
+  );
 
   const updateTaskMutation = useUpdateTask({
     mutation: {

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -1,6 +1,8 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useCreateProject } from '@/api/generated/endpoints/projects/projects';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { invalidateProjects } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 
 export function ProjectCreateDialog() {
@@ -12,6 +14,7 @@ export function ProjectCreateDialog() {
 }
 
 function ProjectCreateForm() {
+  const queryClient = useQueryClient();
   const closeProjectModal = useUiStore((s) => s.closeProjectModal);
   const createProject = useCreateProject();
 
@@ -33,6 +36,7 @@ function ProjectCreateForm() {
           description: description.trim() || undefined,
         },
       });
+      invalidateProjects(queryClient);
       closeProjectModal();
     } catch {
       setError('Failed to create project. Please try again.');

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -1,8 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useCreateTask } from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 
 interface TaskCreateDialogProps {
@@ -25,6 +27,7 @@ function TaskCreateForm({
   projectId: string;
   defaultStatus: TaskStatus | null;
 }) {
+  const queryClient = useQueryClient();
   const closeTaskModal = useUiStore((s) => s.closeTaskModal);
   const createTask = useCreateTask();
   const { data: members } = useListMembers(projectId);
@@ -54,6 +57,7 @@ function TaskCreateForm({
           ...(assignedTo ? { assigned_to: assignedTo } : {}),
         },
       });
+      invalidateTasks(queryClient);
       closeTaskModal();
     } catch {
       setError('Failed to create task. Please try again.');

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -1,8 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 import { PullRequestList } from '../github/PullRequestList';
 import { WorktreePanel } from '../preview/WorktreePanel';
@@ -18,6 +20,7 @@ export function TaskDetailModal() {
 }
 
 function TaskDetailContent({ taskId }: { taskId: string }) {
+  const queryClient = useQueryClient();
   const closeTaskDetail = useUiStore((s) => s.closeTaskDetail);
   const { data: task, isLoading, isError } = useGetTask(taskId);
   const updateTask = useUpdateTask();
@@ -67,6 +70,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const handleDelete = async () => {
     try {
       await deleteTask.mutateAsync({ id: taskId });
+      invalidateTasks(queryClient);
       closeTaskDetail();
     } catch {
       setError('Failed to delete task. Please try again.');
@@ -93,6 +97,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         id: taskId,
         data: { [field]: value },
       });
+      invalidateTasks(queryClient);
     } catch {
       setError(`Failed to update ${field}. Please try again.`);
     }


### PR DESCRIPTION
## Summary
- Optimize Playwright E2E test execution from ~6min to ~16s by fixing root causes of test failures
- Fix worker-scoped `testUser` fixture to share a single registered user per worker instead of re-registering per test
- Enable `fullyParallel: true` + `workers: 2` in CI for parallel execution

### Bug fixes discovered during E2E stabilization
- **dnd-kit PointerSensor missing activation constraint**: clicks on task cards were intercepted as drag operations, preventing the detail modal from opening. Added `distance: 8` constraint.
- **Missing query invalidation after mutations**: `ProjectCreateDialog`, `TaskCreateDialog`, and `TaskDetailModal` relied solely on SSE for cache updates. Added explicit `invalidateProjects` / `invalidateTasks` calls after successful mutations.
- **Auth logout test invalidating shared session**: the logout E2E test deleted the worker-scoped `testUser` session on the server, causing all subsequent tests to get 401. Changed to use a disposable user.

### E2E infrastructure improvements
- Make general API rate limit configurable via `Config` (`GANTRY_GENERAL_RATE_LIMIT_BURST`) to prevent 429s in CI
- Use `addCookies` + `page.evaluate` for reliable session setup without triggering `rotate_session`
- Use `headersArray()` for reliable `Set-Cookie` capture
- Add `process.pid` to test user emails to prevent collision across parallel workers
- Fix button selectors: `/register/i` → `/create account/i`, `/log in/i` → `/sign in/i`
- Fix strict-mode selector violations with `{ exact: true }` for "Start" and "Delete" buttons

Closes #259

## Test plan
- [x] All 20 E2E tests pass locally (44.9s with workers=1)
- [x] All 20 E2E tests pass in CI (16.5s with workers=2)
- [x] All 346 frontend unit tests pass
- [x] All CI jobs green (lint, clippy, test, e2e, security, coverage, api-diff)