### PR TITLE
refactor: ♻️ project list and task detail page routing

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,10 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppRoutes } from './App';
 import * as authApi from './api/generated/endpoints/auth/auth';
-import * as membersApi from './api/generated/endpoints/project-members/project-members';
 import * as projectsApi from './api/generated/endpoints/projects/projects';
-import * as tasksApi from './api/generated/endpoints/tasks/tasks';
-import * as usersApi from './api/generated/endpoints/users/users';
 import { useAuthStore } from './stores/authStore';
 import { useUiStore } from './stores/uiStore';
 
@@ -28,25 +25,7 @@ vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useUpdateProject: vi.fn(),
   useDeleteProject: vi.fn(),
   getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
-}));
-
-vi.mock('./api/generated/endpoints/project-members/project-members', () => ({
-  useListMembers: vi.fn(),
-  useAddMember: vi.fn(),
-  useUpdateMember: vi.fn(),
-  useRemoveMember: vi.fn(),
-  getListMembersQueryKey: vi.fn(() => ['/api/projects/members']),
-}));
-
-vi.mock('./api/generated/endpoints/users/users', () => ({
-  useSearchUsers: vi.fn(),
-}));
-
-vi.mock('./api/generated/endpoints/tasks/tasks', () => ({
-  useListTasks: vi.fn(),
-  useUpdateTask: vi.fn(),
-  useCreateTask: vi.fn(),
-  getListTasksQueryKey: vi.fn(() => ['/api/tasks']),
+  getGetProjectQueryKey: vi.fn(() => ['/api/projects']),
 }));
 
 vi.mock('./api/generated/endpoints/auth/auth', () => ({
@@ -78,80 +57,32 @@ const renderWithProviders = (ui: React.ReactElement, { route = '/' } = {}) => {
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset auth store
     useAuthStore.setState({
       user: null,
       isAuthenticated: false,
       isLoading: false,
     });
-    // Mock useMe to not fetch by default
     vi.mocked(authApi.useMe).mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: false,
     } as ReturnType<typeof authApi.useMe>);
-    // Mock useLogout
     vi.mocked(authApi.useLogout).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof authApi.useLogout>);
-    // Mock useLogin
     vi.mocked(authApi.useLogin).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof authApi.useLogin>);
-    // Mock useRegister
     vi.mocked(authApi.useRegister).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof authApi.useRegister>);
-    // Mock useCreateProject
     vi.mocked(projectsApi.useCreateProject).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof projectsApi.useCreateProject>);
-    // Mock useCreateTask
-    vi.mocked(tasksApi.useCreateTask).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof tasksApi.useCreateTask>);
-    // Mock project detail hooks
-    vi.mocked(projectsApi.useGetProject).mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: false,
-    } as unknown as ReturnType<typeof projectsApi.useGetProject>);
-    vi.mocked(projectsApi.useUpdateProject).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof projectsApi.useUpdateProject>);
-    vi.mocked(projectsApi.useDeleteProject).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof projectsApi.useDeleteProject>);
-    // Mock member hooks
-    vi.mocked(membersApi.useListMembers).mockReturnValue({
-      data: [],
-      isLoading: false,
-    } as unknown as ReturnType<typeof membersApi.useListMembers>);
-    vi.mocked(membersApi.useAddMember).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof membersApi.useAddMember>);
-    vi.mocked(membersApi.useUpdateMember).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof membersApi.useUpdateMember>);
-    vi.mocked(membersApi.useRemoveMember).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof membersApi.useRemoveMember>);
-    // Mock user search
-    vi.mocked(usersApi.useSearchUsers).mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof usersApi.useSearchUsers>);
-    // Reset ui store
     useUiStore.setState({
       isTaskModalOpen: false,
       defaultStatus: null,
@@ -170,7 +101,6 @@ describe('App', () => {
 
       renderWithProviders(<AppRoutes />);
 
-      // Should show login page
       expect(screen.getByText('Sign in to Gantry Board')).toBeInTheDocument();
     });
   });
@@ -212,7 +142,7 @@ describe('App', () => {
       expect(screen.getByText('Gantry Board')).toBeInTheDocument();
     });
 
