### PR TITLE
chore: 👷 Docker and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
           name: openapi-spec
           path: openapi.json
           retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-binary
+          path: target/debug/gantry-board
+          retention-days: 1
 
   # ── API (orval diff) ─────────────────────────────
   api:
@@ -149,22 +154,26 @@ jobs:
       - run: cd frontend && npm run build
 
   # ── Security (cargo-deny, npm audit) ───────────
-  # Runs unconditionally: vulnerability databases update independently of code changes
+  # cargo-deny runs unconditionally; npm audit only when frontend changed
   security:
     name: Security (cargo-deny, npm audit)
     runs-on: ubuntu-latest
+    needs: changes
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny check
       - uses: actions/setup-node@v4
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - run: cd frontend && npm ci
+        if: needs.changes.outputs.frontend == 'true'
       - run: cd frontend && npm audit --audit-level=moderate
+        if: needs.changes.outputs.frontend == 'true'
         continue-on-error: true
 
   # ── E2E (Playwright) ────────────────────────────
@@ -180,11 +189,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Backend build
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo build
-        working-directory: backend
+      # Download pre-built backend binary
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-binary
+          path: backend/bin
+      - run: chmod +x backend/bin/gantry-board
 
       # Frontend setup
       - uses: actions/setup-node@v4
@@ -199,7 +209,7 @@ jobs:
       - name: Start backend server
         run: |
           mkdir -p backend/data
-          ../target/debug/gantry-board &
+          ./bin/gantry-board &
           echo $! > /tmp/backend.pid
           # Wait for backend to be ready
           for i in $(seq 1 30); do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,86 @@
+# Stage 1: Build backend
+FROM rust:1.85-slim-bookworm AS backend-builder
+
+WORKDIR /workspace
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy workspace manifests for dependency caching
+COPY Cargo.toml Cargo.lock ./
+COPY backend/Cargo.toml backend/
+
+# Create dummy src to build dependencies
+RUN mkdir -p backend/src && echo "fn main() {}" > backend/src/main.rs
+RUN cargo build --release -p gantry-board || true
+RUN rm -rf backend/src
+
+# Copy source code
+COPY backend/src backend/src
+COPY backend/migrations backend/migrations
+
+# Build release binary
+RUN cargo build --release -p gantry-board
+
+# Stage 2: Build frontend
+FROM node:22-slim AS frontend-builder
+
+WORKDIR /app
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ .
+RUN npm run build
+
+# Stage 3: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    curl \
+    nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy backend binary
+COPY --from=backend-builder /workspace/target/release/gantry-board /usr/local/bin/gantry-board
+
+# Copy frontend build
+COPY --from=frontend-builder /app/dist /usr/share/nginx/html
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Create data directory
+RUN mkdir -p /data
+
+# Copy entrypoint script
+COPY <<'ENTRYPOINT' /usr/local/bin/entrypoint.sh
+#!/bin/bash
+set -e
+
+# Start backend in background
+gantry-board &
+BACKEND_PID=$!
+
+# Start nginx in foreground
+nginx -g "daemon off;" &
+NGINX_PID=$!
+
+# Wait for either process to exit
+wait -n $BACKEND_PID $NGINX_PID
+EXIT_CODE=$?
+
+# Kill remaining process
+kill $BACKEND_PID $NGINX_PID 2>/dev/null || true
+exit $EXIT_CODE
+ENTRYPOINT
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 80 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=10s \
+    CMD curl -f http://localhost:3000/health || exit 1
+
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -51,36 +51,58 @@ COPY --from=backend-builder /workspace/target/release/gantry-board /usr/local/bi
 # Copy frontend build
 COPY --from=frontend-builder /app/dist /usr/share/nginx/html
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+# Rewrite proxy_pass for single-container mode (backend on localhost, not separate service)
+RUN sed -i 's|http://backend:3000|http://localhost:3000|g' /etc/nginx/conf.d/default.conf
 
-# Create data directory
-RUN mkdir -p /data
+# Create non-root user for runtime
+RUN groupadd --system gantry && useradd --system --gid gantry --create-home gantry \
+    && mkdir -p /data && chown gantry:gantry /data \
+    && chown -R gantry:gantry /usr/share/nginx/html \
+    && chown -R gantry:gantry /var/log/nginx /var/lib/nginx /run
 
 # Copy entrypoint script
 COPY <<'ENTRYPOINT' /usr/local/bin/entrypoint.sh
 #!/bin/bash
 set -e
 
