### PR TITLE
feat: ✨ orphaned session recovery and SQLite backup

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -101,6 +101,22 @@ pub struct Config {
     #[serde(default)]
     pub github_webhook_secret: Option<String>,
 
+    /// Enable automated SQLite backups (default: true)
+    #[serde(default = "default_backup_enabled")]
+    pub backup_enabled: bool,
+
+    /// Directory for SQLite backup files (default: "./data/backups")
+    #[serde(default = "default_backup_dir")]
+    pub backup_dir: String,
+
+    /// Backup interval in seconds (default: 86400 = 24h)
+    #[serde(default = "default_backup_interval_secs")]
+    pub backup_interval_secs: u64,
+
+    /// Number of backup files to retain (default: 7)
+    #[serde(default = "default_backup_retention_count")]
+    pub backup_retention_count: u32,
+
     /// Register rate limit: replenishment interval in seconds (default: 1200)
     #[serde(default = "default_register_rate_limit_per_second")]
     pub register_rate_limit_per_second: u64,
@@ -184,6 +200,22 @@ fn default_preview_base_url() -> String {
 
 fn default_github_sync_interval_secs() -> u64 {
     300 // 5 minutes
+}
+
+fn default_backup_enabled() -> bool {
+    true
+}
+
+fn default_backup_dir() -> String {
+    "./data/backups".to_string()
+}
+
+fn default_backup_interval_secs() -> u64 {
+    86400 // 24 hours
+}
+
+fn default_backup_retention_count() -> u32 {
+    7
 }
 
 fn default_register_rate_limit_per_second() -> u64 {
@@ -324,6 +356,10 @@ impl Default for Config {
             github_sync_interval_secs: default_github_sync_interval_secs(),
             allowed_hosts: Vec::new(),
             github_webhook_secret: None,
+            backup_enabled: default_backup_enabled(),
+            backup_dir: default_backup_dir(),
+            backup_interval_secs: default_backup_interval_secs(),
+            backup_retention_count: default_backup_retention_count(),
             register_rate_limit_per_second: default_register_rate_limit_per_second(),
             register_rate_limit_burst: default_register_rate_limit_burst(),
             login_rate_limit_per_second: default_login_rate_limit_per_second(),
@@ -484,6 +520,30 @@ mod tests {
         };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("rate limit"));
+    }
+
+    #[test]
+    fn test_backup_enabled_defaults_to_true() {
+        let config = Config::default();
+        assert!(config.backup_enabled);
+    }
+
+    #[test]
+    fn test_backup_dir_defaults_to_data_backups() {
+        let config = Config::default();
+        assert_eq!(config.backup_dir, "./data/backups");
+    }
+
+    #[test]
+    fn test_backup_interval_secs_defaults_to_86400() {
+        let config = Config::default();
+        assert_eq!(config.backup_interval_secs, 86400);
+    }
+
+    #[test]
+    fn test_backup_retention_count_defaults_to_7() {
+        let config = Config::default();
+        assert_eq!(config.backup_retention_count, 7);
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -308,6 +308,20 @@ impl Config {
             }
         }
 
+        // Validate backup configuration
+        if self.backup_enabled {
+            if self.backup_retention_count == 0 {
+                return Err(ConfigError::RateLimiter(
+                    "backup_retention_count must be >= 1 to avoid deleting all backups".to_string(),
+                ));
+            }
+            if self.backup_dir.contains("..") {
+                return Err(ConfigError::RateLimiter(
+                    "backup_dir must not contain '..' path traversal sequences".to_string(),
+                ));
+            }
+        }
+
         Ok(())
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -63,6 +63,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     worktree_name = session.worktree_name.as_deref().unwrap_or("-"),
                     "recovered orphaned session"
                 );
+                // Best-effort worktree cleanup
+                if let Some(ref wt_name) = session.worktree_name {
+                    let repo_path = config
+                        .repository_path
+                        .as_deref()
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| PathBuf::from("."));
+                    match gantry_board::services::worktree_service::delete_worktree(
+                        &repo_path, wt_name,
+                    ) {
+                        Ok(()) => {
+                            tracing::info!(worktree = %wt_name, "cleaned up orphaned worktree");
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                worktree = %wt_name,
+                                error = %e,
+                                "failed to clean up orphaned worktree (best-effort)"
+                            );
+                        }
+                    }
+                }
             }
         }
         Err(e) => {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,7 +11,9 @@ use gantry_board::config::Config;
 use gantry_board::db;
 use gantry_board::models::agent_session::AgentType;
 use gantry_board::services::preview_service::PreviewManager;
-use gantry_board::services::{agent_session_output_service, session_service};
+use gantry_board::services::{
+    agent_session_output_service, agent_session_service, backup_service, session_service,
+};
 use gantry_board::sse::hub::SseHub;
 use gantry_board::AppState;
 use tokio_util::sync::CancellationToken;
@@ -46,6 +48,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let pool = db::init_pool(&config.database_url, config.max_db_connections).await?;
+
+    // Recover orphaned agent sessions from unclean shutdown
+    match agent_session_service::recover_orphaned_sessions(&pool).await {
+        Ok(recovered) if !recovered.is_empty() => {
+            tracing::warn!(
+                count = recovered.len(),
+                "recovered orphaned agent sessions (marked as failed)"
+            );
+            for session in &recovered {
+                tracing::warn!(
+                    session_id = %session.id,
+                    task_id = %session.task_id,
+                    worktree_name = session.worktree_name.as_deref().unwrap_or("-"),
+                    "recovered orphaned session"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "failed to recover orphaned agent sessions");
+        }
+        _ => {}
+    }
+
     let sse_hub = Arc::new(SseHub::new(config.sse_broadcast_capacity));
 
     let repo_path = config
@@ -114,6 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Clone values needed by background tasks before moving into AppState
     let sync_github_client = github_client.clone();
     let sync_pool = pool.clone();
+    let backup_pool = pool.clone();
     let sync_sse_hub = Arc::clone(&sse_hub);
 
     let state = AppState {
@@ -225,6 +251,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             interval_secs = sync_interval_secs,
             "background GitHub sync polling started"
         );
+    }
+
+    // Spawn background backup task (if enabled)
+    if config.backup_enabled {
+        backup_service::spawn_backup_task(backup_pool, &config, shutdown_token.clone());
     }
 
     let listener = tokio::net::TcpListener::bind(&config.bind_addr).await?;

--- a/backend/src/services/agent_session_service.rs
+++ b/backend/src/services/agent_session_service.rs
@@ -278,6 +278,43 @@ pub async fn save_prompt_tx(
     Ok(())
 }
 
+/// Recovered session info for logging and worktree cleanup.
+#[derive(Debug)]
+pub struct RecoveredSession {
+    pub id: String,
+    pub task_id: String,
+    pub worktree_name: Option<String>,
+}
+
+/// Recover orphaned agent sessions by marking all active sessions as failed.
+///
+/// This is called on startup to clean up sessions that were left in an active
+/// state (running, paused, pending) due to an unclean shutdown. Sessions in
+/// terminal states (completed, failed, cancelled) are not affected.
+///
+/// This function is idempotent -- calling it multiple times is safe.
+pub async fn recover_orphaned_sessions(pool: &SqlitePool) -> AppResult<Vec<RecoveredSession>> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>)>(
+        r#"
+        UPDATE agent_sessions
+        SET status = 'failed', finished_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+        WHERE status IN ('running', 'paused', 'pending')
+        RETURNING id, task_id, worktree_name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(id, task_id, worktree_name)| RecoveredSession {
+            id,
+            task_id,
+            worktree_name,
+        })
+        .collect())
+}
+
 fn validate_status_transition(from: &AgentSessionStatus, to: &AgentSessionStatus) -> AppResult<()> {
     use AgentSessionStatus::*;
     let allowed = matches!(
@@ -1211,5 +1248,206 @@ mod tests {
             result.is_err(),
             "New session should be blocked while another is paused"
         );
+    }
+
+    #[tokio::test]
+    async fn test_recover_orphaned_sessions_marks_active_as_failed() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id1) = create_test_task(&pool).await;
+        let (_project_id2, task_id2) = create_test_task(&pool).await;
+        let (_project_id3, task_id3) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        // Create a running session
+        let s1 = create_agent_session(&pool, task_id1, &req)
+            .await
+            .expect("create s1");
+        update_agent_session(
+            &pool,
+            task_id1,
+            s1.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("s1 to running");
+
+        // Create a paused session
+        let s2 = create_agent_session(&pool, task_id2, &req)
+            .await
+            .expect("create s2");
+        update_agent_session(
+            &pool,
+            task_id2,
+            s2.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("s2 to running");
+        update_agent_session(
+            &pool,
+            task_id2,
+            s2.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Paused,
+            },
+        )
+        .await
+        .expect("s2 to paused");
+
+        // Create a pending session
+        let s3 = create_agent_session(&pool, task_id3, &req)
+            .await
+            .expect("create s3");
+
+        // Recover orphaned sessions
+        let recovered = recover_orphaned_sessions(&pool)
+            .await
+            .expect("recover should succeed");
+        assert_eq!(
+            recovered.len(),
+            3,
+            "all three active sessions should be recovered"
+        );
+
+        // Verify all are now failed with finished_at set
+        let r1 = get_agent_session(&pool, task_id1, s1.id)
+            .await
+            .expect("get s1");
+        assert_eq!(r1.status, AgentSessionStatus::Failed);
+        assert!(r1.finished_at.is_some());
+
+        let r2 = get_agent_session(&pool, task_id2, s2.id)
+            .await
+            .expect("get s2");
+        assert_eq!(r2.status, AgentSessionStatus::Failed);
+        assert!(r2.finished_at.is_some());
+
+        let r3 = get_agent_session(&pool, task_id3, s3.id)
+            .await
+            .expect("get s3");
+        assert_eq!(r3.status, AgentSessionStatus::Failed);
+        assert!(r3.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_recover_orphaned_sessions_idempotent() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        // Create a running session
+        let s = create_agent_session(&pool, task_id, &req)
+            .await
+            .expect("create session");
+        update_agent_session(
+            &pool,
+            task_id,
+            s.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("to running");
+
+        // First recovery
+        let recovered1 = recover_orphaned_sessions(&pool)
+            .await
+            .expect("first recover");
+        assert_eq!(recovered1.len(), 1);
+
+        // Second recovery should be a no-op
+        let recovered2 = recover_orphaned_sessions(&pool)
+            .await
+            .expect("second recover");
+        assert_eq!(recovered2.len(), 0, "second call should be no-op");
+    }
+
+    #[tokio::test]
+    async fn test_recover_orphaned_sessions_does_not_affect_terminal_states() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id1) = create_test_task(&pool).await;
+        let (_project_id2, task_id2) = create_test_task(&pool).await;
+
+        let req = CreateAgentSessionRequest {
+            agent_type: AgentType::ClaudeCode,
+        };
+
+        // Create a completed session
+        let s1 = create_agent_session(&pool, task_id1, &req)
+            .await
+            .expect("create s1");
+        update_agent_session(
+            &pool,
+            task_id1,
+            s1.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("s1 to running");
+        update_agent_session(
+            &pool,
+            task_id1,
+            s1.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("s1 to completed");
+
+        // Create a failed session
+        let s2 = create_agent_session(&pool, task_id2, &req)
+            .await
+            .expect("create s2");
+        update_agent_session(
+            &pool,
+            task_id2,
+            s2.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("s2 to running");
+        update_agent_session(
+            &pool,
+            task_id2,
+            s2.id,
+            &UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Failed,
+            },
+        )
+        .await
+        .expect("s2 to failed");
+
+        // Recover should not touch them
+        let recovered = recover_orphaned_sessions(&pool)
+            .await
+            .expect("recover should succeed");
+        assert_eq!(recovered.len(), 0, "terminal states should not be affected");
+
+        // Verify statuses unchanged
+        let r1 = get_agent_session(&pool, task_id1, s1.id)
+            .await
+            .expect("get s1");
+        assert_eq!(r1.status, AgentSessionStatus::Completed);
+
+        let r2 = get_agent_session(&pool, task_id2, s2.id)
+            .await
+            .expect("get s2");
+        assert_eq!(r2.status, AgentSessionStatus::Failed);
     }
 }

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -1,0 +1,320 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sqlx::SqlitePool;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::AppResult;
+
+/// Create a SQLite backup using VACUUM INTO.
+///
+/// Steps:
+/// 1. Execute `PRAGMA wal_checkpoint(TRUNCATE)` to flush the WAL
+/// 2. Execute `VACUUM INTO '<backup_dir>/gantry_board_YYYYMMDD_HHMMSS.db'`
+/// 3. Return the path to the created backup file
+pub async fn create_backup(pool: &SqlitePool, backup_dir: &Path) -> AppResult<PathBuf> {
+    let start = std::time::Instant::now();
+
+    // Ensure backup directory exists
+    std::fs::create_dir_all(backup_dir).map_err(|e| {
+        crate::error::AppError::Internal(format!(
+            "failed to create backup directory {}: {}",
+            backup_dir.display(),
+            e
+        ))
+    })?;
+
+    // Flush WAL to database file
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(pool)
+        .await?;
+
+    // Generate backup filename with timestamp
+    let now = chrono::Utc::now();
+    let filename = format!("gantry_board_{}.db", now.format("%Y%m%d_%H%M%S"));
+    let backup_path = backup_dir.join(&filename);
+
+    // VACUUM INTO creates an independent copy of the database
+    let path_str = backup_path
+        .to_str()
+        .ok_or_else(|| {
+            crate::error::AppError::Internal("backup path contains invalid UTF-8".to_string())
+        })?
+        .to_string();
+
+    sqlx::query(&format!("VACUUM INTO '{}'", path_str.replace('\'', "''")))
+        .execute(pool)
+        .await?;
+
+    let duration = start.elapsed();
+    let file_size = std::fs::metadata(&backup_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    tracing::info!(
+        path = %backup_path.display(),
+        size_bytes = file_size,
+        duration_ms = duration.as_millis() as u64,
+        "SQLite backup created"
+    );
+
+    Ok(backup_path)
+}
+
+/// Rotate backup files, keeping only `retention_count` most recent.
+///
+/// Lists backup files matching the naming pattern `gantry_board_*.db`,
+/// sorts by name (which includes timestamps), and deletes the oldest
+/// files beyond the retention count. Returns the number of files deleted.
+pub fn rotate_backups(backup_dir: &Path, retention_count: u32) -> AppResult<u32> {
+    let entries = match std::fs::read_dir(backup_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => {
+            return Err(crate::error::AppError::Internal(format!(
+                "failed to read backup directory {}: {}",
+                backup_dir.display(),
+                e
+            )));
+        }
+    };
+
+    // Collect backup files matching our naming pattern
+    let mut backup_files: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            if name.starts_with("gantry_board_") && name.ends_with(".db") {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Sort by name (timestamp order, oldest first)
+    backup_files.sort();
+
+    let total = backup_files.len();
+    let to_delete = total.saturating_sub(retention_count as usize);
+
+    if to_delete == 0 {
+        return Ok(0);
+    }
+
+    let mut deleted = 0u32;
+    for name in backup_files.iter().take(to_delete) {
+        let path = backup_dir.join(name);
+        if let Err(e) = std::fs::remove_file(&path) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to delete old backup file"
+            );
+        } else {
+            deleted += 1;
+        }
+    }
+
+    if deleted > 0 {
+        tracing::info!(deleted, "rotated old backup files");
+    }
+
+    Ok(deleted)
+}
+
+/// Spawn a background task that periodically creates backups and rotates old ones.
+///
+/// Uses the CancellationToken pattern for graceful shutdown.
+pub fn spawn_backup_task(
+    pool: SqlitePool,
+    config: &crate::config::Config,
+    cancel_token: CancellationToken,
+) {
+    let interval_secs = config.backup_interval_secs.max(60);
+    let backup_dir = PathBuf::from(&config.backup_dir);
+    let retention_count = config.backup_retention_count;
+
+    tracing::info!(
+        interval_secs,
+        backup_dir = %backup_dir.display(),
+        retention_count,
+        "background backup task started"
+    );
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        interval.tick().await; // skip the immediate first tick
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("backup task shutting down");
+                    return;
+                }
+            }
+
+            match create_backup(&pool, &backup_dir).await {
+                Ok(_) => {
+                    if let Err(e) = rotate_backups(&backup_dir, retention_count) {
+                        tracing::warn!(error = %e, "backup rotation failed");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "scheduled backup failed");
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::setup_test_db;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_create_backup_creates_valid_sqlite_file() {
+        let pool = setup_test_db().await;
+        let backup_dir = TempDir::new().expect("create temp dir");
+
+        let backup_path = create_backup(&pool, backup_dir.path())
+            .await
+            .expect("backup should succeed");
+
+        // File should exist
+        assert!(backup_path.exists(), "backup file should exist");
+
+        // File should be non-empty
+        let metadata = fs::metadata(&backup_path).expect("metadata");
+        assert!(metadata.len() > 0, "backup file should be non-empty");
+
+        // File name should match pattern gantry_board_YYYYMMDD_HHMMSS.db
+        let file_name = backup_path
+            .file_name()
+            .expect("file name")
+            .to_str()
+            .expect("utf8");
+        assert!(
+            file_name.starts_with("gantry_board_"),
+            "file name should start with gantry_board_"
+        );
+        assert!(file_name.ends_with(".db"), "file name should end with .db");
+
+        // Should be a valid SQLite database (try to open it)
+        let backup_url = format!("sqlite:{}?mode=ro", backup_path.display());
+        let backup_pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect(&backup_url)
+            .await
+            .expect("should be valid SQLite");
+        backup_pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_create_backup_creates_backup_dir_if_missing() {
+        let pool = setup_test_db().await;
+        let base_dir = TempDir::new().expect("create temp dir");
+        let backup_dir = base_dir.path().join("nested").join("backups");
+
+        let backup_path = create_backup(&pool, &backup_dir)
+            .await
+            .expect("backup should succeed");
+
+        assert!(backup_path.exists(), "backup file should exist");
+        assert!(backup_dir.exists(), "backup dir should have been created");
+    }
+
+    #[test]
+    fn test_rotate_backups_keeps_retention_count() {
+        let backup_dir = TempDir::new().expect("create temp dir");
+
+        // Create 5 fake backup files with sequential timestamps
+        let names = [
+            "gantry_board_20260101_000000.db",
+            "gantry_board_20260102_000000.db",
+            "gantry_board_20260103_000000.db",
+            "gantry_board_20260104_000000.db",
+            "gantry_board_20260105_000000.db",
+        ];
+        for name in &names {
+            fs::write(backup_dir.path().join(name), b"dummy").expect("write");
+        }
+
+        // Keep only 3
+        let deleted = rotate_backups(backup_dir.path(), 3).expect("rotate should succeed");
+        assert_eq!(deleted, 2, "should delete 2 oldest backups");
+
+        // Verify the 3 newest remain
+        let remaining: Vec<String> = fs::read_dir(backup_dir.path())
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(remaining.len(), 3);
+        assert!(!remaining.contains(&"gantry_board_20260101_000000.db".to_string()));
+        assert!(!remaining.contains(&"gantry_board_20260102_000000.db".to_string()));
+        assert!(remaining.contains(&"gantry_board_20260103_000000.db".to_string()));
+        assert!(remaining.contains(&"gantry_board_20260104_000000.db".to_string()));
+        assert!(remaining.contains(&"gantry_board_20260105_000000.db".to_string()));
+    }
+
+    #[test]
+    fn test_rotate_backups_no_op_when_under_retention() {
+        let backup_dir = TempDir::new().expect("create temp dir");
+
+        // Create 2 files
+        fs::write(
+            backup_dir.path().join("gantry_board_20260101_000000.db"),
+            b"dummy",
+        )
+        .expect("write");
+        fs::write(
+            backup_dir.path().join("gantry_board_20260102_000000.db"),
+            b"dummy",
+        )
+        .expect("write");
+
+        // Keep 5
+        let deleted = rotate_backups(backup_dir.path(), 5).expect("rotate should succeed");
+        assert_eq!(deleted, 0, "should delete nothing when under retention");
+    }
+
+    #[test]
+    fn test_rotate_backups_ignores_non_backup_files() {
+        let backup_dir = TempDir::new().expect("create temp dir");
+
+        // Create backup files and some non-backup files
+        fs::write(
+            backup_dir.path().join("gantry_board_20260101_000000.db"),
+            b"dummy",
+        )
+        .expect("write");
+        fs::write(
+            backup_dir.path().join("gantry_board_20260102_000000.db"),
+            b"dummy",
+        )
+        .expect("write");
+        fs::write(backup_dir.path().join("other_file.txt"), b"dummy").expect("write");
+        fs::write(backup_dir.path().join("README.md"), b"dummy").expect("write");
+
+        // Keep 1
+        let deleted = rotate_backups(backup_dir.path(), 1).expect("rotate should succeed");
+        assert_eq!(deleted, 1, "should only delete 1 backup file");
+
+        // Non-backup files should still exist
+        assert!(backup_dir.path().join("other_file.txt").exists());
+        assert!(backup_dir.path().join("README.md").exists());
+    }
+
+    #[test]
+    fn test_rotate_backups_handles_empty_dir() {
+        let backup_dir = TempDir::new().expect("create temp dir");
+
+        let deleted = rotate_backups(backup_dir.path(), 3).expect("rotate should succeed");
+        assert_eq!(deleted, 0);
+    }
+}

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -173,13 +173,28 @@ pub fn spawn_backup_task(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::setup_test_db;
     use std::fs;
     use tempfile::TempDir;
 
+    /// Create a file-based SQLite pool (VACUUM INTO requires a real file, not :memory:)
+    async fn setup_file_db() -> (TempDir, SqlitePool) {
+        let tmp = TempDir::new().expect("create temp dir");
+        let db_path = tmp.path().join("test.db");
+        let url = format!("sqlite:{}?mode=rwc", db_path.display());
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect(&url)
+            .await
+            .expect("create file-based test db");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+        (tmp, pool)
+    }
+
     #[tokio::test]
     async fn test_create_backup_creates_valid_sqlite_file() {
-        let pool = setup_test_db().await;
+        let (_db_dir, pool) = setup_file_db().await;
         let backup_dir = TempDir::new().expect("create temp dir");
 
         let backup_path = create_backup(&pool, backup_dir.path())
@@ -216,7 +231,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_backup_creates_backup_dir_if_missing() {
-        let pool = setup_test_db().await;
+        let (_db_dir, pool) = setup_file_db().await;
         let base_dir = TempDir::new().expect("create temp dir");
         let backup_dir = base_dir.path().join("nested").join("backups");
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_session_output_service;
 pub mod agent_session_service;
 pub mod authorization_service;
+pub mod backup_service;
 pub mod github_link_service;
 pub mod github_pr_service;
 pub mod github_sync_service;

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,76 @@
+# SQLite Backup and Restore
+
+## Overview
+
+Gantry Board automatically backs up its SQLite database on a configurable schedule. Backups use SQLite's `VACUUM INTO` command, which creates a consistent, standalone copy of the database even while the application is running.
+
+## Configuration
+
+Backup behavior is controlled via environment variables (or `config.toml`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GANTRY_BACKUP_ENABLED` | `true` | Enable/disable automated backups |
+| `GANTRY_BACKUP_DIR` | `./data/backups` | Directory for backup files |
+| `GANTRY_BACKUP_INTERVAL_SECS` | `86400` (24h) | Interval between backups |
+| `GANTRY_BACKUP_RETENTION_COUNT` | `7` | Number of backups to retain |
+
+## Automated Backups
+
+When `GANTRY_BACKUP_ENABLED=true` (the default), the application:
+
+1. Spawns a background task that runs every `GANTRY_BACKUP_INTERVAL_SECS` seconds
+2. Flushes the WAL with `PRAGMA wal_checkpoint(TRUNCATE)`
+3. Creates a backup with `VACUUM INTO` at `<backup_dir>/gantry_board_YYYYMMDD_HHMMSS.db`
+4. Rotates old backups, keeping only `GANTRY_BACKUP_RETENTION_COUNT` most recent files
+
+## Manual Backup
+
+To create a manual backup using the task runner:
+
+```bash
+task db:backup
+```
+
+Or using `sqlite3` directly:
+
+```bash
+sqlite3 ./data/gantry_board.db "VACUUM INTO './data/backups/manual_backup.db';"
+```
+
+## Restore from Backup
+
+To restore from a backup:
+
+1. Stop the Gantry Board application
+2. Replace the database file with the backup:
+
+```bash
+# Stop the application first
+cp ./data/gantry_board.db ./data/gantry_board.db.old  # keep current as safety net
+cp ./data/backups/gantry_board_20260221_120000.db ./data/gantry_board.db
+```
+
+3. Remove any WAL and SHM files:
+
+```bash
+rm -f ./data/gantry_board.db-wal ./data/gantry_board.db-shm
+```
+
+4. Restart the application
+
+## Backup File Format
+
+- Backup files are named `gantry_board_YYYYMMDD_HHMMSS.db`
+- Each backup is a standalone SQLite database file
+- Backups include all data and schema but exclude the WAL/SHM files
+- Backups can be opened independently with any SQLite client for inspection
+
+## Monitoring
+
+The application logs backup events at the following levels:
+
+- `INFO`: Successful backup creation (includes file size and duration)
+- `INFO`: Backup rotation (number of old files deleted)
+- `WARN`: Rotation failures (non-fatal)
+- `ERROR`: Backup creation failures

--- a/taskfiles/db.yml
+++ b/taskfiles/db.yml
@@ -23,3 +23,14 @@ tasks:
       - sqlx database drop -y
       - sqlx database create
       - sqlx migrate run
+
+  backup:
+    desc: Create a manual SQLite backup
+    cmds:
+      - |
+        mkdir -p ./data/backups
+        BACKUP_FILE="./data/backups/gantry_board_$(date +%Y%m%d_%H%M%S).db"
+        sqlite3 ./data/gantry_board.db "PRAGMA wal_checkpoint(TRUNCATE);"
+        sqlite3 ./data/gantry_board.db "VACUUM INTO '${BACKUP_FILE}';"
+        echo "Backup created: ${BACKUP_FILE}"
+        ls -lh "${BACKUP_FILE}"


### PR DESCRIPTION
## Summary
- #281: Recover orphaned agent sessions on startup (running/paused/pending → failed)
- #282: Automated SQLite backup with VACUUM INTO and rotation

### Details
- `recover_orphaned_sessions()` runs after pool init, before orchestrator
- Backup service with configurable interval, directory, and retention count
- Config: `GANTRY_BACKUP_ENABLED`, `GANTRY_BACKUP_DIR`, `GANTRY_BACKUP_INTERVAL_SECS`, `GANTRY_BACKUP_RETENTION_COUNT`
- `task db:backup` for manual backup
- `docs/BACKUP.md` with procedures

## Test plan
- [x] Orphaned sessions transition to failed with finished_at
- [x] Recovery is idempotent
- [x] Backup creates valid SQLite file
- [x] Rotation keeps only retention_count files
- [x] All existing tests pass

Closes #281, #282