-    it('renders project selector', () => {
+    it('renders project list page with project cards', () => {
       vi.mocked(projectsApi.useListProjects).mockReturnValue({
         data: {
           data: [
@@ -228,12 +158,11 @@ describe('App', () => {
 
       renderWithProviders(<AppRoutes />);
 
-      expect(screen.getByLabelText('Project:')).toBeInTheDocument();
       expect(screen.getByText('Project One')).toBeInTheDocument();
       expect(screen.getByText('Project Two')).toBeInTheDocument();
     });
 
-    it('shows placeholder when no project is selected', () => {
+    it('shows empty state when no projects', () => {
       vi.mocked(projectsApi.useListProjects).mockReturnValue({
         data: { data: [], total: 0, limit: 50, offset: 0 },
         isLoading: false,
@@ -241,7 +170,7 @@ describe('App', () => {
 
       renderWithProviders(<AppRoutes />);
 
-      expect(screen.getByText('Select a project to view its tasks')).toBeInTheDocument();
+      expect(screen.getByText(/no projects/i)).toBeInTheDocument();
     });
 
     it('shows user name and logout button', () => {
@@ -253,7 +182,7 @@ describe('App', () => {
       renderWithProviders(<AppRoutes />);
 
       expect(screen.getByText('Test User')).toBeInTheDocument();
-      expect(screen.getByText('Logout')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
     });
 
     it('renders new project button', () => {
@@ -275,7 +204,7 @@ describe('App', () => {
       } as ReturnType<typeof projectsApi.useListProjects>);
 
       renderWithProviders(<AppRoutes />);
-      await user.click(screen.getByRole('button', { name: /new project/i }));
+      await user.click(screen.getAllByRole('button', { name: /new project/i })[0]);
 
       expect(useUiStore.getState().isProjectModalOpen).toBe(true);
     });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,158 +1,25 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { FolderPlus, LogOut, MessageSquare, Settings, Users } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
-import { useLogout, useMe } from '@/api/generated/endpoints/auth/auth';
-import { useListProjects } from '@/api/generated/endpoints/projects/projects';
-import { KanbanBoard } from '@/components/board';
+import { useMe } from '@/api/generated/endpoints/auth/auth';
+import { ProjectBoardPage } from '@/components/board';
 import { ErrorBoundary, ToastContainer } from '@/components/common';
 import {
+  AppLayout,
   GuestRoute,
   InvitationAcceptPage,
   LoginPage,
   ProtectedRoute,
   RegisterPage,
 } from '@/components/layout';
-import {
-  ProjectChatPanel,
-  ProjectCreateDialog,
-  ProjectMembersPanel,
-  ProjectSettingsModal,
-} from '@/components/project';
-import { TaskCreateDialog, TaskDetailModal } from '@/components/task';
-import { connectEventSource } from '@/hooks/useEventSource';
+import { ProjectCreateDialog, ProjectListPage } from '@/components/project';
+import { TaskDetailPage } from '@/components/task';
 import { useAuthStore } from '@/stores/authStore';
-import { useUiStore } from '@/stores/uiStore';
-
-function KanbanApp() {
-  const queryClient = useQueryClient();
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const { data: projects, isLoading: projectsLoading } = useListProjects();
-  const user = useAuthStore((state) => state.user);
-  const logout = useLogout();
-  const setUser = useAuthStore((state) => state.setUser);
-  const openProjectModal = useUiStore((s) => s.openProjectModal);
-  const openProjectSettings = useUiStore((s) => s.openProjectSettings);
-  const openProjectMembers = useUiStore((s) => s.openProjectMembers);
-  const openProjectChat = useUiStore((s) => s.openProjectChat);
-
-  // Connect to real-time updates (WebSocket with SSE fallback)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: queryClient is stable from provider
-  useEffect(() => {
-    const cleanup = connectEventSource(queryClient);
-    return cleanup;
-  }, []);
-
-  const handleLogout = async () => {
-    try {
-      await logout.mutateAsync();
-      setUser(null);
-    } catch {
-      // If logout fails on server, still clear local state
-      setUser(null);
-    }
-  };
-
-  return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="bg-white shadow">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-          <h1 className="text-2xl font-bold text-gray-900">Gantry Board</h1>
-          <div className="flex items-center gap-4">
-            <label htmlFor="project-select" className="text-sm font-medium text-gray-700">
-              Project:
-            </label>
-            <select
-              id="project-select"
-              value={selectedProjectId ?? ''}
-              onChange={(e) => setSelectedProjectId(e.target.value || null)}
-              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              disabled={projectsLoading}
-            >
-              <option value="">Select a project...</option>
-              {projects?.data?.map((project) => (
-                <option key={project.id} value={project.id}>
-                  {project.name}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              onClick={openProjectModal}
-              className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
-            >
-              <FolderPlus className="h-4 w-4" /> New Project
-            </button>
-            {selectedProjectId && (
-              <>
-                <button
-                  type="button"
-                  onClick={openProjectSettings}
-                  className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-                >
-                  <Settings className="h-4 w-4" /> Settings
-                </button>
-                <button
-                  type="button"
-                  onClick={openProjectMembers}
-                  className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-                >
-                  <Users className="h-4 w-4" /> Members
-                </button>
-                <button
-                  type="button"
-                  onClick={openProjectChat}
-                  className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-                >
-                  <MessageSquare className="h-4 w-4" /> Project Chat
-                </button>
-              </>
-            )}
-
-            <div className="flex items-center gap-2 border-l pl-4">
-              <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
-              <button
-                type="button"
-                onClick={handleLogout}
-                disabled={logout.isPending}
-                className="flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
-              >
-                <LogOut className="h-4 w-4" /> Logout
-              </button>
-            </div>
-          </div>
-        </div>
-      </header>
-      <main>
-        {selectedProjectId ? (
-          <KanbanBoard projectId={selectedProjectId} />
-        ) : (
-          <div className="flex items-center justify-center p-12">
-            <p className="text-gray-500">Select a project to view its tasks</p>
-          </div>
-        )}
-      </main>
-      <ProjectCreateDialog />
-      {selectedProjectId && <TaskCreateDialog projectId={selectedProjectId} />}
-      <TaskDetailModal />
-      {selectedProjectId && (
-        <ProjectSettingsModal
-          projectId={selectedProjectId}
-          onProjectDeleted={() => setSelectedProjectId(null)}
-        />
-      )}
-      {selectedProjectId && <ProjectMembersPanel projectId={selectedProjectId} />}
-      {selectedProjectId && <ProjectChatPanel projectId={selectedProjectId} />}
-    </div>
-  );
-}
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const setUser = useAuthStore((state) => state.setUser);
   const setLoading = useAuthStore((state) => state.setLoading);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  // Only fetch /me if we think we're authenticated (from persisted state)
   const {
     data: user,
     isLoading,
@@ -167,10 +34,8 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isAuthenticated) {
       if (isLoading) {
-        // Keep loading while /me query is in-flight
         setLoading(true);
       } else if (isError) {
-        // Session expired or invalid
         setUser(null);
       } else if (user) {
         setUser(user);
@@ -207,15 +72,19 @@ export function AppRoutes() {
         />
         <Route path="/invite/:token" element={<InvitationAcceptPage />} />
         <Route
-          path="/"
           element={
             <ProtectedRoute>
-              <KanbanApp />
+              <AppLayout />
             </ProtectedRoute>
           }
-        />
+        >
+          <Route index element={<ProjectListPage />} />
+          <Route path="projects/:projectId" element={<ProjectBoardPage />} />
+          <Route path="projects/:projectId/tasks/:taskId" element={<TaskDetailPage />} />
+        </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      <ProjectCreateDialog />
     </AuthProvider>
   );
 }

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -1,9 +1,9 @@
 import { MessageSquare, Settings, Users } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { KanbanBoard } from './KanbanBoard';
 import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
 import { TaskCreateDialog } from '@/components/task';
 import { useUiStore } from '@/stores/uiStore';
+import { KanbanBoard } from './KanbanBoard';
 
 export function ProjectBoardPage() {
   const { projectId } = useParams<{ projectId: string }>();

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -1,0 +1,49 @@
+import { MessageSquare, Settings, Users } from 'lucide-react';
+import { useParams } from 'react-router-dom';
+import { KanbanBoard } from '@/components/board';
+import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
+import { TaskCreateDialog, TaskDetailModal } from '@/components/task';
+import { useUiStore } from '@/stores/uiStore';
+
+export function ProjectBoardPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const openProjectSettings = useUiStore((s) => s.openProjectSettings);
+  const openProjectMembers = useUiStore((s) => s.openProjectMembers);
+  const openProjectChat = useUiStore((s) => s.openProjectChat);
+
+  if (!projectId) return null;
+
+  return (
+    <>
+      <div className="mx-auto flex max-w-7xl items-center gap-3 px-4 pt-4">
+        <button
+          type="button"
+          onClick={openProjectSettings}
+          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          <Settings className="h-4 w-4" /> Settings
+        </button>
+        <button
+          type="button"
+          onClick={openProjectMembers}
+          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          <Users className="h-4 w-4" /> Members
+        </button>
+        <button
+          type="button"
+          onClick={openProjectChat}
+          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          <MessageSquare className="h-4 w-4" /> Project Chat
+        </button>
+      </div>
+      <KanbanBoard projectId={projectId} />
+      <TaskCreateDialog projectId={projectId} />
+      <TaskDetailModal />
+      <ProjectSettingsModal projectId={projectId} onProjectDeleted={() => {}} />
+      <ProjectMembersPanel projectId={projectId} />
+      <ProjectChatPanel projectId={projectId} />
+    </>
+  );
+}

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -1,12 +1,13 @@
 import { MessageSquare, Settings, Users } from 'lucide-react';
-import { useParams } from 'react-router-dom';
-import { KanbanBoard } from '@/components/board';
+import { useNavigate, useParams } from 'react-router-dom';
+import { KanbanBoard } from './KanbanBoard';
 import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
-import { TaskCreateDialog, TaskDetailModal } from '@/components/task';
+import { TaskCreateDialog } from '@/components/task';
 import { useUiStore } from '@/stores/uiStore';
 
 export function ProjectBoardPage() {
   const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
   const openProjectSettings = useUiStore((s) => s.openProjectSettings);
   const openProjectMembers = useUiStore((s) => s.openProjectMembers);
   const openProjectChat = useUiStore((s) => s.openProjectChat);
@@ -40,8 +41,7 @@ export function ProjectBoardPage() {
       </div>
       <KanbanBoard projectId={projectId} />
       <TaskCreateDialog projectId={projectId} />
-      <TaskDetailModal />
-      <ProjectSettingsModal projectId={projectId} onProjectDeleted={() => {}} />
+      <ProjectSettingsModal projectId={projectId} onProjectDeleted={() => navigate('/')} />
       <ProjectMembersPanel projectId={projectId} />
       <ProjectChatPanel projectId={projectId} />
     </>

--- a/frontend/src/components/board/index.ts
+++ b/frontend/src/components/board/index.ts
@@ -1,4 +1,5 @@
 export { KanbanBoard } from './KanbanBoard';
 export { KanbanColumn } from './KanbanColumn';
+export { ProjectBoardPage } from './ProjectBoardPage';
 export { TaskCard } from './TaskCard';
 export { TaskFilterBar } from './TaskFilterBar';

--- a/frontend/src/components/layout/AppLayout.test.tsx
+++ b/frontend/src/components/layout/AppLayout.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from '@/stores/authStore';
@@ -19,8 +18,7 @@ vi.mock('@/api/generated/endpoints/auth/auth', () => ({
   useLogout: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (route = '/') => {
   const queryClient = createQueryClient();

--- a/frontend/src/components/layout/AppLayout.test.tsx
+++ b/frontend/src/components/layout/AppLayout.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { useAuthStore } from '@/stores/authStore';
+import { AppLayout } from './AppLayout';
+
+// Mock EventSource for SSE
+class MockEventSource {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  close() {}
+  addEventListener() {}
+}
+vi.stubGlobal('EventSource', MockEventSource);
+
+vi.mock('@/api/generated/endpoints/auth/auth', () => ({
+  useLogout: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (route = '/') => {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route index element={<div>Index Page</div>} />
+            <Route path="projects/:projectId" element={<div>Board Page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe('AppLayout', () => {
+  it('renders header with logo', () => {
+    useAuthStore.setState({
+      user: { id: 'u1', name: 'Alice', email: 'a@b.com', created_at: '', updated_at: '' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    renderWithProviders();
+
+    expect(screen.getByText('Gantry Board')).toBeInTheDocument();
+  });
+
+  it('renders user name', () => {
+    useAuthStore.setState({
+      user: { id: 'u1', name: 'Alice', email: 'a@b.com', created_at: '', updated_at: '' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    renderWithProviders();
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('renders outlet content', () => {
+    useAuthStore.setState({
+      user: { id: 'u1', name: 'Alice', email: 'a@b.com', created_at: '', updated_at: '' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    renderWithProviders();
+
+    expect(screen.getByText('Index Page')).toBeInTheDocument();
+  });
+
+  it('renders logout button', () => {
+    useAuthStore.setState({
+      user: { id: 'u1', name: 'Alice', email: 'a@b.com', created_at: '', updated_at: '' },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    renderWithProviders();
+
+    expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,56 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { LogOut } from 'lucide-react';
+import { useEffect } from 'react';
+import { Link, Outlet } from 'react-router-dom';
+import { useLogout } from '@/api/generated/endpoints/auth/auth';
+import { connectEventSource } from '@/hooks/useEventSource';
+import { useAuthStore } from '@/stores/authStore';
+
+export function AppLayout() {
+  const queryClient = useQueryClient();
+  const user = useAuthStore((state) => state.user);
+  const logout = useLogout();
+  const setUser = useAuthStore((state) => state.setUser);
+
+  // Connect to real-time updates (WebSocket with SSE fallback)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: queryClient is stable from provider
+  useEffect(() => {
+    const cleanup = connectEventSource(queryClient);
+    return cleanup;
+  }, []);
+
+  const handleLogout = async () => {
+    try {
+      await logout.mutateAsync();
+      setUser(null);
+    } catch {
+      setUser(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-white shadow">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+          <Link to="/" className="text-2xl font-bold text-gray-900 hover:text-gray-700">
+            Gantry Board
+          </Link>
+          <div className="flex items-center gap-2 border-l pl-4">
+            <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
+            <button
+              type="button"
+              onClick={handleLogout}
+              disabled={logout.isPending}
+              className="flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+            >
+              <LogOut className="h-4 w-4" /> Logout
+            </button>
+          </div>
+        </div>
+      </header>
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,3 +1,4 @@
+export { AppLayout } from './AppLayout';
 export { GuestRoute } from './GuestRoute';
 export { InvitationAcceptPage } from './InvitationAcceptPage';
 export { LoginPage } from './LoginPage';

--- a/frontend/src/components/project/ProjectCard.test.tsx
+++ b/frontend/src/components/project/ProjectCard.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { ProjectCard } from './ProjectCard';
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('ProjectCard', () => {
+  it('renders project name', () => {
+    renderWithRouter(
+      <ProjectCard
+        project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }}
+      />,
+    );
+
+    expect(screen.getByText('My Project')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    renderWithRouter(
+      <ProjectCard
+        project={{
+          id: 'p1',
+          name: 'My Project',
+          description: 'A great project',
+          created_at: '',
+          updated_at: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('A great project')).toBeInTheDocument();
+  });
+
+  it('links to project board', () => {
+    renderWithRouter(
+      <ProjectCard
+        project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }}
+      />,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/projects/p1');
+  });
+});

--- a/frontend/src/components/project/ProjectCard.test.tsx
+++ b/frontend/src/components/project/ProjectCard.test.tsx
@@ -3,15 +3,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { ProjectCard } from './ProjectCard';
 
-const renderWithRouter = (ui: React.ReactElement) =>
-  render(<MemoryRouter>{ui}</MemoryRouter>);
+const renderWithRouter = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
 describe('ProjectCard', () => {
   it('renders project name', () => {
     renderWithRouter(
-      <ProjectCard
-        project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }}
-      />,
+      <ProjectCard project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }} />,
     );
 
     expect(screen.getByText('My Project')).toBeInTheDocument();
@@ -35,9 +32,7 @@ describe('ProjectCard', () => {
 
   it('links to project board', () => {
     renderWithRouter(
-      <ProjectCard
-        project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }}
-      />,
+      <ProjectCard project={{ id: 'p1', name: 'My Project', created_at: '', updated_at: '' }} />,
     );
 
     const link = screen.getByRole('link');

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -1,0 +1,34 @@
+import { Settings } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { Project } from '@/api/generated/model';
+
+interface ProjectCardProps {
+  project: Project;
+  onSettings?: (projectId: string) => void;
+}
+
+export function ProjectCard({ project, onSettings }: ProjectCardProps) {
+  return (
+    <div className="group relative rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
+      <Link to={`/projects/${project.id}`} className="block">
+        <h3 className="text-lg font-semibold text-gray-900">{project.name}</h3>
+        {project.description && (
+          <p className="mt-1 line-clamp-2 text-sm text-gray-500">{project.description}</p>
+        )}
+      </Link>
+      {onSettings && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSettings(project.id);
+          }}
+          className="absolute right-3 top-3 rounded p-1 text-gray-400 opacity-0 hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
+          aria-label="Project settings"
+        >
+          <Settings className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/project/ProjectListPage.test.tsx
+++ b/frontend/src/components/project/ProjectListPage.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import * as projectsApi from '@/api/generated/endpoints/projects/projects';
-import { useUiStore } from '@/stores/uiStore';
 import { ProjectListPage } from './ProjectListPage';
 
 vi.mock('@/api/generated/endpoints/projects/projects', () => ({
@@ -12,8 +11,7 @@ vi.mock('@/api/generated/endpoints/projects/projects', () => ({
   getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
 }));
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (ui: React.ReactElement) =>
   render(
@@ -49,7 +47,13 @@ describe('ProjectListPage', () => {
     vi.mocked(projectsApi.useListProjects).mockReturnValue({
       data: {
         data: [
-          { id: 'p1', name: 'Project Alpha', description: 'Desc A', created_at: '', updated_at: '' },
+          {
+            id: 'p1',
+            name: 'Project Alpha',
+            description: 'Desc A',
+            created_at: '',
+            updated_at: '',
+          },
           { id: 'p2', name: 'Project Beta', created_at: '', updated_at: '' },
         ],
         total: 2,

--- a/frontend/src/components/project/ProjectListPage.test.tsx
+++ b/frontend/src/components/project/ProjectListPage.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import * as projectsApi from '@/api/generated/endpoints/projects/projects';
+import { useUiStore } from '@/stores/uiStore';
+import { ProjectListPage } from './ProjectListPage';
+
+vi.mock('@/api/generated/endpoints/projects/projects', () => ({
+  useListProjects: vi.fn(),
+  useCreateProject: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  getListProjectsQueryKey: vi.fn(() => ['/api/projects']),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+describe('ProjectListPage', () => {
+  it('shows loading state', () => {
+    vi.mocked(projectsApi.useListProjects).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof projectsApi.useListProjects>);
+
+    renderWithProviders(<ProjectListPage />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no projects', () => {
+    vi.mocked(projectsApi.useListProjects).mockReturnValue({
+      data: { data: [], total: 0, limit: 50, offset: 0 },
+      isLoading: false,
+    } as ReturnType<typeof projectsApi.useListProjects>);
+
+    renderWithProviders(<ProjectListPage />);
+
+    expect(screen.getByText(/no projects/i)).toBeInTheDocument();
+  });
+
+  it('renders project cards', () => {
+    vi.mocked(projectsApi.useListProjects).mockReturnValue({
+      data: {
+        data: [
+          { id: 'p1', name: 'Project Alpha', description: 'Desc A', created_at: '', updated_at: '' },
+          { id: 'p2', name: 'Project Beta', created_at: '', updated_at: '' },
+        ],
+        total: 2,
+        limit: 50,
+        offset: 0,
+      },
+      isLoading: false,
+    } as ReturnType<typeof projectsApi.useListProjects>);
+
+    renderWithProviders(<ProjectListPage />);
+
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Project Beta')).toBeInTheDocument();
+  });
+
+  it('has a new project button', () => {
+    vi.mocked(projectsApi.useListProjects).mockReturnValue({
+      data: { data: [], total: 0, limit: 50, offset: 0 },
+      isLoading: false,
+    } as ReturnType<typeof projectsApi.useListProjects>);
+
+    renderWithProviders(<ProjectListPage />);
+
+    expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/project/ProjectListPage.tsx
+++ b/frontend/src/components/project/ProjectListPage.tsx
@@ -4,7 +4,7 @@ import { useUiStore } from '@/stores/uiStore';
 import { ProjectCard } from './ProjectCard';
 
 export function ProjectListPage() {
-  const { data: projectsResponse, isLoading } = useListProjects();
+  const { data: projectsResponse, isLoading, isError } = useListProjects();
   const openProjectModal = useUiStore((s) => s.openProjectModal);
   const projects = projectsResponse?.data;
 
@@ -12,6 +12,14 @@ export function ProjectListPage() {
     return (
       <div className="flex items-center justify-center p-12">
         <p className="text-gray-500">Loading projects...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <p className="text-red-500">Failed to load projects.</p>
       </div>
     );
   }

--- a/frontend/src/components/project/ProjectListPage.tsx
+++ b/frontend/src/components/project/ProjectListPage.tsx
@@ -1,0 +1,52 @@
+import { FolderPlus } from 'lucide-react';
+import { useListProjects } from '@/api/generated/endpoints/projects/projects';
+import { useUiStore } from '@/stores/uiStore';
+import { ProjectCard } from './ProjectCard';
+
+export function ProjectListPage() {
+  const { data: projectsResponse, isLoading } = useListProjects();
+  const openProjectModal = useUiStore((s) => s.openProjectModal);
+  const projects = projectsResponse?.data;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <p className="text-gray-500">Loading projects...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900">Projects</h2>
+        <button
+          type="button"
+          onClick={openProjectModal}
+          className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+        >
+          <FolderPlus className="h-4 w-4" /> New Project
+        </button>
+      </div>
+
+      {!projects || projects.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 py-16">
+          <p className="text-gray-500">No projects yet</p>
+          <button
+            type="button"
+            onClick={openProjectModal}
+            className="mt-4 flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          >
+            <FolderPlus className="h-4 w-4" /> Create your first project
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/project/index.ts
+++ b/frontend/src/components/project/index.ts
@@ -1,4 +1,6 @@
+export { ProjectCard } from './ProjectCard';
 export { ProjectChatPanel } from './ProjectChatPanel';
 export { ProjectCreateDialog } from './ProjectCreateDialog';
+export { ProjectListPage } from './ProjectListPage';
 export { ProjectMembersPanel } from './ProjectMembersPanel';
 export { ProjectSettingsModal } from './ProjectSettingsModal';

--- a/frontend/src/components/task/TaskDetailPage.test.tsx
+++ b/frontend/src/components/task/TaskDetailPage.test.tsx
@@ -2,7 +2,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import * as membersApi from '@/api/generated/endpoints/project-members/project-members';
 import * as tasksApi from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { TaskDetailPage } from './TaskDetailPage';
@@ -21,6 +20,9 @@ vi.mock('@/api/generated/endpoints/project-members/project-members', () => ({
 vi.mock('@/api/generated/endpoints/agent-sessions/agent-sessions', () => ({
   useListAgentSessions: vi.fn(() => ({ data: undefined })),
   useStartAgentSession: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useStopAgentSession: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useGetAgentSessionOutputs: vi.fn(() => ({ data: undefined })),
+  getListAgentSessionsQueryKey: vi.fn(() => ['/api/agent-sessions']),
 }));
 
 vi.mock('@/api/generated/endpoints/task-comments/task-comments', () => ({
@@ -40,8 +42,7 @@ vi.mock('@/api/generated/endpoints/worktrees/worktrees', () => ({
   getListWorktreesQueryKey: vi.fn(() => ['/api/worktrees']),
 }));
 
-const createQueryClient = () =>
-  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (taskId = 'task-1', projectId = 'proj-1') =>
   render(

--- a/frontend/src/components/task/TaskDetailPage.test.tsx
+++ b/frontend/src/components/task/TaskDetailPage.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import * as membersApi from '@/api/generated/endpoints/project-members/project-members';
+import * as tasksApi from '@/api/generated/endpoints/tasks/tasks';
+import { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { TaskDetailPage } from './TaskDetailPage';
+
+vi.mock('@/api/generated/endpoints/tasks/tasks', () => ({
+  useGetTask: vi.fn(),
+  useUpdateTask: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDeleteTask: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  getListTasksQueryKey: vi.fn(() => ['/api/tasks']),
+}));
+
+vi.mock('@/api/generated/endpoints/project-members/project-members', () => ({
+  useListMembers: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('@/api/generated/endpoints/agent-sessions/agent-sessions', () => ({
+  useListAgentSessions: vi.fn(() => ({ data: undefined })),
+  useStartAgentSession: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+vi.mock('@/api/generated/endpoints/task-comments/task-comments', () => ({
+  useListComments: vi.fn(() => ({ data: undefined })),
+  useCreateComment: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  getListCommentsQueryKey: vi.fn(() => ['/api/comments']),
+}));
+
+vi.mock('@/api/generated/endpoints/pull-requests/pull-requests', () => ({
+  useListPullRequests: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+
+vi.mock('@/api/generated/endpoints/worktrees/worktrees', () => ({
+  useListWorktrees: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useCreateWorktree: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDeleteWorktree: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  getListWorktreesQueryKey: vi.fn(() => ['/api/worktrees']),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const renderWithProviders = (taskId = 'task-1', projectId = 'proj-1') =>
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[`/projects/${projectId}/tasks/${taskId}`]}>
+        <Routes>
+          <Route path="projects/:projectId/tasks/:taskId" element={<TaskDetailPage />} />
+          <Route path="projects/:projectId" element={<div>Board Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+describe('TaskDetailPage', () => {
+  it('shows loading state', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as ReturnType<typeof tasksApi.useGetTask>);
+
+    renderWithProviders();
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof tasksApi.useGetTask>);
+
+    renderWithProviders();
+
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+  });
+
+  it('renders task title when loaded', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: {
+        id: 'task-1',
+        project_id: 'proj-1',
+        title: 'Fix the bug',
+        description: 'Detailed desc',
+        status: TaskStatus.todo,
+        priority: TaskPriority.high,
+        position: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof tasksApi.useGetTask>);
+
+    renderWithProviders();
+
+    expect(screen.getByText('Fix the bug')).toBeInTheDocument();
+  });
+
+  it('has a back to board link', () => {
+    vi.mocked(tasksApi.useGetTask).mockReturnValue({
+      data: {
+        id: 'task-1',
+        project_id: 'proj-1',
+        title: 'Fix the bug',
+        status: TaskStatus.todo,
+        priority: TaskPriority.high,
+        position: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof tasksApi.useGetTask>);
+
+    renderWithProviders();
+
+    const backLink = screen.getByRole('link', { name: /back to board/i });
+    expect(backLink).toHaveAttribute('href', '/projects/proj-1');
+  });
+});

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -1,0 +1,287 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft } from 'lucide-react';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
+import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
+import type { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { invalidateTasks } from '@/services/queryInvalidation';
+import { PullRequestList } from '../github/PullRequestList';
+import { WorktreePanel } from '../preview/WorktreePanel';
+import { TaskTimeline } from './TaskTimeline';
+
+export function TaskDetailPage() {
+  const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: task, isLoading, isError } = useGetTask(taskId ?? '');
+  const updateTask = useUpdateTask();
+  const deleteTask = useDeleteTask();
+  const { data: members } = useListMembers(projectId ?? '', {
+    query: { enabled: !!projectId },
+  });
+
+  const [editingField, setEditingField] = useState<'title' | 'description' | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startEditing = (field: 'title' | 'description', value: string) => {
+    setEditingField(field);
+    setEditValue(value);
+  };
+
+  const saveField = async (field: 'title' | 'description') => {
+    if (!taskId) return;
+    const trimmed = editValue.trim();
+    if (field === 'title' && !trimmed) {
+      setEditingField(null);
+      return;
+    }
+    const currentValue = field === 'title' ? task?.title : task?.description;
+    try {
+      if (trimmed !== (currentValue ?? '')) {
+        await updateTask.mutateAsync({
+          id: taskId,
+          data: { [field]: trimmed },
+        });
+      }
+    } catch {
+      setError(`Failed to update ${field}. Please try again.`);
+    } finally {
+      setEditingField(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!taskId) return;
+    try {
+      await deleteTask.mutateAsync({ id: taskId });
+      invalidateTasks(queryClient);
+      navigate(`/projects/${projectId}`);
+    } catch {
+      setError('Failed to delete task. Please try again.');
+    }
+  };
+
+  const handleAssigneeChange = async (value: string) => {
+    if (!taskId) return;
+    try {
+      await updateTask.mutateAsync({
+        id: taskId,
+        data: { assigned_to: value || null },
+      });
+    } catch {
+      setError('Failed to update assignee. Please try again.');
+    }
+  };
+
+  const handleSelectChange = async (
+    field: 'status' | 'priority',
+    value: TaskStatus | TaskPriority,
+  ) => {
+    if (!taskId) return;
+    try {
+      await updateTask.mutateAsync({
+        id: taskId,
+        data: { [field]: value },
+      });
+      invalidateTasks(queryClient);
+    } catch {
+      setError(`Failed to update ${field}. Please try again.`);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <p className="text-gray-500">Loading task...</p>
+      </div>
+    );
+  }
+
+  if (isError || !task) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-8">
+        <Link
+          to={`/projects/${projectId}`}
+          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to Board
+        </Link>
+        <p className="text-red-500">Failed to load task.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <Link
+        to={`/projects/${projectId}`}
+        className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to Board
+      </Link>
+
+      {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        {/* Main content */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Title */}
+          <div>
+            {editingField === 'title' ? (
+              <input
+                type="text"
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={() => saveField('title')}
+                className="w-full rounded border border-blue-300 px-3 py-2 text-xl font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                className="w-full cursor-pointer rounded px-2 py-1 text-left text-xl font-semibold text-gray-900 hover:bg-gray-100"
+                onClick={() => startEditing('title', task.title)}
+              >
+                {task.title}
+              </button>
+            )}
+          </div>
+
+          {/* Description */}
+          <div>
+            <h3 className="mb-1 text-sm font-medium text-gray-700">Description</h3>
+            {editingField === 'description' ? (
+              <textarea
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={() => saveField('description')}
+                rows={4}
+                className="w-full rounded border border-blue-300 px-3 py-2 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                className="w-full cursor-pointer rounded px-2 py-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                onClick={() => startEditing('description', task.description ?? '')}
+              >
+                {task.description || 'No description'}
+              </button>
+            )}
+          </div>
+
+          {/* Activity */}
+          <div className="border-t pt-6">
+            <h3 className="mb-3 text-sm font-medium text-gray-700">Activity</h3>
+            <TaskTimeline taskId={task.id} />
+          </div>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <div>
+            <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
+              Status
+            </label>
+            <select
+              id="task-status"
+              value={task.status}
+              onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="backlog">Backlog</option>
+              <option value="todo">To Do</option>
+              <option value="in_progress">In Progress</option>
+              <option value="in_review">In Review</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
+              Priority
+            </label>
+            <select
+              id="task-priority"
+              value={task.priority}
+              onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+              <option value="urgent">Urgent</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
+              Assignee
+            </label>
+            <select
+              id="task-assignee"
+              value={task.assigned_to ?? ''}
+              onChange={(e) => handleAssigneeChange(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="">Unassigned</option>
+              {members?.map((m) => (
+                <option key={m.user_id} value={m.user_id}>
+                  {m.user_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium text-gray-700">Worktrees</h3>
+            <WorktreePanel />
+          </div>
+
+          <div className="border-t pt-4">
+            <h3 className="mb-2 text-sm font-medium text-gray-700">Pull Requests</h3>
+            <PullRequestList taskId={task.id} />
+          </div>
+
+          <div className="border-t pt-4">
+            {showDeleteConfirm ? (
+              <div className="rounded-md bg-red-50 p-3">
+                <p className="mb-2 text-sm text-red-700">
+                  Are you sure you want to delete this task?
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(false)}
+                    className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+                  >
+                    Confirm
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="w-full rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
+              >
+                Delete Task
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -3,7 +3,12 @@ import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
-import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
+import {
+  getGetTaskQueryKey,
+  useDeleteTask,
+  useGetTask,
+  useUpdateTask,
+} from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { PullRequestList } from '../github/PullRequestList';
@@ -46,6 +51,8 @@ export function TaskDetailPage() {
           id: taskId,
           data: { [field]: trimmed },
         });
+        queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
+        invalidateTasks(queryClient);
       }
     } catch {
       setError(`Failed to update ${field}. Please try again.`);
@@ -72,6 +79,8 @@ export function TaskDetailPage() {
         id: taskId,
         data: { assigned_to: value || null },
       });
+      queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
+      invalidateTasks(queryClient);
     } catch {
       setError('Failed to update assignee. Please try again.');
     }
@@ -87,6 +96,7 @@ export function TaskDetailPage() {
         id: taskId,
         data: { [field]: value },
       });
+      queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
       invalidateTasks(queryClient);
     } catch {
       setError(`Failed to update ${field}. Please try again.`);

--- a/frontend/src/components/task/index.ts
+++ b/frontend/src/components/task/index.ts
@@ -1,5 +1,6 @@
 export { TaskCreateDialog } from './TaskCreateDialog';
 export { TaskDetailModal } from './TaskDetailModal';
+export { TaskDetailPage } from './TaskDetailPage';
 export { TaskTimeline } from './TaskTimeline';
 export { TimelineAgentSessionItem } from './TimelineAgentSessionItem';
 export { TimelineCommentItem } from './TimelineCommentItem';


### PR DESCRIPTION
## Summary
Epic #312 Phase 2: Routing overhaul

- **Project list page** (#304): Display project card grid at `/`, shared `AppLayout` with header + `<Outlet />`
- **Task detail full page** (#308): Replace modal with URL-based navigation at `/projects/:projectId/tasks/:taskId`, 2-column layout (main + sidebar)

### New route structure
```
/                                    → ProjectListPage
/projects/:projectId                 → ProjectBoardPage (KanbanBoard)
/projects/:projectId/tasks/:taskId   → TaskDetailPage
/login, /register                    → GuestRoute wrapped
/invite/:token                       → InvitationAcceptPage
```

### New components
- `AppLayout` — shared header + Outlet
- `ProjectListPage` — project card grid
- `ProjectCard` — individual project card
- `ProjectBoardPage` — board view + settings/members/chat buttons
- `TaskDetailPage` — full-page task detail with sidebar

> Stacked PR: depends on #313

## Test plan
- [x] `/` displays project list
- [x] Clicking a project card navigates to `/projects/:id`
- [x] Clicking a task card navigates to `/projects/:id/tasks/:taskId`
- [x] Back button returns to board
- [x] All 385 tests pass