+# Forward termination signals to child processes for graceful shutdown
+terminate() {
+    kill -TERM "$BACKEND_PID" "$NGINX_PID" 2>/dev/null || true
+}
+trap terminate SIGTERM SIGINT
+
 # Start backend in background
 gantry-board &
 BACKEND_PID=$!
 
-# Start nginx in foreground
+# Start nginx in background (non-daemonized)
 nginx -g "daemon off;" &
 NGINX_PID=$!
 
 # Wait for either process to exit
-wait -n $BACKEND_PID $NGINX_PID
+wait -n "$BACKEND_PID" "$NGINX_PID"
 EXIT_CODE=$?
 
-# Kill remaining process
-kill $BACKEND_PID $NGINX_PID 2>/dev/null || true
-exit $EXIT_CODE
+# Kill remaining process(es) that are still running
+if kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" 2>/dev/null || true
+fi
+if kill -0 "$NGINX_PID" 2>/dev/null; then
+    kill "$NGINX_PID" 2>/dev/null || true
+fi
+
+# Wait for both to fully exit (avoid zombies)
+wait "$BACKEND_PID" "$NGINX_PID" 2>/dev/null || true
+
+exit "$EXIT_CODE"
 ENTRYPOINT
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER gantry
 
 EXPOSE 80 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=10s \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://localhost:3000/health && curl -f http://localhost/ || exit 1
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,19 @@ services:
     volumes:
       - gantry-data:/data
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+          pids: 256
+        reservations:
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   frontend:
     build:
@@ -24,6 +37,16 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   gantry-data:

--- a/docs/DOCKER_SECURITY.md
+++ b/docs/DOCKER_SECURITY.md
@@ -79,8 +79,46 @@ The Docker host is configurable via:
 - **Environment variable:** `GANTRY_DOCKER_HOST`
 - **Default:** `unix:///var/run/docker.sock`
 
+## Resource Limits
+
+Production containers are configured with resource limits in `docker-compose.prod.yml` to prevent runaway resource consumption.
+
+### Default Limits
+
+| Service   | CPU   | Memory (limit) | Memory (reserved) | PID limit |
+|-----------|-------|--------------|--------------------|-----------|
+| backend   | 4.0   | 4 GB         | 1 GB               | 256       |
+| frontend  | 1.0   | 512 MB       | -                  | -         |
+
+### Logging
+
+All services use the `json-file` logging driver with rotation:
+
+- **max-size:** 10 MB per log file
+- **max-file:** 3 files (30 MB total per service)
+
+### Adjusting Limits
+
+Override limits via environment-specific compose overrides or by editing `docker-compose.prod.yml` directly:
+
+```yaml
+services:
+  backend:
+    deploy:
+      resources:
+        limits:
+          cpus: '8.0'
+          memory: 8G
+          pids: 512
+        reservations:
+          memory: 2G
+```
+
+For high-load deployments with many concurrent agents, increase the backend CPU, memory, and PID limits proportionally. The frontend/nginx service typically needs minimal resources.
+
 ## References
 
 - [Docker daemon attack surface](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)
 - [Rootless Docker](https://docs.docker.com/engine/security/rootless/)
 - [Docker-in-Docker](https://hub.docker.com/_/docker)
+- [Docker Compose deploy resources](https://docs.docker.com/compose/compose-file/deploy/#resources)


### PR DESCRIPTION
## Summary

- **CI E2E binary reuse (#267):** The `rust` job now uploads the debug binary as an artifact. The `e2e` job downloads it instead of rebuilding from source, saving ~3-5 minutes. The `security` job now conditionally runs `npm audit` only when frontend files changed.
- **Docker release pipeline (#283):** New `release.yml` workflow builds and pushes a Docker image to GHCR on `main` push or version tags. A root-level `Dockerfile.prod` combines backend and frontend into a single deployable container. GitHub Releases are auto-created for version tags.
- **Container resource limits (#284):** Added CPU, memory, and PID limits to `docker-compose.prod.yml` backend and frontend services. Added log rotation (json-file driver, 10MB x 3 files). Documented limits in `docs/DOCKER_SECURITY.md`.

Closes #267, closes #283, closes #284

## Test plan
- [ ] Verify CI workflow YAML passes GitHub Actions syntax validation
- [ ] Confirm E2E job successfully downloads and runs the pre-built binary artifact
- [ ] Verify `docker compose -f docker-compose.prod.yml config` validates successfully
- [ ] Confirm release workflow triggers correctly on main branch push
- [ ] Verify resource limits are applied with `docker compose up` and `docker stats`