### PR TITLE
feat: 🌐 internationalize frontend with react-i18next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,10 +13,13 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.75.0",
         "@tanstack/react-query-devtools": "^5.75.0",
+        "i18next": "^25.8.13",
+        "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^0.575.0",
         "pino": "^10.3.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.4",
         "react-router-dom": "^7.13.0",
         "zustand": "^5.0.0"
       },
@@ -384,7 +387,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5675,6 +5677,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5718,6 +5729,46 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.13",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.13.tgz",
+      "integrity": "sha512-E0vzjBY1yM+nsFrtgkjLhST2NBkirkvOVoQa0MSldhsuZ3jUge7ZNpuwG0Cfc74zwo5ZwRzg3uOgT+McBn32iA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -7961,6 +8012,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.4.tgz",
+      "integrity": "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9285,7 +9363,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9385,6 +9463,15 @@
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/utility-types": {
       "version": "3.11.0",
@@ -9575,6 +9662,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,10 +21,13 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.75.0",
     "@tanstack/react-query-devtools": "^5.75.0",
+    "i18next": "^25.8.13",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^0.575.0",
     "pino": "^10.3.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-i18next": "^16.5.4",
     "react-router-dom": "^7.13.0",
     "zustand": "^5.0.0"
   },

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -18,25 +18,6 @@ class MockEventSource {
 }
 vi.stubGlobal('EventSource', MockEventSource);
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        'app.title': 'Gantry Board',
-        'auth.logout': 'Logout',
-        'auth.signInTo': 'Sign in to Gantry Board',
-        'project.projects': 'Projects',
-        'project.newProject': 'New Project',
-        'project.noProjects': 'No projects yet',
-        'project.createFirst': 'Create your first project',
-        'project.loadingProjects': 'Loading projects...',
-      };
-      return translations[key] ?? key;
-    },
-    i18n: { language: 'en', changeLanguage: vi.fn() },
-  }),
-}));
-
 vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
   useCreateProject: vi.fn(),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -18,6 +18,25 @@ class MockEventSource {
 }
 vi.stubGlobal('EventSource', MockEventSource);
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'app.title': 'Gantry Board',
+        'auth.logout': 'Logout',
+        'auth.signInTo': 'Sign in to Gantry Board',
+        'project.projects': 'Projects',
+        'project.newProject': 'New Project',
+        'project.noProjects': 'No projects yet',
+        'project.createFirst': 'Create your first project',
+        'project.loadingProjects': 'Loading projects...',
+      };
+      return translations[key] ?? key;
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}));
+
 vi.mock('./api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
   useCreateProject: vi.fn(),

--- a/frontend/src/components/agent/AgentOutputViewer.tsx
+++ b/frontend/src/components/agent/AgentOutputViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface AgentOutputViewerProps {
   lines: string[];
@@ -6,6 +7,7 @@ interface AgentOutputViewerProps {
 }
 
 export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewerProps) {
+  const { t } = useTranslation();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   const lineCount = lines.length;
@@ -18,11 +20,17 @@ export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewe
   }, [lineCount]);
 
   if (isLoading) {
-    return <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">Loading output...</div>;
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        {t('agent.loadingOutput')}
+      </div>
+    );
   }
 
   if (lines.length === 0) {
-    return <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">No output yet</div>;
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">{t('agent.noOutput')}</div>
+    );
   }
 
   return (

--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListAgentSessionsQueryKey,
   useGetAgentSessionOutputs,
@@ -30,6 +31,7 @@ const STATUS_COLORS: Record<AgentSessionStatus, string> = {
 const TERMINAL_STATUSES: AgentSessionStatus[] = ['completed', 'failed', 'cancelled'];
 
 export function AgentPanel({ taskId }: AgentPanelProps) {
+  const { t } = useTranslation();
   const [agentType, setAgentType] = useState<AgentType>('claude_code');
   const [prompt, setPrompt] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -108,7 +110,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
       setActiveSession(result.session.id);
       setPrompt('');
     } catch {
-      setError('Failed to start agent session. Please try again.');
+      setError(t('agent.startFailed'));
     }
   };
 
@@ -122,7 +124,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
       });
       reset();
     } catch {
-      setError('Failed to stop agent session. Please try again.');
+      setError(t('agent.stopFailed'));
     }
   };
 
@@ -136,7 +138,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
       });
       queryClient.invalidateQueries({ queryKey: getListAgentSessionsQueryKey(taskId) });
     } catch {
-      setError('Failed to pause agent session. Please try again.');
+      setError(t('agent.pauseFailed'));
     }
   };
 
@@ -150,7 +152,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
       });
       queryClient.invalidateQueries({ queryKey: getListAgentSessionsQueryKey(taskId) });
     } catch {
-      setError('Failed to resume agent session. Please try again.');
+      setError(t('agent.resumeFailed'));
     }
   };
 
@@ -177,12 +179,14 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600">
-                {activeSession.agent_type === 'claude_code' ? 'Claude Code' : 'Gemini CLI'}
+                {activeSession.agent_type === 'claude_code'
+                  ? t('agent.claudeCode')
+                  : t('agent.geminiCli')}
               </span>
               <span
                 className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[activeSession.status]}`}
               >
-                {activeSession.status}
+                {t(`agent.status.${activeSession.status}`)}
               </span>
             </div>
             {!TERMINAL_STATUSES.includes(activeSession.status) && (
@@ -194,7 +198,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                     disabled={pauseSession.isPending}
                     className="rounded-md bg-yellow-600 px-3 py-1.5 text-sm text-white hover:bg-yellow-700 disabled:opacity-50"
                   >
-                    Pause
+                    {t('agent.pause')}
                   </button>
                 )}
                 {activeSession.status === 'paused' && (
@@ -204,7 +208,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                     disabled={resumeSession.isPending}
                     className="rounded-md bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700 disabled:opacity-50"
                   >
-                    Resume
+                    {t('agent.resume')}
                   </button>
                 )}
                 <button
@@ -213,7 +217,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                   disabled={stopSession.isPending}
                   className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
                 >
-                  Stop
+                  {t('common.stop')}
                 </button>
               </div>
             )}
@@ -229,15 +233,17 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                 onClick={handleBackToInput}
                 className="text-sm text-blue-600 hover:text-blue-800"
               >
-                Back
+                {t('common.back')}
               </button>
               <span className="text-sm text-gray-600">
-                {viewingSession.agent_type === 'claude_code' ? 'Claude Code' : 'Gemini CLI'}
+                {viewingSession.agent_type === 'claude_code'
+                  ? t('agent.claudeCode')
+                  : t('agent.geminiCli')}
               </span>
               <span
                 className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[viewingSession.status]}`}
               >
-                {viewingSession.status}
+                {t(`agent.status.${viewingSession.status}`)}
               </span>
             </div>
           </div>
@@ -247,7 +253,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
         <div className="space-y-3">
           <div>
             <label htmlFor="agent-type-select" className="block text-sm font-medium text-gray-700">
-              Agent Type
+              {t('agent.agentType')}
             </label>
             <select
               id="agent-type-select"
@@ -255,8 +261,8 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               onChange={(e) => setAgentType(e.target.value as AgentType)}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
             >
-              <option value="claude_code">Claude Code</option>
-              <option value="gemini_cli">Gemini CLI</option>
+              <option value="claude_code">{t('agent.claudeCode')}</option>
+              <option value="gemini_cli">{t('agent.geminiCli')}</option>
             </select>
           </div>
           <div>
@@ -264,13 +270,13 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               htmlFor="agent-prompt-textarea"
               className="block text-sm font-medium text-gray-700"
             >
-              Prompt
+              {t('agent.prompt')}
             </label>
             <textarea
               id="agent-prompt-textarea"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              placeholder="Enter prompt for the agent..."
+              placeholder={t('agent.promptPlaceholder')}
               rows={3}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
@@ -281,11 +287,11 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
             disabled={!prompt.trim() || startSession.isPending}
             className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
           >
-            Start
+            {t('common.start')}
           </button>
           {pastSessions.length > 0 && (
             <div>
-              <h4 className="text-sm font-medium text-gray-700">Past Sessions</h4>
+              <h4 className="text-sm font-medium text-gray-700">{t('agent.pastSessions')}</h4>
               <div className="mt-1 space-y-1">
                 {pastSessions.map((session) => (
                   <button
@@ -298,7 +304,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[session.status]}`}
                     >
-                      {session.status}
+                      {t(`agent.status.${session.status}`)}
                     </span>
                   </button>
                 ))}

--- a/frontend/src/components/board/KanbanBoard.tsx
+++ b/frontend/src/components/board/KanbanBoard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@dnd-kit/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import {
   getListTasksQueryKey,
@@ -35,6 +36,7 @@ const COLUMN_ORDER: TaskStatus[] = [
 ];
 
 export function KanbanBoard({ projectId }: KanbanBoardProps) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const { data: tasksResponse, isLoading, error } = useListTasks({ project_id: projectId });
@@ -162,7 +164,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   if (isLoading) {
     return (
       <div data-testid="kanban-loading" className="flex items-center justify-center p-8">
-        <div className="text-gray-500">Loading tasks...</div>
+        <div className="text-gray-500">{t('board.loadingTasks')}</div>
       </div>
     );
   }
@@ -170,7 +172,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   if (error) {
     return (
       <div data-testid="kanban-error" className="flex items-center justify-center p-8">
-        <div className="text-red-500">Failed to load tasks</div>
+        <div className="text-red-500">{t('board.loadFailed')}</div>
       </div>
     );
   }

--- a/frontend/src/components/board/KanbanColumn.tsx
+++ b/frontend/src/components/board/KanbanColumn.tsx
@@ -1,5 +1,6 @@
 import { useDroppable } from '@dnd-kit/core';
 import { Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ProjectMember, Task } from '@/api/generated/model';
 import { TaskStatus } from '@/api/generated/model';
 import { useUiStore } from '@/stores/uiStore';
@@ -12,12 +13,12 @@ interface KanbanColumnProps {
   members?: ProjectMember[];
 }
 
-const statusLabels: Record<TaskStatus, string> = {
-  [TaskStatus.backlog]: 'Backlog',
-  [TaskStatus.todo]: 'To Do',
-  [TaskStatus.in_progress]: 'In Progress',
-  [TaskStatus.in_review]: 'In Review',
-  [TaskStatus.done]: 'Done',
+const statusLabelKeys: Record<TaskStatus, string> = {
+  [TaskStatus.backlog]: 'board.status.backlog',
+  [TaskStatus.todo]: 'board.status.todo',
+  [TaskStatus.in_progress]: 'board.status.in_progress',
+  [TaskStatus.in_review]: 'board.status.in_review',
+  [TaskStatus.done]: 'board.status.done',
 };
 
 const statusColors: Record<TaskStatus, { bg: string; badge: string }> = {
@@ -29,6 +30,7 @@ const statusColors: Record<TaskStatus, { bg: string; badge: string }> = {
 };
 
 export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanColumnProps) {
+  const { t } = useTranslation();
   const openTaskModal = useUiStore((s) => s.openTaskModal);
   const { setNodeRef, isOver } = useDroppable({
     id: status,
@@ -41,7 +43,7 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
       }`}
     >
       <div className="flex items-center justify-between p-3">
-        <h2 className="text-sm font-semibold text-gray-700">{statusLabels[status]}</h2>
+        <h2 className="text-sm font-semibold text-gray-700">{t(statusLabelKeys[status])}</h2>
         <span
           className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[status].badge}`}
         >
@@ -54,7 +56,7 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
             data-testid="column-empty"
             className="flex h-24 items-center justify-center rounded border-2 border-dashed border-gray-300 text-sm text-gray-400"
           >
-            No tasks
+            {t('board.noTasks')}
           </div>
         ) : (
           tasks.map((task) => (
@@ -73,7 +75,7 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
           onClick={() => openTaskModal(status)}
           className="flex w-full items-center justify-center gap-1 rounded-md py-1.5 text-sm text-gray-500 hover:bg-gray-200 hover:text-gray-700"
         >
-          <Plus className="h-4 w-4" /> Add Task
+          <Plus className="h-4 w-4" /> {t('board.addTask')}
         </button>
       </div>
     </div>

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -1,4 +1,5 @@
 import { MessageSquare, Settings, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
 import { TaskCreateDialog } from '@/components/task';
@@ -6,6 +7,7 @@ import { useUiStore } from '@/stores/uiStore';
 import { KanbanBoard } from './KanbanBoard';
 
 export function ProjectBoardPage() {
+  const { t } = useTranslation();
   const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
   const openProjectSettings = useUiStore((s) => s.openProjectSettings);
@@ -22,21 +24,21 @@ export function ProjectBoardPage() {
           onClick={openProjectSettings}
           className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
         >
-          <Settings className="h-4 w-4" /> Settings
+          <Settings className="h-4 w-4" /> {t('project.settings')}
         </button>
         <button
           type="button"
           onClick={openProjectMembers}
           className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
         >
-          <Users className="h-4 w-4" /> Members
+          <Users className="h-4 w-4" /> {t('members.members')}
         </button>
         <button
           type="button"
           onClick={openProjectChat}
           className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
         >
-          <MessageSquare className="h-4 w-4" /> Project Chat
+          <MessageSquare className="h-4 w-4" /> {t('chat.projectChat')}
         </button>
       </div>
       <KanbanBoard projectId={projectId} />

--- a/frontend/src/components/board/TaskFilterBar.tsx
+++ b/frontend/src/components/board/TaskFilterBar.tsx
@@ -1,5 +1,6 @@
 import { Search } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { ProjectMember } from '@/api/generated/model';
 import { TaskPriority } from '@/api/generated/model';
 import { useBoardStore } from '@/stores/boardStore';
@@ -8,14 +9,15 @@ interface TaskFilterBarProps {
   members?: ProjectMember[];
 }
 
-const priorityLabels: Record<TaskPriority, string> = {
-  [TaskPriority.low]: 'Low',
-  [TaskPriority.medium]: 'Medium',
-  [TaskPriority.high]: 'High',
-  [TaskPriority.urgent]: 'Urgent',
+const priorityLabelKeys: Record<TaskPriority, string> = {
+  [TaskPriority.low]: 'board.priorityLabel.low',
+  [TaskPriority.medium]: 'board.priorityLabel.medium',
+  [TaskPriority.high]: 'board.priorityLabel.high',
+  [TaskPriority.urgent]: 'board.priorityLabel.urgent',
 };
 
 export function TaskFilterBar({ members }: TaskFilterBarProps) {
+  const { t } = useTranslation();
   const searchText = useBoardStore((s) => s.searchText);
   const setSearchText = useBoardStore((s) => s.setSearchText);
   const assigneeFilter = useBoardStore((s) => s.assigneeFilter);
@@ -48,7 +50,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
         <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
         <input
           type="text"
-          placeholder="Search tasks..."
+          placeholder={t('board.searchPlaceholder')}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
           className="rounded-md border border-gray-300 py-1.5 pl-8 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
@@ -64,7 +66,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
           }}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
         >
-          Assignee
+          {t('board.assignee')}
         </button>
         {assigneeOpen && (
           <div
@@ -77,7 +79,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
                 checked={assigneeFilter.includes('unassigned')}
                 onChange={() => toggleAssignee('unassigned')}
               />
-              Unassigned
+              {t('common.unassigned')}
             </label>
             {members?.map((m) => (
               <label
@@ -105,7 +107,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
           }}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
         >
-          Priority
+          {t('board.priority')}
         </button>
         {priorityOpen && (
           <div
@@ -122,7 +124,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
                   checked={priorityFilter.includes(p)}
                   onChange={() => togglePriority(p)}
                 />
-                {priorityLabels[p]}
+                {t(priorityLabelKeys[p])}
               </label>
             ))}
           </div>
@@ -135,7 +137,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
           onClick={clearFilters}
           className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
         >
-          Clear all
+          {t('common.clearAll')}
         </button>
       )}
     </div>

--- a/frontend/src/components/common/CommentSection.tsx
+++ b/frontend/src/components/common/CommentSection.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListCommentsQueryKey,
   useCreateComment,
@@ -10,17 +11,20 @@ import {
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 
-function timeAgo(dateStr: string): string {
+function timeAgo(
+  dateStr: string,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
   const diffSec = Math.floor((now - then) / 1000);
-  if (diffSec < 60) return 'just now';
+  if (diffSec < 60) return t('common.timeAgo.justNow');
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffMin < 60) return t('common.timeAgo.minutesAgo', { count: diffMin });
   const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffHr < 24) return t('common.timeAgo.hoursAgo', { count: diffHr });
   const diffDay = Math.floor(diffHr / 24);
-  return `${diffDay}d ago`;
+  return t('common.timeAgo.daysAgo', { count: diffDay });
 }
 
 function CommentItem({
@@ -32,6 +36,7 @@ function CommentItem({
   taskId: string;
   isOwner: boolean;
 }) {
+  const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -61,7 +66,7 @@ function CommentItem({
       setEditing(false);
       invalidateComments();
     } catch {
-      addToast('error', 'Failed to update comment.');
+      addToast('error', t('comment.updateFailed'));
     }
   };
 
@@ -71,7 +76,7 @@ function CommentItem({
       setShowDeleteConfirm(false);
       invalidateComments();
     } catch {
-      addToast('error', 'Failed to delete comment.');
+      addToast('error', t('comment.deleteFailed'));
     }
   };
 
@@ -90,24 +95,24 @@ function CommentItem({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-gray-900">{comment.user_name}</span>
-          <span className="text-xs text-gray-500">{timeAgo(comment.created_at)}</span>
+          <span className="text-xs text-gray-500">{timeAgo(comment.created_at, t)}</span>
           {isOwner && !editing && !showDeleteConfirm && (
             <div className="ml-auto flex gap-1">
               <button
                 type="button"
-                aria-label="Edit"
+                aria-label={t('common.edit')}
                 onClick={handleEdit}
                 className="text-xs text-gray-400 hover:text-gray-600"
               >
-                Edit
+                {t('common.edit')}
               </button>
               <button
                 type="button"
-                aria-label="Delete"
+                aria-label={t('common.delete')}
                 onClick={() => setShowDeleteConfirm(true)}
                 className="text-xs text-gray-400 hover:text-red-600"
               >
-                Delete
+                {t('common.delete')}
               </button>
             </div>
           )}
@@ -126,33 +131,33 @@ function CommentItem({
                 onClick={handleSave}
                 className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
               >
-                Save
+                {t('common.save')}
               </button>
               <button
                 type="button"
                 onClick={() => setEditing(false)}
                 className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
               >
-                Cancel
+                {t('common.cancel')}
               </button>
             </div>
           </div>
         ) : showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">Delete this comment?</span>
+            <span className="text-xs text-red-700">{t('comment.deleteConfirm')}</span>
             <button
               type="button"
               onClick={handleDelete}
               className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
             >
-              Confirm
+              {t('common.confirm')}
             </button>
             <button
               type="button"
               onClick={() => setShowDeleteConfirm(false)}
               className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
           </div>
         ) : (
@@ -164,6 +169,7 @@ function CommentItem({
 }
 
 export function CommentSection({ taskId }: { taskId: string }) {
+  const { t } = useTranslation();
   const { data: comments, isLoading } = useListComments(taskId);
   const createComment = useCreateComment();
   const queryClient = useQueryClient();
@@ -179,14 +185,14 @@ export function CommentSection({ taskId }: { taskId: string }) {
       setNewComment('');
       queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
     } catch {
-      addToast('error', 'Failed to post comment.');
+      addToast('error', t('comment.postFailed'));
     }
   };
 
   return (
     <div>
       {isLoading ? (
-        <p className="text-sm text-gray-500">Loading comments...</p>
+        <p className="text-sm text-gray-500">{t('comment.loadingComments')}</p>
       ) : comments && comments.length > 0 ? (
         <div className="divide-y">
           {comments.map((c) => (
@@ -199,13 +205,13 @@ export function CommentSection({ taskId }: { taskId: string }) {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-gray-500">No comments yet.</p>
+        <p className="text-sm text-gray-500">{t('comment.noComments')}</p>
       )}
       <div className="mt-3 flex gap-2">
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
-          placeholder="Add a comment..."
+          placeholder={t('comment.addPlaceholder')}
           rows={2}
           className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
         />
@@ -215,7 +221,7 @@ export function CommentSection({ taskId }: { taskId: string }) {
           disabled={!newComment.trim() || createComment.isPending}
           className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          Post
+          {t('common.post')}
         </button>
       </div>
     </div>

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import type { ErrorInfo, ReactNode } from 'react';
 import { Component } from 'react';
+import i18n from '@/lib/i18n';
 import { logger } from '@/lib/logger';
 
 interface Props {
@@ -26,16 +27,16 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div className="flex min-h-screen items-center justify-center bg-gray-100">
           <div className="rounded-lg bg-white p-8 text-center shadow-lg">
-            <h1 className="mb-4 text-2xl font-bold text-gray-900">Something went wrong</h1>
-            <p className="mb-6 text-gray-600">
-              An unexpected error occurred. Please try reloading the page.
-            </p>
+            <h1 className="mb-4 text-2xl font-bold text-gray-900">
+              {i18n.t('error.somethingWrong')}
+            </h1>
+            <p className="mb-6 text-gray-600">{i18n.t('error.unexpectedError')}</p>
             <button
               type="button"
               onClick={() => window.location.reload()}
               className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
             >
-              Reload Page
+              {i18n.t('common.reloadPage')}
             </button>
           </div>
         </div>

--- a/frontend/src/components/common/LanguageSwitcher.test.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18n from 'i18next';
+import { describe, expect, it, vi } from 'vitest';
+import { LanguageSwitcher } from './LanguageSwitcher';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'language.en': 'English',
+        'language.ja': '日本語',
+      };
+      return translations[key] ?? key;
+    },
+    i18n: {
+      language: 'en',
+      changeLanguage: vi.fn(),
+    },
+  }),
+}));
+
+describe('LanguageSwitcher', () => {
+  it('renders a language select', () => {
+    render(<LanguageSwitcher />);
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+  });
+
+  it('displays available languages', () => {
+    render(<LanguageSwitcher />);
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('日本語')).toBeInTheDocument();
+  });
+
+  it('selects current language', () => {
+    render(<LanguageSwitcher />);
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('en');
+  });
+
+  it('calls changeLanguage when selection changes', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSwitcher />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'ja');
+
+    const { useTranslation } = await import('react-i18next');
+    expect(useTranslation().i18n.changeLanguage).toHaveBeenCalledWith('ja');
+  });
+});

--- a/frontend/src/components/common/LanguageSwitcher.test.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import i18n from 'i18next';
 import { describe, expect, it, vi } from 'vitest';
 import { LanguageSwitcher } from './LanguageSwitcher';
+
+const mockChangeLanguage = vi.fn();
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -15,7 +16,7 @@ vi.mock('react-i18next', () => ({
     },
     i18n: {
       language: 'en',
-      changeLanguage: vi.fn(),
+      changeLanguage: mockChangeLanguage,
     },
   }),
 }));
@@ -46,7 +47,6 @@ describe('LanguageSwitcher', () => {
     const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'ja');
 
-    const { useTranslation } = await import('react-i18next');
-    expect(useTranslation().i18n.changeLanguage).toHaveBeenCalledWith('ja');
+    expect(mockChangeLanguage).toHaveBeenCalledWith('ja');
   });
 });

--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+
+const LANGUAGES = [
+  { code: 'en', labelKey: 'language.en' },
+  { code: 'ja', labelKey: 'language.ja' },
+] as const;
+
+export function LanguageSwitcher() {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <select
+      value={i18n.language}
+      onChange={(e) => i18n.changeLanguage(e.target.value)}
+      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700"
+    >
+      {LANGUAGES.map((lang) => (
+        <option key={lang.code} value={lang.code}>
+          {t(lang.labelKey)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -10,8 +10,9 @@ export function LanguageSwitcher() {
 
   return (
     <select
-      value={i18n.language}
+      value={i18n.resolvedLanguage ?? i18n.language}
       onChange={(e) => i18n.changeLanguage(e.target.value)}
+      aria-label={t('language.switchLanguage')}
       className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700"
     >
       {LANGUAGES.map((lang) => (

--- a/frontend/src/components/common/ToastContainer.tsx
+++ b/frontend/src/components/common/ToastContainer.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useToastStore } from '@/stores/toastStore';
 
 const typeStyles = {
@@ -7,6 +8,7 @@ const typeStyles = {
 };
 
 export function ToastContainer() {
+  const { t } = useTranslation();
   const toasts = useToastStore((s) => s.toasts);
   const removeToast = useToastStore((s) => s.removeToast);
 
@@ -25,7 +27,7 @@ export function ToastContainer() {
           <button
             type="button"
             onClick={() => removeToast(toast.id)}
-            aria-label="Dismiss"
+            aria-label={t('common.dismiss')}
             className="ml-2 text-lg leading-none opacity-60 hover:opacity-100"
           >
             &times;

--- a/frontend/src/components/github/GitHubLinkSettings.tsx
+++ b/frontend/src/components/github/GitHubLinkSettings.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getGetGithubLinkQueryKey,
   useCreateGithubLink,
@@ -10,6 +11,7 @@ import {
 import { useToastStore } from '@/stores/toastStore';
 
 export function GitHubLinkSettings({ projectId }: { projectId: string }) {
+  const { t } = useTranslation();
   const { data: link, isLoading, isError } = useGetGithubLink(projectId);
   const createLink = useCreateGithubLink();
   const deleteLink = useDeleteGithubLink();
@@ -33,9 +35,9 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
       setRepoOwner('');
       setRepoName('');
       await invalidate();
-      addToast('success', 'GitHub repository linked.');
+      addToast('success', t('github.linked'));
     } catch {
-      addToast('error', 'Failed to link repository.');
+      addToast('error', t('github.linkFailed'));
     }
   };
 
@@ -43,9 +45,9 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
     try {
       const result = await syncLink.mutateAsync({ projectId });
       await invalidate();
-      addToast('success', `Sync complete: ${result.pushed} pushed, ${result.pulled} pulled.`);
+      addToast('success', t('github.syncComplete', { pushed: result.pushed, pulled: result.pulled }));
     } catch {
-      addToast('error', 'Sync failed.');
+      addToast('error', t('github.syncFailed'));
     }
   };
 
@@ -54,14 +56,14 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
       await deleteLink.mutateAsync({ projectId });
       setShowUnlinkConfirm(false);
       await invalidate();
-      addToast('success', 'GitHub repository unlinked.');
+      addToast('success', t('github.unlinked'));
     } catch {
-      addToast('error', 'Failed to unlink repository.');
+      addToast('error', t('github.unlinkFailed'));
     }
   };
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">Loading...</p>;
+    return <p className="text-sm text-gray-500">{t('common.loading')}</p>;
   }
 
   if (isError || !link) {
@@ -70,27 +72,27 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
         <div className="flex gap-2">
           <div className="flex-1">
             <label htmlFor="github-owner" className="block text-xs font-medium text-gray-600">
-              Owner
+              {t('github.owner')}
             </label>
             <input
               id="github-owner"
               type="text"
               value={repoOwner}
               onChange={(e) => setRepoOwner(e.target.value)}
-              placeholder="owner"
+              placeholder={t('github.ownerPlaceholder')}
               className="mt-0.5 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
           </div>
           <div className="flex-1">
             <label htmlFor="github-repo" className="block text-xs font-medium text-gray-600">
-              Repository
+              {t('github.repository')}
             </label>
             <input
               id="github-repo"
               type="text"
               value={repoName}
               onChange={(e) => setRepoName(e.target.value)}
-              placeholder="repo"
+              placeholder={t('github.repoPlaceholder')}
               className="mt-0.5 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
           </div>
@@ -101,7 +103,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
           disabled={!repoOwner.trim() || !repoName.trim() || createLink.isPending}
           className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          Link
+          {t('github.link')}
         </button>
       </div>
     );
@@ -120,18 +122,18 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
             disabled={syncLink.isPending}
             className="rounded border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 disabled:opacity-50"
           >
-            Sync
+            {t('github.sync')}
           </button>
           {showUnlinkConfirm ? (
             <div className="flex items-center gap-2">
-              <span className="text-xs text-red-600">Are you sure?</span>
+              <span className="text-xs text-red-600">{t('common.areYouSure')}</span>
               <button
                 type="button"
                 onClick={() => setShowUnlinkConfirm(false)}
                 disabled={deleteLink.isPending}
                 className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-50"
               >
-                Cancel
+                {t('common.cancel')}
               </button>
               <button
                 type="button"
@@ -139,7 +141,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
                 disabled={deleteLink.isPending}
                 className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
               >
-                Confirm
+                {t('common.confirm')}
               </button>
             </div>
           ) : (
@@ -148,7 +150,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
               onClick={() => setShowUnlinkConfirm(true)}
               className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
             >
-              Unlink
+              {t('github.unlink')}
             </button>
           )}
         </div>

--- a/frontend/src/components/github/GitHubLinkSettings.tsx
+++ b/frontend/src/components/github/GitHubLinkSettings.tsx
@@ -45,7 +45,10 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
     try {
       const result = await syncLink.mutateAsync({ projectId });
       await invalidate();
-      addToast('success', t('github.syncComplete', { pushed: result.pushed, pulled: result.pulled }));
+      addToast(
+        'success',
+        t('github.syncComplete', { pushed: result.pushed, pulled: result.pulled }),
+      );
     } catch {
       addToast('error', t('github.syncFailed'));
     }

--- a/frontend/src/components/github/PullRequestList.tsx
+++ b/frontend/src/components/github/PullRequestList.tsx
@@ -1,19 +1,21 @@
+import { useTranslation } from 'react-i18next';
 import { useListPullRequests } from '@/api/generated/endpoints/pull-requests/pull-requests';
 import type { GitHubPullRequest } from '@/api/generated/model';
 
 export function PullRequestList({ taskId }: { taskId: string }) {
+  const { t } = useTranslation();
   const { data: pullRequests, isLoading, isError } = useListPullRequests(taskId);
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">Loading pull requests...</p>;
+    return <p className="text-sm text-gray-500">{t('github.loadingPullRequests')}</p>;
   }
 
   if (isError) {
-    return <p className="text-sm text-red-500">Failed to load pull requests.</p>;
+    return <p className="text-sm text-red-500">{t('github.loadPullRequestsFailed')}</p>;
   }
 
   if (!pullRequests || pullRequests.length === 0) {
-    return <p className="text-sm text-gray-500">No pull requests</p>;
+    return <p className="text-sm text-gray-500">{t('github.noPullRequests')}</p>;
   }
 
   return (
@@ -26,7 +28,8 @@ export function PullRequestList({ taskId }: { taskId: string }) {
 }
 
 function PullRequestItem({ pr }: { pr: GitHubPullRequest }) {
-  const badge = getBadge(pr);
+  const { t } = useTranslation();
+  const badge = getBadge(pr, t);
 
   return (
     <div className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2">
@@ -51,12 +54,15 @@ function PullRequestItem({ pr }: { pr: GitHubPullRequest }) {
   );
 }
 
-function getBadge(pr: GitHubPullRequest): { label: string; classes: string } {
+function getBadge(
+  pr: GitHubPullRequest,
+  t: (key: string) => string,
+): { label: string; classes: string } {
   if (pr.state === 'open') {
-    return { label: 'open', classes: 'bg-green-100 text-green-800' };
+    return { label: t('github.prOpen'), classes: 'bg-green-100 text-green-800' };
   }
   if (pr.is_merged) {
-    return { label: 'merged', classes: 'bg-purple-100 text-purple-800' };
+    return { label: t('github.prMerged'), classes: 'bg-purple-100 text-purple-800' };
   }
-  return { label: 'closed', classes: 'bg-red-100 text-red-800' };
+  return { label: t('github.prClosed'), classes: 'bg-red-100 text-red-800' };
 }

--- a/frontend/src/components/layout/AppLayout.test.tsx
+++ b/frontend/src/components/layout/AppLayout.test.tsx
@@ -18,6 +18,19 @@ vi.mock('@/api/generated/endpoints/auth/auth', () => ({
   useLogout: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
 }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'app.title': 'Gantry Board',
+        'auth.logout': 'Logout',
+      };
+      return translations[key] ?? key;
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}));
+
 const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 const renderWithProviders = (route = '/') => {

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,12 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, Outlet } from 'react-router-dom';
 import { useLogout } from '@/api/generated/endpoints/auth/auth';
+import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
 import { connectEventSource } from '@/hooks/useEventSource';
 import { useAuthStore } from '@/stores/authStore';
 
 export function AppLayout() {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const user = useAuthStore((state) => state.user);
   const logout = useLogout();
@@ -33,9 +36,10 @@ export function AppLayout() {
       <header className="bg-white shadow">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
           <Link to="/" className="text-2xl font-bold text-gray-900 hover:text-gray-700">
-            Gantry Board
+            {t('app.title')}
           </Link>
           <div className="flex items-center gap-2 border-l pl-4">
+            <LanguageSwitcher />
             <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
             <button
               type="button"
@@ -43,7 +47,7 @@ export function AppLayout() {
               disabled={logout.isPending}
               className="flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
             >
-              <LogOut className="h-4 w-4" /> Logout
+              <LogOut className="h-4 w-4" /> {t('auth.logout')}
             </button>
           </div>
         </div>

--- a/frontend/src/components/layout/GuestRoute.tsx
+++ b/frontend/src/components/layout/GuestRoute.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -6,12 +7,13 @@ interface GuestRouteProps {
 }
 
 export function GuestRoute({ children }: GuestRouteProps) {
+  const { t } = useTranslation();
   const { isAuthenticated, isLoading } = useAuthStore();
 
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <div className="text-gray-500">Loading...</div>
+        <div className="text-gray-500">{t('common.loading')}</div>
       </div>
     );
   }

--- a/frontend/src/components/layout/InvitationAcceptPage.tsx
+++ b/frontend/src/components/layout/InvitationAcceptPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   useAcceptInvitation,
@@ -6,6 +7,7 @@ import {
 import { useAuthStore } from '@/stores/authStore';
 
 export function InvitationAcceptPage() {
+  const { t } = useTranslation();
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -21,7 +23,7 @@ export function InvitationAcceptPage() {
   if (!token) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <p className="text-gray-500">Invalid invitation link.</p>
+        <p className="text-gray-500">{t('invitation.invalidLink')}</p>
       </div>
     );
   }
@@ -38,44 +40,45 @@ export function InvitationAcceptPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-2xl font-bold text-gray-900">Project Invitation</h1>
+        <h1 className="mb-6 text-2xl font-bold text-gray-900">{t('invitation.title')}</h1>
 
         {isLoading ? (
-          <p className="text-gray-500">Loading invitation...</p>
+          <p className="text-gray-500">{t('invitation.loadingInvitation')}</p>
         ) : isError ? (
-          <p className="text-red-500">Invalid or expired invitation link.</p>
+          <p className="text-red-500">{t('invitation.expiredOrInvalid')}</p>
         ) : info ? (
           <div className="space-y-4">
             <div className="rounded-md bg-blue-50 p-4">
               <p className="text-sm text-gray-700">
-                <span className="font-medium">{info.invited_by_name}</span> invited you to join
+                <span className="font-medium">{info.invited_by_name}</span>{' '}
+                {t('invitation.invitedYou')}
               </p>
               <p className="mt-1 text-lg font-semibold text-gray-900">{info.project_name}</p>
               <p className="mt-1 text-sm text-gray-500">
-                Role: <span className="font-medium">{info.role}</span>
+                {t('invitation.role')} <span className="font-medium">{info.role}</span>
               </p>
             </div>
 
             {info.accepted ? (
-              <p className="text-sm text-green-600">This invitation has already been accepted.</p>
+              <p className="text-sm text-green-600">{t('invitation.alreadyAccepted')}</p>
             ) : info.expired ? (
-              <p className="text-sm text-red-600">This invitation has expired.</p>
+              <p className="text-sm text-red-600">{t('invitation.expired')}</p>
             ) : !isAuthenticated ? (
               <div className="space-y-2">
-                <p className="text-sm text-gray-600">Please log in to accept this invitation.</p>
+                <p className="text-sm text-gray-600">{t('invitation.loginRequired')}</p>
                 <button
                   type="button"
                   onClick={() => navigate(`/login?redirect=/invite/${token}`)}
                   className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
                 >
-                  Log In
+                  {t('invitation.logIn')}
                 </button>
                 <button
                   type="button"
                   onClick={() => navigate(`/register?redirect=/invite/${token}`)}
                   className="w-full rounded-md border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
                 >
-                  Create Account
+                  {t('auth.createAccountBtn')}
                 </button>
               </div>
             ) : (
@@ -86,12 +89,10 @@ export function InvitationAcceptPage() {
                   disabled={acceptMutation.isPending}
                   className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
                 >
-                  {acceptMutation.isPending ? 'Accepting...' : 'Accept Invitation'}
+                  {acceptMutation.isPending ? t('invitation.accepting') : t('invitation.accept')}
                 </button>
                 {acceptMutation.isError && (
-                  <p className="text-sm text-red-600">
-                    Failed to accept invitation. It may have expired or already been used.
-                  </p>
+                  <p className="text-sm text-red-600">{t('invitation.acceptFailed')}</p>
                 )}
               </div>
             )}

--- a/frontend/src/components/layout/LoginPage.tsx
+++ b/frontend/src/components/layout/LoginPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useLogin } from '@/api/generated/endpoints/auth/auth';
 import { useAuthStore } from '@/stores/authStore';
 
 export function LoginPage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const redirectTo = searchParams.get('redirect');
@@ -25,16 +27,14 @@ export function LoginPage() {
       setUser(response.user);
       navigate(redirectTo ?? '/', { replace: true });
     } catch {
-      setError('Invalid email or password. Please try again.');
+      setError(t('auth.invalidCredentials'));
     }
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">
-          Sign in to Gantry Board
-        </h1>
+        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">{t('auth.signInTo')}</h1>
 
         {error && (
           <div
@@ -48,7 +48,7 @@ export function LoginPage() {
         <form onSubmit={handleSubmit} data-testid="login-form" className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-              Email
+              {t('auth.email')}
             </label>
             <input
               id="email"
@@ -57,13 +57,13 @@ export function LoginPage() {
               onChange={(e) => setEmail(e.target.value)}
               required
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              placeholder="you@example.com"
+              placeholder={t('auth.emailPlaceholder')}
             />
           </div>
 
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-              Password
+              {t('auth.password')}
             </label>
             <input
               id="password"
@@ -72,7 +72,7 @@ export function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              placeholder="Enter your password"
+              placeholder={t('auth.passwordPlaceholder')}
             />
           </div>
 
@@ -81,17 +81,17 @@ export function LoginPage() {
             disabled={login.isPending}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {login.isPending ? 'Signing in...' : 'Sign in'}
+            {login.isPending ? t('auth.signingIn') : t('auth.signIn')}
           </button>
         </form>
 
         <p className="mt-4 text-center text-sm text-gray-600">
-          Don't have an account?{' '}
+          {t('auth.noAccount')}{' '}
           <Link
             to={redirectTo ? `/register?redirect=${encodeURIComponent(redirectTo)}` : '/register'}
             className="text-blue-600 hover:text-blue-500"
           >
-            Sign up
+            {t('auth.signUp')}
           </Link>
         </p>
       </div>

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -6,12 +7,13 @@ interface ProtectedRouteProps {
 }
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { t } = useTranslation();
   const { isAuthenticated, isLoading } = useAuthStore();
 
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <div className="text-gray-500">Loading...</div>
+        <div className="text-gray-500">{t('common.loading')}</div>
       </div>
     );
   }

--- a/frontend/src/components/layout/RegisterPage.tsx
+++ b/frontend/src/components/layout/RegisterPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useRegister } from '@/api/generated/endpoints/auth/auth';
 import { useAuthStore } from '@/stores/authStore';
 
 export function RegisterPage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const redirectTo = searchParams.get('redirect');
@@ -20,7 +22,7 @@ export function RegisterPage() {
     setError(null);
 
     if (password.length < 8) {
-      setError('Password must be at least 8 characters');
+      setError(t('auth.passwordTooShort'));
       return;
     }
 
@@ -31,14 +33,16 @@ export function RegisterPage() {
       setUser(response.user);
       navigate(redirectTo ?? '/', { replace: true });
     } catch {
-      setError('Registration failed. The email may already be in use.');
+      setError(t('auth.registrationFailed'));
     }
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">Create your account</h1>
+        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">
+          {t('auth.createAccount')}
+        </h1>
 
         {error && (
           <div
@@ -52,7 +56,7 @@ export function RegisterPage() {
         <form onSubmit={handleSubmit} data-testid="register-form" className="space-y-4">
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-gray-700">
-              Name
+              {t('auth.name')}
             </label>
             <input
               id="name"
@@ -61,13 +65,13 @@ export function RegisterPage() {
               onChange={(e) => setName(e.target.value)}
               required
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              placeholder="Your name"
+              placeholder={t('auth.namePlaceholder')}
             />
           </div>
 
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-              Email
+              {t('auth.email')}
             </label>
             <input
               id="email"
@@ -76,13 +80,13 @@ export function RegisterPage() {
               onChange={(e) => setEmail(e.target.value)}
               required
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              placeholder="you@example.com"
+              placeholder={t('auth.emailPlaceholder')}
             />
           </div>
 
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-              Password
+              {t('auth.password')}
             </label>
             <input
               id="password"
@@ -92,7 +96,7 @@ export function RegisterPage() {
               required
               minLength={8}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              placeholder="At least 8 characters"
+              placeholder={t('auth.passwordMinLength')}
             />
           </div>
 
@@ -101,17 +105,17 @@ export function RegisterPage() {
             disabled={register.isPending}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {register.isPending ? 'Creating account...' : 'Create account'}
+            {register.isPending ? t('auth.creatingAccount') : t('auth.createAccountBtn')}
           </button>
         </form>
 
         <p className="mt-4 text-center text-sm text-gray-600">
-          Already have an account?{' '}
+          {t('auth.hasAccount')}{' '}
           <Link
             to={redirectTo ? `/login?redirect=${encodeURIComponent(redirectTo)}` : '/login'}
             className="text-blue-600 hover:text-blue-500"
           >
-            Sign in
+            {t('auth.signIn')}
           </Link>
         </p>
       </div>

--- a/frontend/src/components/preview/PreviewPanel.tsx
+++ b/frontend/src/components/preview/PreviewPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   useCreatePreview,
   useDeletePreview,
@@ -30,6 +31,7 @@ function PreviewActions({
   onRestart: (id: string) => void;
   onDelete: (id: string) => void;
 }) {
+  const { t } = useTranslation();
   const { status, id } = preview;
 
   return (
@@ -40,7 +42,7 @@ function PreviewActions({
           onClick={() => onStart(id)}
           className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700"
         >
-          Start
+          {t('preview.start')}
         </button>
       )}
       {status === 'running' && (
@@ -50,14 +52,14 @@ function PreviewActions({
             onClick={() => onStop(id)}
             className="rounded bg-yellow-600 px-2 py-1 text-xs text-white hover:bg-yellow-700"
           >
-            Stop
+            {t('preview.stop')}
           </button>
           <button
             type="button"
             onClick={() => onRestart(id)}
             className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700"
           >
-            Restart
+            {t('preview.restart')}
           </button>
         </>
       )}
@@ -66,13 +68,14 @@ function PreviewActions({
         onClick={() => onDelete(id)}
         className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700"
       >
-        Delete
+        {t('preview.delete')}
       </button>
     </div>
   );
 }
 
 export function PreviewPanel() {
+  const { t } = useTranslation();
   const [worktreeName, setWorktreeName] = useState('');
   const [error, setError] = useState<string | null>(null);
 
@@ -89,7 +92,7 @@ export function PreviewPanel() {
       await createPreview({ data: { worktree_name: worktreeName } });
       setWorktreeName('');
     } catch {
-      setError('Failed to create preview');
+      setError(t('preview.createFailed'));
     }
   };
 
@@ -98,7 +101,7 @@ export function PreviewPanel() {
     try {
       await startPreview({ id });
     } catch {
-      setError('Failed to start preview');
+      setError(t('preview.startFailed'));
     }
   };
 
@@ -107,7 +110,7 @@ export function PreviewPanel() {
     try {
       await stopPreview({ id });
     } catch {
-      setError('Failed to stop preview');
+      setError(t('preview.stopFailed'));
     }
   };
 
@@ -116,7 +119,7 @@ export function PreviewPanel() {
     try {
       await restartPreview({ id });
     } catch {
-      setError('Failed to restart preview');
+      setError(t('preview.restartFailed'));
     }
   };
 
@@ -125,33 +128,33 @@ export function PreviewPanel() {
     try {
       await deletePreview({ id });
     } catch {
-      setError('Failed to delete preview');
+      setError(t('preview.deleteFailed'));
     }
   };
 
   if (isLoading) {
-    return <div className="p-4 text-gray-500">Loading previews...</div>;
+    return <div className="p-4 text-gray-500">{t('preview.loadingPreviews')}</div>;
   }
 
   if (isError) {
-    return <div className="p-4 text-red-500">Failed to load previews</div>;
+    return <div className="p-4 text-red-500">{t('preview.loadFailed')}</div>;
   }
 
   return (
     <div className="space-y-4 p-4">
-      <h2 className="text-lg font-semibold">Docker Previews</h2>
+      <h2 className="text-lg font-semibold">{t('preview.dockerPreviews')}</h2>
 
       {/* Create form */}
       <div className="flex gap-2">
         <label className="sr-only" htmlFor="preview-worktree-name">
-          Worktree Name
+          {t('preview.worktreeNameLabel')}
         </label>
         <input
           id="preview-worktree-name"
           type="text"
           value={worktreeName}
           onChange={(e) => setWorktreeName(e.target.value)}
-          placeholder="Worktree name"
+          placeholder={t('preview.worktreeName')}
           className="flex-1 rounded border px-3 py-1 text-sm"
         />
         <button
@@ -160,14 +163,16 @@ export function PreviewPanel() {
           disabled={!worktreeName.trim() || isCreating}
           className="rounded bg-indigo-600 px-3 py-1 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
         >
-          Create
+          {t('common.create')}
         </button>
       </div>
 
       {error && <div className="text-sm text-red-500">{error}</div>}
 
       {/* Preview list */}
-      {previews && previews.length === 0 && <p className="text-sm text-gray-500">No previews</p>}
+      {previews && previews.length === 0 && (
+        <p className="text-sm text-gray-500">{t('preview.noPreviews')}</p>
+      )}
 
       {previews?.map((preview) => (
         <div key={preview.id} className="flex items-center justify-between rounded border p-3">

--- a/frontend/src/components/preview/WorktreePanel.tsx
+++ b/frontend/src/components/preview/WorktreePanel.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListProjectWorktreesQueryKey,
   useCreateProjectWorktree,
@@ -8,6 +9,7 @@ import {
 } from '@/api/generated/endpoints/worktrees/worktrees';
 
 export function WorktreePanel({ projectId }: { projectId: string }) {
+  const { t } = useTranslation();
   const [name, setName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [deletingName, setDeletingName] = useState<string | null>(null);
@@ -31,7 +33,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
       setName('');
       await invalidateList();
     } catch {
-      setError('Failed to create worktree. Please try again.');
+      setError(t('worktree.createFailed'));
     }
   };
 
@@ -42,16 +44,16 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
       setDeletingName(null);
       await invalidateList();
     } catch {
-      setError('Failed to delete worktree. Please try again.');
+      setError(t('worktree.deleteFailed'));
     }
   };
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">Loading worktrees...</p>;
+    return <p className="text-sm text-gray-500">{t('worktree.loadingWorktrees')}</p>;
   }
 
   if (isError) {
-    return <p className="text-sm text-red-500">Failed to load worktrees.</p>;
+    return <p className="text-sm text-red-500">{t('worktree.loadFailed')}</p>;
   }
 
   return (
@@ -70,20 +72,20 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
                 {wt.branch && <span className="text-gray-500">{wt.branch}</span>}
                 {!wt.is_valid && (
                   <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800">
-                    invalid
+                    {t('worktree.invalid')}
                   </span>
                 )}
               </div>
               {deletingName === wt.name ? (
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-red-600">Are you sure?</span>
+                  <span className="text-xs text-red-600">{t('worktree.deleteConfirm')}</span>
                   <button
                     type="button"
                     onClick={() => setDeletingName(null)}
                     disabled={deleteWorktree.isPending}
                     className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                   >
-                    Cancel
+                    {t('common.cancel')}
                   </button>
                   <button
                     type="button"
@@ -91,7 +93,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
                     disabled={deleteWorktree.isPending}
                     className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
                   >
-                    Confirm
+                    {t('common.confirm')}
                   </button>
                 </div>
               ) : (
@@ -100,27 +102,27 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
                   onClick={() => setDeletingName(wt.name)}
                   className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
                 >
-                  Delete
+                  {t('common.delete')}
                 </button>
               )}
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-sm text-gray-500">No worktrees</p>
+        <p className="text-sm text-gray-500">{t('worktree.noWorktrees')}</p>
       )}
 
       <div className="flex gap-2">
         <div className="flex-1">
           <label htmlFor="worktree-name-input" className="sr-only">
-            Worktree Name
+            {t('worktree.worktreeName')}
           </label>
           <input
             id="worktree-name-input"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Worktree name..."
+            placeholder={t('worktree.namePlaceholder')}
             className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
@@ -130,7 +132,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
           disabled={!name.trim() || createWorktree.isPending}
           className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          Create
+          {t('common.create')}
         </button>
       </div>
     </div>

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { Settings } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Project } from '@/api/generated/model';
 
@@ -8,6 +9,7 @@ interface ProjectCardProps {
 }
 
 export function ProjectCard({ project, onSettings }: ProjectCardProps) {
+  const { t } = useTranslation();
   return (
     <div className="group relative rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
       <Link to={`/projects/${project.id}`} className="block">
@@ -24,7 +26,7 @@ export function ProjectCard({ project, onSettings }: ProjectCardProps) {
             onSettings(project.id);
           }}
           className="absolute right-3 top-3 rounded p-1 text-gray-400 opacity-0 hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
-          aria-label="Project settings"
+          aria-label={t('project.projectSettings')}
         >
           <Settings className="h-4 w-4" />
         </button>

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListMessagesQueryKey,
   useCreateMessage,
@@ -40,6 +41,7 @@ function MessageItem({
   projectId: string;
   isOwner: boolean;
 }) {
+  const { t } = useTranslation();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const queryClient = useQueryClient();
   const deleteMessage = useDeleteMessage();
@@ -55,7 +57,7 @@ function MessageItem({
       setShowDeleteConfirm(false);
       invalidateMessages();
     } catch {
-      addToast('error', 'Failed to delete message.');
+      addToast('error', t('chat.deleteFailed'));
     }
   };
 
@@ -78,30 +80,30 @@ function MessageItem({
           {isOwner && !showDeleteConfirm && (
             <button
               type="button"
-              aria-label="Delete"
+              aria-label={t('common.delete')}
               onClick={() => setShowDeleteConfirm(true)}
               className="ml-auto text-xs text-gray-400 hover:text-red-600"
             >
-              Delete
+              {t('common.delete')}
             </button>
           )}
         </div>
         {showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">Delete this message?</span>
+            <span className="text-xs text-red-700">{t('chat.deleteMessageConfirm')}</span>
             <button
               type="button"
               onClick={handleDelete}
               className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
             >
-              Confirm
+              {t('common.confirm')}
             </button>
             <button
               type="button"
               onClick={() => setShowDeleteConfirm(false)}
               className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
           </div>
         ) : (
@@ -119,6 +121,7 @@ export function ProjectChatPanel({ projectId }: { projectId: string }) {
 }
 
 function ProjectChatContent({ projectId }: { projectId: string }) {
+  const { t } = useTranslation();
   const closeProjectChat = useUiStore((s) => s.closeProjectChat);
   const { data: messages, isLoading } = useListMessages(projectId);
   const createMessage = useCreateMessage();
@@ -140,7 +143,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
       setNewMessage('');
       queryClient.invalidateQueries({ queryKey: getListMessagesQueryKey(projectId) });
     } catch {
-      addToast('error', 'Failed to send message.');
+      addToast('error', t('chat.sendFailed'));
     }
   };
 
@@ -167,13 +170,13 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
       <div className="flex h-[600px] w-full max-w-lg flex-col rounded-lg bg-white shadow-xl">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <h2 id="project-chat-title" className="text-lg font-semibold text-gray-900">
-            Project Chat
+            {t('chat.projectChat')}
           </h2>
           <button
             type="button"
             onClick={closeProjectChat}
             className="text-gray-400 hover:text-gray-600"
-            aria-label="Close"
+            aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
           </button>
@@ -181,7 +184,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
 
         <div className="flex-1 overflow-y-auto px-4 py-2">
           {isLoading ? (
-            <p className="text-sm text-gray-500">Loading messages...</p>
+            <p className="text-sm text-gray-500">{t('chat.loadingMessages')}</p>
           ) : displayMessages.length > 0 ? (
             <div className="divide-y">
               {displayMessages.map((m) => (
@@ -195,7 +198,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
             </div>
           ) : (
             <p className="py-8 text-center text-sm text-gray-500">
-              No messages yet. Start the conversation!
+              {t('chat.noMessages')}
             </p>
           )}
         </div>
@@ -206,18 +209,18 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
               value={newMessage}
               onChange={(e) => setNewMessage(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder="Type a message..."
+              placeholder={t('chat.placeholder')}
               rows={2}
               className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
             <button
               type="button"
-              aria-label="Send"
+              aria-label={t('common.send')}
               onClick={handleSubmit}
               disabled={!newMessage.trim() || createMessage.isPending}
               className="self-end rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
             >
-              Send
+              {t('common.send')}
             </button>
           </div>
         </div>

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -197,9 +197,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
               ))}
             </div>
           ) : (
-            <p className="py-8 text-center text-sm text-gray-500">
-              {t('chat.noMessages')}
-            </p>
+            <p className="py-8 text-center text-sm text-gray-500">{t('chat.noMessages')}</p>
           )}
         </div>
 

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -13,17 +13,20 @@ import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
 
-function timeAgo(dateStr: string): string {
+function timeAgo(
+  dateStr: string,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();
   const diffSec = Math.floor((now - then) / 1000);
-  if (diffSec < 60) return 'just now';
+  if (diffSec < 60) return t('common.timeAgo.justNow');
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffMin < 60) return t('common.timeAgo.minutesAgo', { count: diffMin });
   const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffHr < 24) return t('common.timeAgo.hoursAgo', { count: diffHr });
   const diffDay = Math.floor(diffHr / 24);
-  return `${diffDay}d ago`;
+  return t('common.timeAgo.daysAgo', { count: diffDay });
 }
 
 function MessageItem({
@@ -76,7 +79,7 @@ function MessageItem({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-gray-900">{message.user_name}</span>
-          <span className="text-xs text-gray-500">{timeAgo(message.created_at)}</span>
+          <span className="text-xs text-gray-500">{timeAgo(message.created_at, t)}</span>
           {isOwner && !showDeleteConfirm && (
             <button
               type="button"

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useCreateProject } from '@/api/generated/endpoints/projects/projects';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { invalidateProjects } from '@/services/queryInvalidation';
@@ -14,6 +15,7 @@ export function ProjectCreateDialog() {
 }
 
 function ProjectCreateForm() {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const closeProjectModal = useUiStore((s) => s.closeProjectModal);
   const createProject = useCreateProject();
@@ -41,7 +43,7 @@ function ProjectCreateForm() {
       invalidateProjects(queryClient);
       closeProjectModal();
     } catch {
-      setError('Failed to create project. Please try again.');
+      setError(t('project.createFailed'));
     }
   };
 
@@ -60,13 +62,13 @@ function ProjectCreateForm() {
         className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
       >
         <h2 id="project-create-title" className="mb-4 text-lg font-semibold">
-          Create Project
+          {t('project.createProject')}
         </h2>
         {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">
-              Name
+              {t('project.name')}
             </label>
             <input
               id="project-name"
@@ -82,7 +84,7 @@ function ProjectCreateForm() {
               htmlFor="project-description"
               className="block text-sm font-medium text-gray-700"
             >
-              Description
+              {t('project.description')}
             </label>
             <textarea
               id="project-description"
@@ -97,14 +99,14 @@ function ProjectCreateForm() {
               htmlFor="project-repository-path"
               className="block text-sm font-medium text-gray-700"
             >
-              Repository Path
+              {t('project.repositoryPath')}
             </label>
             <input
               id="project-repository-path"
               type="text"
               value={repositoryPath}
               onChange={(e) => setRepositoryPath(e.target.value)}
-              placeholder="/path/to/git/repo (optional)"
+              placeholder={t('project.repositoryPathPlaceholder')}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
           </div>
@@ -114,14 +116,14 @@ function ProjectCreateForm() {
               onClick={closeProjectModal}
               className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={createProject.isPending}
               className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
             >
-              Create
+              {t('common.create')}
             </button>
           </div>
         </form>

--- a/frontend/src/components/project/ProjectListPage.tsx
+++ b/frontend/src/components/project/ProjectListPage.tsx
@@ -1,9 +1,11 @@
 import { FolderPlus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useListProjects } from '@/api/generated/endpoints/projects/projects';
 import { useUiStore } from '@/stores/uiStore';
 import { ProjectCard } from './ProjectCard';
 
 export function ProjectListPage() {
+  const { t } = useTranslation();
   const { data: projectsResponse, isLoading, isError } = useListProjects();
   const openProjectModal = useUiStore((s) => s.openProjectModal);
   const projects = projectsResponse?.data;
@@ -11,7 +13,7 @@ export function ProjectListPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-gray-500">Loading projects...</p>
+        <p className="text-gray-500">{t('project.loadingProjects')}</p>
       </div>
     );
   }
@@ -19,7 +21,7 @@ export function ProjectListPage() {
   if (isError) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-red-500">Failed to load projects.</p>
+        <p className="text-red-500">{t('project.loadFailed')}</p>
       </div>
     );
   }
@@ -27,25 +29,25 @@ export function ProjectListPage() {
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-900">Projects</h2>
+        <h2 className="text-xl font-semibold text-gray-900">{t('project.projects')}</h2>
         <button
           type="button"
           onClick={openProjectModal}
           className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
         >
-          <FolderPlus className="h-4 w-4" /> New Project
+          <FolderPlus className="h-4 w-4" /> {t('project.newProject')}
         </button>
       </div>
 
       {!projects || projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 py-16">
-          <p className="text-gray-500">No projects yet</p>
+          <p className="text-gray-500">{t('project.noProjects')}</p>
           <button
             type="button"
             onClick={openProjectModal}
             className="mt-4 flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
           >
-            <FolderPlus className="h-4 w-4" /> Create your first project
+            <FolderPlus className="h-4 w-4" /> {t('project.createFirst')}
           </button>
         </div>
       ) : (

--- a/frontend/src/components/project/ProjectMembersPanel.test.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.test.tsx
@@ -130,8 +130,8 @@ describe('ProjectMembersPanel', () => {
     renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
     // Alice (self/owner) shows a static badge, Bob has a role select
     // Check that role text exists somewhere in the document
-    expect(screen.getAllByText('owner').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('member').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Owner').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Member').length).toBeGreaterThanOrEqual(1);
   });
 
   describe('owner permissions', () => {

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListInvitationsQueryKey,
   useCreateInvitation,
@@ -29,6 +30,7 @@ export function ProjectMembersPanel({ projectId }: { projectId: string }) {
 }
 
 function ProjectMembersContent({ projectId }: { projectId: string }) {
+  const { t } = useTranslation();
   const closeProjectMembers = useUiStore((s) => s.closeProjectMembers);
   const { data: members, isLoading, isError } = useListMembers(projectId);
   const addMember = useAddMember();
@@ -74,9 +76,9 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
       invalidateMembers();
       setSelectedUser(null);
       setSearchQuery('');
-      addToast('success', `${selectedUser.name} added.`);
+      addToast('success', t('members.addedSuccess', { name: selectedUser.name }));
     } catch {
-      addToast('error', 'Failed to add member.');
+      addToast('error', t('members.addFailed'));
     }
   };
 
@@ -89,7 +91,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
       });
       invalidateMembers();
     } catch {
-      addToast('error', 'Failed to update role.');
+      addToast('error', t('members.roleUpdateFailed'));
     }
   };
 
@@ -98,9 +100,9 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
       await removeMember.mutateAsync({ projectId, userId });
       invalidateMembers();
       setRemovingUserId(null);
-      addToast('success', 'Member removed.');
+      addToast('success', t('members.removed'));
     } catch {
-      addToast('error', 'Failed to remove member.');
+      addToast('error', t('members.removeFailed'));
     }
   };
 
@@ -123,22 +125,22 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
       <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h2 id="project-members-title" className="text-lg font-semibold text-gray-900">
-            Members
+            {t('members.members')}
           </h2>
           <button
             type="button"
             onClick={closeProjectMembers}
             className="text-gray-400 hover:text-gray-600"
-            aria-label="Close"
+            aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         {isLoading ? (
-          <p className="text-sm text-gray-500">Loading...</p>
+          <p className="text-sm text-gray-500">{t('common.loading')}</p>
         ) : isError ? (
-          <p className="text-sm text-red-500">Failed to load members.</p>
+          <p className="text-sm text-red-500">{t('members.loadFailed')}</p>
         ) : (
           <div className="space-y-3">
             {members?.map((m) => (
@@ -153,7 +155,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
                 {m.user_id === currentUser?.id || !canManageMember(m.role) ? (
                   <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-                    {m.role}
+                    {t(`members.role.${m.role}`)}
                   </span>
                 ) : removingUserId === m.user_id ? (
                   <div className="flex items-center gap-1">
@@ -162,14 +164,14 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                       onClick={() => handleRemove(m.user_id)}
                       className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
                     >
-                      Confirm
+                      {t('common.confirm')}
                     </button>
                     <button
                       type="button"
                       onClick={() => setRemovingUserId(null)}
                       className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
                     >
-                      Cancel
+                      {t('common.cancel')}
                     </button>
                   </div>
                 ) : (
@@ -181,17 +183,17 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                       }
                       className="rounded border border-gray-300 px-1 py-0.5 text-xs"
                     >
-                      <option value="owner">owner</option>
-                      <option value="admin">admin</option>
-                      <option value="member">member</option>
+                      <option value="owner">{t('members.role.owner')}</option>
+                      <option value="admin">{t('members.role.admin')}</option>
+                      <option value="member">{t('members.role.member')}</option>
                     </select>
                     <button
                       type="button"
                       onClick={() => setRemovingUserId(m.user_id)}
                       className="text-xs text-gray-400 hover:text-red-600"
-                      aria-label="Remove"
+                      aria-label={t('common.remove')}
                     >
-                      Remove
+                      {t('common.remove')}
                     </button>
                   </div>
                 )}
@@ -204,7 +206,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
         {canManage && (
           <div className="mt-4 border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">Add Existing User</h3>
+            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('members.addExistingUser')}</h3>
             <div className="relative">
               <input
                 type="text"
@@ -213,7 +215,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                   setSearchQuery(e.target.value);
                   setSelectedUser(null);
                 }}
-                placeholder="Search users by name or email..."
+                placeholder={t('members.searchPlaceholder')}
                 className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
               />
               {!selectedUser && filteredResults && filteredResults.length > 0 && (
@@ -242,8 +244,8 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 onChange={(e) => setInviteRole(e.target.value as MemberRoleType)}
                 className="rounded border border-gray-300 px-2 py-1.5 text-sm"
               >
-                <option value="member">member</option>
-                <option value="admin">admin</option>
+                <option value="member">{t('members.role.member')}</option>
+                <option value="admin">{t('members.role.admin')}</option>
               </select>
               <button
                 type="button"
@@ -251,7 +253,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 disabled={!selectedUser || addMember.isPending}
                 className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
               >
-                Add
+                {t('common.add')}
               </button>
             </div>
           </div>
@@ -262,6 +264,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 }
 
 function InvitationSection({ projectId }: { projectId: string }) {
+  const { t } = useTranslation();
   const { data: invitations } = useListInvitations(projectId);
   const createInvitation = useCreateInvitation();
   const deleteInvitation = useDeleteInvitation();
@@ -283,12 +286,12 @@ function InvitationSection({ projectId }: { projectId: string }) {
       invalidateInvitations();
       try {
         await navigator.clipboard.writeText(result.invite_url);
-        addToast('success', 'Invitation link copied to clipboard!');
+        addToast('success', t('members.inviteCopied'));
       } catch {
-        addToast('success', `Invitation created: ${result.invite_url}`);
+        addToast('success', t('members.inviteCreated', { url: result.invite_url }));
       }
     } catch {
-      addToast('error', 'Failed to create invitation.');
+      addToast('error', t('members.inviteFailed'));
     }
   };
 
@@ -297,7 +300,7 @@ function InvitationSection({ projectId }: { projectId: string }) {
       await deleteInvitation.mutateAsync({ projectId, invitationId });
       invalidateInvitations();
     } catch {
-      addToast('error', 'Failed to revoke invitation.');
+      addToast('error', t('members.revokeFailed'));
     }
   };
 
@@ -310,7 +313,7 @@ function InvitationSection({ projectId }: { projectId: string }) {
   return (
     <div className="mt-4 border-t pt-4">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-gray-700">Invitation Links</h3>
+        <h3 className="text-sm font-medium text-gray-700">{t('members.invitationLinks')}</h3>
         <button
           type="button"
           onClick={handleCreate}
@@ -318,7 +321,7 @@ function InvitationSection({ projectId }: { projectId: string }) {
           className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700 disabled:opacity-50"
           data-testid="create-invitation-btn"
         >
-          Create Link
+          {t('members.createLink')}
         </button>
       </div>
 
@@ -338,24 +341,24 @@ function InvitationSection({ projectId }: { projectId: string }) {
                   </p>
                   <p className={`text-xs ${isExpired ? 'text-red-500' : 'text-gray-400'}`}>
                     {isExpired
-                      ? 'Expired'
-                      : `Expires ${new Date(inv.expires_at).toLocaleDateString()}`}
+                      ? t('members.expired')
+                      : t('members.expires', { date: new Date(inv.expires_at).toLocaleDateString() })}
                   </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => handleDelete(inv.id)}
                   className="text-xs text-gray-400 hover:text-red-600"
-                  aria-label="Revoke"
+                  aria-label={t('members.revoke')}
                 >
-                  Revoke
+                  {t('members.revoke')}
                 </button>
               </div>
             );
           })}
         </div>
       ) : (
-        <p className="text-xs text-gray-500">No pending invitations.</p>
+        <p className="text-xs text-gray-500">{t('members.noPendingInvitations')}</p>
       )}
     </div>
   );

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -206,7 +206,9 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
         {canManage && (
           <div className="mt-4 border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('members.addExistingUser')}</h3>
+            <h3 className="mb-2 text-sm font-medium text-gray-700">
+              {t('members.addExistingUser')}
+            </h3>
             <div className="relative">
               <input
                 type="text"
@@ -342,7 +344,9 @@ function InvitationSection({ projectId }: { projectId: string }) {
                   <p className={`text-xs ${isExpired ? 'text-red-500' : 'text-gray-400'}`}>
                     {isExpired
                       ? t('members.expired')
-                      : t('members.expires', { date: new Date(inv.expires_at).toLocaleDateString() })}
+                      : t('members.expires', {
+                          date: new Date(inv.expires_at).toLocaleDateString(),
+                        })}
                   </p>
                 </div>
                 <button

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import {
   getGetProjectQueryKey,
@@ -35,6 +36,7 @@ function ProjectSettingsContent({
   projectId: string;
   onProjectDeleted: () => void;
 }) {
+  const { t } = useTranslation();
   const closeProjectSettings = useUiStore((s) => s.closeProjectSettings);
   const { data: project, isLoading, isError } = useGetProject(projectId);
   const { data: members } = useListMembers(projectId);
@@ -92,10 +94,10 @@ function ProjectSettingsContent({
         queryClient.invalidateQueries({
           queryKey: getGetProjectQueryKey(projectId),
         });
-        addToast('success', `Project ${field} updated.`);
+        addToast('success', t('project.fieldUpdated', { field }));
       }
     } catch {
-      addToast('error', `Failed to update ${field}.`);
+      addToast('error', t('project.fieldUpdateFailed', { field }));
     } finally {
       setEditingField(null);
     }
@@ -109,9 +111,9 @@ function ProjectSettingsContent({
       });
       closeProjectSettings();
       onProjectDeleted();
-      addToast('success', 'Project deleted.');
+      addToast('success', t('project.deleted'));
     } catch {
-      addToast('error', 'Failed to delete project.');
+      addToast('error', t('project.deleteFailed'));
     }
   };
 
@@ -128,26 +130,26 @@ function ProjectSettingsContent({
       <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h2 id="project-settings-title" className="text-lg font-semibold text-gray-900">
-            Project Settings
+            {t('project.settings')}
           </h2>
           <button
             type="button"
             onClick={closeProjectSettings}
             className="text-gray-400 hover:text-gray-600"
-            aria-label="Close"
+            aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         {isLoading ? (
-          <p className="text-sm text-gray-500">Loading...</p>
+          <p className="text-sm text-gray-500">{t('common.loading')}</p>
         ) : isError || !project ? (
-          <p className="text-sm text-red-500">Failed to load project.</p>
+          <p className="text-sm text-red-500">{t('project.loadFailed')}</p>
         ) : (
           <div className="space-y-4">
             <div>
-              <h3 className="text-sm font-medium text-gray-700">Name</h3>
+              <h3 className="text-sm font-medium text-gray-700">{t('project.name')}</h3>
               {editingField === 'name' ? (
                 <input
                   type="text"
@@ -171,7 +173,7 @@ function ProjectSettingsContent({
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">Description</h3>
+              <h3 className="text-sm font-medium text-gray-700">{t('project.description')}</h3>
               {editingField === 'description' ? (
                 <textarea
                   value={editValue}
@@ -187,17 +189,17 @@ function ProjectSettingsContent({
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
                   onClick={() => startEditing('description', project.description ?? '')}
                 >
-                  {project.description || 'No description'}
+                  {project.description || t('common.noDescription')}
                 </button>
               ) : (
                 <p className="mt-1 px-1 text-sm text-gray-600">
-                  {project.description || 'No description'}
+                  {project.description || t('common.noDescription')}
                 </p>
               )}
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">Repository Path</h3>
+              <h3 className="text-sm font-medium text-gray-700">{t('project.repositoryPath')}</h3>
               {editingField === 'repository_path' ? (
                 <input
                   type="text"
@@ -214,18 +216,18 @@ function ProjectSettingsContent({
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
                   onClick={() => startEditing('repository_path', project.repository_path ?? '')}
                 >
-                  {project.repository_path || 'Not set (using global)'}
+                  {project.repository_path || t('project.notSetGlobal')}
                 </button>
               ) : (
                 <p className="mt-1 px-1 text-sm text-gray-600">
-                  {project.repository_path || 'Not set (using global)'}
+                  {project.repository_path || t('project.notSetGlobal')}
                 </p>
               )}
             </div>
 
             {canEdit && (
               <div className="border-t pt-4">
-                <h3 className="text-sm font-medium text-gray-700 mb-2">GitHub</h3>
+                <h3 className="text-sm font-medium text-gray-700 mb-2">{t('github.github')}</h3>
                 <GitHubLinkSettings projectId={projectId} />
               </div>
             )}
@@ -234,21 +236,21 @@ function ProjectSettingsContent({
               <div className="border-t pt-4">
                 {showDeleteConfirm ? (
                   <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
-                    <p className="text-sm text-red-700">Are you sure? This cannot be undone.</p>
+                    <p className="text-sm text-red-700">{t('project.deleteConfirm')}</p>
                     <div className="flex gap-2">
                       <button
                         type="button"
                         onClick={() => setShowDeleteConfirm(false)}
                         className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                       >
-                        Cancel
+                        {t('common.cancel')}
                       </button>
                       <button
                         type="button"
                         onClick={handleDelete}
                         className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
                       >
-                        Confirm
+                        {t('common.confirm')}
                       </button>
                     </div>
                   </div>
@@ -258,7 +260,7 @@ function ProjectSettingsContent({
                     onClick={() => setShowDeleteConfirm(true)}
                     className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
                   >
-                    Delete Project
+                    {t('project.deleteProject')}
                   </button>
                 )}
               </div>

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -94,10 +94,14 @@ function ProjectSettingsContent({
         queryClient.invalidateQueries({
           queryKey: getGetProjectQueryKey(projectId),
         });
-        addToast('success', t('project.fieldUpdated', { field }));
+        const fieldLabelKey =
+          field === 'repository_path' ? 'project.repositoryPath' : `project.${field}`;
+        addToast('success', t('project.fieldUpdated', { field: t(fieldLabelKey) }));
       }
     } catch {
-      addToast('error', t('project.fieldUpdateFailed', { field }));
+      const fieldLabelKey =
+        field === 'repository_path' ? 'project.repositoryPath' : `project.${field}`;
+      addToast('error', t('project.fieldUpdateFailed', { field: t(fieldLabelKey) }));
     } finally {
       setEditingField(null);
     }

--- a/frontend/src/components/task/ActivityFilter.tsx
+++ b/frontend/src/components/task/ActivityFilter.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 export type ActivityFilterValue = 'all' | 'comments';
 
 export function ActivityFilter({
@@ -7,6 +9,7 @@ export function ActivityFilter({
   value: ActivityFilterValue;
   onChange: (value: ActivityFilterValue) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="inline-flex rounded-md border border-gray-200">
       <button
@@ -19,7 +22,7 @@ export function ActivityFilter({
           value === 'all' ? 'bg-gray-100 text-gray-900' : 'bg-white text-gray-500 hover:bg-gray-50'
         }`}
       >
-        All Activity
+        {t('activity.filterAll')}
       </button>
       <button
         type="button"
@@ -33,7 +36,7 @@ export function ActivityFilter({
             : 'bg-white text-gray-500 hover:bg-gray-50'
         }`}
       >
-        Comments Only
+        {t('activity.filterComments')}
       </button>
     </div>
   );

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useCreateTask } from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';
@@ -27,6 +28,7 @@ function TaskCreateForm({
   projectId: string;
   defaultStatus: TaskStatus | null;
 }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const closeTaskModal = useUiStore((s) => s.closeTaskModal);
   const createTask = useCreateTask();
@@ -60,7 +62,7 @@ function TaskCreateForm({
       invalidateTasks(queryClient);
       closeTaskModal();
     } catch {
-      setError('Failed to create task. Please try again.');
+      setError(t('task.createFailed'));
     }
   };
 
@@ -79,13 +81,13 @@ function TaskCreateForm({
         className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
       >
         <h2 id="task-create-title" className="mb-4 text-lg font-semibold">
-          Create Task
+          {t('task.createTask')}
         </h2>
         {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
-              Title
+              {t('task.title')}
             </label>
             <input
               id="task-title"
@@ -98,7 +100,7 @@ function TaskCreateForm({
           </div>
           <div>
             <label htmlFor="task-description" className="block text-sm font-medium text-gray-700">
-              Description
+              {t('task.description')}
             </label>
             <textarea
               id="task-description"
@@ -111,7 +113,7 @@ function TaskCreateForm({
           <div className="grid grid-cols-3 gap-4">
             <div>
               <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
-                Status
+                {t('task.status')}
               </label>
               <select
                 id="task-status"
@@ -119,16 +121,16 @@ function TaskCreateForm({
                 onChange={(e) => setStatus(e.target.value as TaskStatus)}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
               >
-                <option value={TaskStatus.backlog}>Backlog</option>
-                <option value={TaskStatus.todo}>To Do</option>
-                <option value={TaskStatus.in_progress}>In Progress</option>
-                <option value={TaskStatus.in_review}>In Review</option>
-                <option value={TaskStatus.done}>Done</option>
+                <option value={TaskStatus.backlog}>{t('board.status.backlog')}</option>
+                <option value={TaskStatus.todo}>{t('board.status.todo')}</option>
+                <option value={TaskStatus.in_progress}>{t('board.status.in_progress')}</option>
+                <option value={TaskStatus.in_review}>{t('board.status.in_review')}</option>
+                <option value={TaskStatus.done}>{t('board.status.done')}</option>
               </select>
             </div>
             <div>
               <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
-                Priority
+                {t('task.priority')}
               </label>
               <select
                 id="task-priority"
@@ -136,15 +138,15 @@ function TaskCreateForm({
                 onChange={(e) => setPriority(e.target.value as TaskPriority)}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
               >
-                <option value={TaskPriority.low}>Low</option>
-                <option value={TaskPriority.medium}>Medium</option>
-                <option value={TaskPriority.high}>High</option>
-                <option value={TaskPriority.urgent}>Urgent</option>
+                <option value={TaskPriority.low}>{t('board.priorityLabel.low')}</option>
+                <option value={TaskPriority.medium}>{t('board.priorityLabel.medium')}</option>
+                <option value={TaskPriority.high}>{t('board.priorityLabel.high')}</option>
+                <option value={TaskPriority.urgent}>{t('board.priorityLabel.urgent')}</option>
               </select>
             </div>
             <div>
               <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
-                Assignee
+                {t('board.assignee')}
               </label>
               <select
                 id="task-assignee"
@@ -152,7 +154,7 @@ function TaskCreateForm({
                 onChange={(e) => setAssignedTo(e.target.value)}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
               >
-                <option value="">Unassigned</option>
+                <option value="">{t('common.unassigned')}</option>
                 {members?.map((m) => (
                   <option key={m.user_id} value={m.user_id}>
                     {m.user_name}
@@ -167,14 +169,14 @@ function TaskCreateForm({
               onClick={closeTaskModal}
               className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={createTask.isPending}
               className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
             >
-              Create
+              {t('common.create')}
             </button>
           </div>
         </form>

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -64,7 +64,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         });
       }
     } catch {
-      setError(t('task.updateFailed', { field }));
+      setError(t('task.updateFailed', { field: t(`task.${field}`) }));
     } finally {
       setEditingField(null);
     }
@@ -102,7 +102,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       });
       invalidateTasks(queryClient);
     } catch {
-      setError(t('task.updateFailed', { field }));
+      setError(t('task.updateFailed', { field: t(`task.${field}`) }));
     }
   };
 

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
@@ -21,6 +22,7 @@ export function TaskDetailModal() {
 }
 
 function TaskDetailContent({ taskId }: { taskId: string }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const closeTaskDetail = useUiStore((s) => s.closeTaskDetail);
   const { data: task, isLoading, isError } = useGetTask(taskId);
@@ -62,7 +64,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         });
       }
     } catch {
-      setError(`Failed to update ${field}. Please try again.`);
+      setError(t('task.updateFailed', { field }));
     } finally {
       setEditingField(null);
     }
@@ -74,7 +76,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       invalidateTasks(queryClient);
       closeTaskDetail();
     } catch {
-      setError('Failed to delete task. Please try again.');
+      setError(t('task.deleteFailed'));
     }
   };
 
@@ -85,7 +87,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         data: { assigned_to: value || null },
       });
     } catch {
-      setError('Failed to update assignee. Please try again.');
+      setError(t('task.assigneeFailed'));
     }
   };
 
@@ -100,7 +102,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       });
       invalidateTasks(queryClient);
     } catch {
-      setError(`Failed to update ${field}. Please try again.`);
+      setError(t('task.updateFailed', { field }));
     }
   };
 
@@ -119,9 +121,9 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
         className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl"
       >
         {isLoading ? (
-          <p className="text-sm text-gray-500">Loading...</p>
+          <p className="text-sm text-gray-500">{t('common.loading')}</p>
         ) : isError || !task ? (
-          <p className="text-sm text-red-500">Failed to load task.</p>
+          <p className="text-sm text-red-500">{t('task.loadFailed')}</p>
         ) : (
           <div className="space-y-4">
             {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
@@ -150,14 +152,14 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                 type="button"
                 onClick={closeTaskDetail}
                 className="text-gray-400 hover:text-gray-600"
-                aria-label="Close"
+                aria-label={t('common.close')}
               >
                 <X className="h-5 w-5" />
               </button>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">Description</h3>
+              <h3 className="text-sm font-medium text-gray-700">{t('task.description')}</h3>
               {editingField === 'description' ? (
                 <textarea
                   value={editValue}
@@ -173,7 +175,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
                   onClick={() => startEditing('description', task.description ?? '')}
                 >
-                  {task.description || 'No description'}
+                  {task.description || t('common.noDescription')}
                 </button>
               )}
             </div>
@@ -184,7 +186,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   htmlFor="task-detail-status"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Status
+                  {t('task.status')}
                 </label>
                 <select
                   id="task-detail-status"
@@ -192,11 +194,11 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
                 >
-                  <option value="backlog">Backlog</option>
-                  <option value="todo">To Do</option>
-                  <option value="in_progress">In Progress</option>
-                  <option value="in_review">In Review</option>
-                  <option value="done">Done</option>
+                  <option value="backlog">{t('board.status.backlog')}</option>
+                  <option value="todo">{t('board.status.todo')}</option>
+                  <option value="in_progress">{t('board.status.in_progress')}</option>
+                  <option value="in_review">{t('board.status.in_review')}</option>
+                  <option value="done">{t('board.status.done')}</option>
                 </select>
               </div>
               <div>
@@ -204,7 +206,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   htmlFor="task-detail-priority"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Priority
+                  {t('task.priority')}
                 </label>
                 <select
                   id="task-detail-priority"
@@ -212,10 +214,10 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
                 >
-                  <option value="low">Low</option>
-                  <option value="medium">Medium</option>
-                  <option value="high">High</option>
-                  <option value="urgent">Urgent</option>
+                  <option value="low">{t('board.priorityLabel.low')}</option>
+                  <option value="medium">{t('board.priorityLabel.medium')}</option>
+                  <option value="high">{t('board.priorityLabel.high')}</option>
+                  <option value="urgent">{t('board.priorityLabel.urgent')}</option>
                 </select>
               </div>
               <div>
@@ -223,7 +225,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   htmlFor="task-detail-assignee"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Assignee
+                  {t('board.assignee')}
                 </label>
                 <select
                   id="task-detail-assignee"
@@ -231,7 +233,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   onChange={(e) => handleAssigneeChange(e.target.value)}
                   className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
                 >
-                  <option value="">Unassigned</option>
+                  <option value="">{t('common.unassigned')}</option>
                   {members?.map((m) => (
                     <option key={m.user_id} value={m.user_id}>
                       {m.user_name}
@@ -242,38 +244,38 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Worktrees</h3>
+              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('worktree.worktrees')}</h3>
               <WorktreePanel projectId={task.project_id} />
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Pull Requests</h3>
+              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('task.pullRequests')}</h3>
               <PullRequestList taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">Activity</h3>
+              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('activity.title')}</h3>
               <TaskTimeline taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">
               {showDeleteConfirm ? (
                 <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
-                  <p className="text-sm text-red-700">Are you sure you want to delete this task?</p>
+                  <p className="text-sm text-red-700">{t('task.deleteConfirm')}</p>
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() => setShowDeleteConfirm(false)}
                       className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                     >
-                      Cancel
+                      {t('common.cancel')}
                     </button>
                     <button
                       type="button"
                       onClick={handleDelete}
                       className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
                     >
-                      Confirm
+                      {t('common.confirm')}
                     </button>
                   </div>
                 </div>
@@ -283,7 +285,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   onClick={() => setShowDeleteConfirm(true)}
                   className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
                 >
-                  Delete
+                  {t('common.delete')}
                 </button>
               )}
             </div>

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import {
@@ -16,6 +17,7 @@ import { WorktreePanel } from '../preview/WorktreePanel';
 import { TaskTimeline } from './TaskTimeline';
 
 export function TaskDetailPage() {
+  const { t } = useTranslation();
   const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -55,7 +57,7 @@ export function TaskDetailPage() {
         invalidateTasks(queryClient);
       }
     } catch {
-      setError(`Failed to update ${field}. Please try again.`);
+      setError(t('task.updateFailed', { field }));
     } finally {
       setEditingField(null);
     }
@@ -68,7 +70,7 @@ export function TaskDetailPage() {
       invalidateTasks(queryClient);
       navigate(`/projects/${projectId}`);
     } catch {
-      setError('Failed to delete task. Please try again.');
+      setError(t('task.deleteFailed'));
     }
   };
 
@@ -82,7 +84,7 @@ export function TaskDetailPage() {
       queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
       invalidateTasks(queryClient);
     } catch {
-      setError('Failed to update assignee. Please try again.');
+      setError(t('task.assigneeFailed'));
     }
   };
 
@@ -99,14 +101,14 @@ export function TaskDetailPage() {
       queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
       invalidateTasks(queryClient);
     } catch {
-      setError(`Failed to update ${field}. Please try again.`);
+      setError(t('task.updateFailed', { field }));
     }
   };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-gray-500">Loading task...</p>
+        <p className="text-gray-500">{t('task.loadingTask')}</p>
       </div>
     );
   }
@@ -118,9 +120,9 @@ export function TaskDetailPage() {
           to={`/projects/${projectId}`}
           className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
         >
-          <ArrowLeft className="h-4 w-4" /> Back to Board
+          <ArrowLeft className="h-4 w-4" /> {t('task.backToBoard')}
         </Link>
-        <p className="text-red-500">Failed to load task.</p>
+        <p className="text-red-500">{t('task.loadFailed')}</p>
       </div>
     );
   }
@@ -131,7 +133,7 @@ export function TaskDetailPage() {
         to={`/projects/${projectId}`}
         className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
       >
-        <ArrowLeft className="h-4 w-4" /> Back to Board
+        <ArrowLeft className="h-4 w-4" /> {t('task.backToBoard')}
       </Link>
 
       {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
@@ -163,7 +165,7 @@ export function TaskDetailPage() {
 
           {/* Description */}
           <div>
-            <h3 className="mb-1 text-sm font-medium text-gray-700">Description</h3>
+            <h3 className="mb-1 text-sm font-medium text-gray-700">{t('task.description')}</h3>
             {editingField === 'description' ? (
               <textarea
                 value={editValue}
@@ -179,14 +181,14 @@ export function TaskDetailPage() {
                 className="w-full cursor-pointer rounded px-2 py-1 text-left text-sm text-gray-600 hover:bg-gray-100"
                 onClick={() => startEditing('description', task.description ?? '')}
               >
-                {task.description || 'No description'}
+                {task.description || t('common.noDescription')}
               </button>
             )}
           </div>
 
           {/* Activity */}
           <div className="border-t pt-6">
-            <h3 className="mb-3 text-sm font-medium text-gray-700">Activity</h3>
+            <h3 className="mb-3 text-sm font-medium text-gray-700">{t('activity.title')}</h3>
             <TaskTimeline taskId={task.id} />
           </div>
         </div>
@@ -195,7 +197,7 @@ export function TaskDetailPage() {
         <div className="space-y-6">
           <div>
             <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
-              Status
+              {t('task.status')}
             </label>
             <select
               id="task-status"
@@ -203,17 +205,17 @@ export function TaskDetailPage() {
               onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
             >
-              <option value="backlog">Backlog</option>
-              <option value="todo">To Do</option>
-              <option value="in_progress">In Progress</option>
-              <option value="in_review">In Review</option>
-              <option value="done">Done</option>
+              <option value="backlog">{t('board.status.backlog')}</option>
+              <option value="todo">{t('board.status.todo')}</option>
+              <option value="in_progress">{t('board.status.in_progress')}</option>
+              <option value="in_review">{t('board.status.in_review')}</option>
+              <option value="done">{t('board.status.done')}</option>
             </select>
           </div>
 
           <div>
             <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
-              Priority
+              {t('task.priority')}
             </label>
             <select
               id="task-priority"
@@ -221,16 +223,16 @@ export function TaskDetailPage() {
               onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
             >
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-              <option value="urgent">Urgent</option>
+              <option value="low">{t('board.priorityLabel.low')}</option>
+              <option value="medium">{t('board.priorityLabel.medium')}</option>
+              <option value="high">{t('board.priorityLabel.high')}</option>
+              <option value="urgent">{t('board.priorityLabel.urgent')}</option>
             </select>
           </div>
 
           <div>
             <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
-              Assignee
+              {t('board.assignee')}
             </label>
             <select
               id="task-assignee"
@@ -238,7 +240,7 @@ export function TaskDetailPage() {
               onChange={(e) => handleAssigneeChange(e.target.value)}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
             >
-              <option value="">Unassigned</option>
+              <option value="">{t('common.unassigned')}</option>
               {members?.map((m) => (
                 <option key={m.user_id} value={m.user_id}>
                   {m.user_name}
@@ -248,12 +250,12 @@ export function TaskDetailPage() {
           </div>
 
           <div className="border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">Worktrees</h3>
+            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('worktree.worktrees')}</h3>
             <WorktreePanel projectId={projectId ?? ''} />
           </div>
 
           <div className="border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">Pull Requests</h3>
+            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('task.pullRequests')}</h3>
             <PullRequestList taskId={task.id} />
           </div>
 
@@ -261,7 +263,7 @@ export function TaskDetailPage() {
             {showDeleteConfirm ? (
               <div className="rounded-md bg-red-50 p-3">
                 <p className="mb-2 text-sm text-red-700">
-                  Are you sure you want to delete this task?
+                  {t('task.deleteConfirm')}
                 </p>
                 <div className="flex gap-2">
                   <button
@@ -269,14 +271,14 @@ export function TaskDetailPage() {
                     onClick={() => setShowDeleteConfirm(false)}
                     className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                   >
-                    Cancel
+                    {t('common.cancel')}
                   </button>
                   <button
                     type="button"
                     onClick={handleDelete}
                     className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
                   >
-                    Confirm
+                    {t('common.confirm')}
                   </button>
                 </div>
               </div>
@@ -286,7 +288,7 @@ export function TaskDetailPage() {
                 onClick={() => setShowDeleteConfirm(true)}
                 className="w-full rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
               >
-                Delete Task
+                {t('task.deleteTask')}
               </button>
             )}
           </div>

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -57,7 +57,7 @@ export function TaskDetailPage() {
         invalidateTasks(queryClient);
       }
     } catch {
-      setError(t('task.updateFailed', { field }));
+      setError(t('task.updateFailed', { field: t(`task.${field}`) }));
     } finally {
       setEditingField(null);
     }
@@ -101,7 +101,7 @@ export function TaskDetailPage() {
       queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) });
       invalidateTasks(queryClient);
     } catch {
-      setError(t('task.updateFailed', { field }));
+      setError(t('task.updateFailed', { field: t(`task.${field}`) }));
     }
   };
 

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -262,9 +262,7 @@ export function TaskDetailPage() {
           <div className="border-t pt-4">
             {showDeleteConfirm ? (
               <div className="rounded-md bg-red-50 p-3">
-                <p className="mb-2 text-sm text-red-700">
-                  {t('task.deleteConfirm')}
-                </p>
+                <p className="mb-2 text-sm text-red-700">{t('task.deleteConfirm')}</p>
                 <div className="flex gap-2">
                   <button
                     type="button"

--- a/frontend/src/components/task/TaskTimeline.tsx
+++ b/frontend/src/components/task/TaskTimeline.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListAgentSessionsQueryKey,
   useGetAgentSessionOutputs,
@@ -28,6 +29,7 @@ export type { TimelineItem } from './timelineUtils';
 export { mergeTimeline } from './timelineUtils';
 
 export function TaskTimeline({ taskId }: { taskId: string }) {
+  const { t } = useTranslation();
   const { data: comments, isLoading: commentsLoading } = useListComments(taskId);
   const { data: sessions, isLoading: sessionsLoading } = useListAgentSessions(taskId);
   const createComment = useCreateComment();
@@ -112,7 +114,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
       setPrompt('');
       invalidateSessions();
     } catch {
-      setAgentError('Failed to start agent session.');
+      setAgentError(t('agent.startFailed'));
     } finally {
       isStartingRef.current = false;
     }
@@ -125,7 +127,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
       reset();
       invalidateSessions();
     } catch {
-      setAgentError('Failed to stop agent session.');
+      setAgentError(t('agent.stopFailed'));
     }
   };
 
@@ -137,7 +139,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
       setNewComment('');
       queryClient.invalidateQueries({ queryKey: getListCommentsQueryKey(taskId) });
     } catch {
-      addToast('error', 'Failed to post comment.');
+      addToast('error', t('activity.commentFailed'));
     }
   };
 
@@ -178,7 +180,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
               disabled={stopSession.isPending}
               className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
             >
-              Stop
+              {t('common.stop')}
             </button>
           </div>
           <AgentOutputViewer lines={outputLines} isLoading={false} />
@@ -201,7 +203,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                   }}
                   className="text-sm text-blue-600 hover:text-blue-800"
                 >
-                  Back
+                  {t('common.back')}
                 </button>
                 <span className="text-sm text-gray-600">
                   {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
@@ -229,7 +231,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 htmlFor="timeline-agent-type"
                 className="block text-sm font-medium text-gray-700"
               >
-                Agent Type
+                {t('agent.agentType')}
               </label>
               <select
                 id="timeline-agent-type"
@@ -237,8 +239,8 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 onChange={(e) => setAgentType(e.target.value as AgentType)}
                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
               >
-                <option value="claude_code">Claude Code</option>
-                <option value="gemini_cli">Gemini CLI</option>
+                <option value="claude_code">{t('agent.claudeCode')}</option>
+                <option value="gemini_cli">{t('agent.geminiCli')}</option>
               </select>
             </div>
             <div className="flex items-end">
@@ -248,14 +250,14 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 disabled={!prompt.trim() || startSession.isPending}
                 className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
               >
-                Start
+                {t('common.start')}
               </button>
             </div>
           </div>
           <textarea
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Enter prompt for the agent..."
+            placeholder={t('agent.promptPlaceholder')}
             rows={2}
             className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
           />
@@ -273,7 +275,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
               handleSubmitComment();
             }
           }}
-          placeholder="Add a comment..."
+          placeholder={t('activity.commentPlaceholder')}
           rows={2}
           className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
         />
@@ -283,7 +285,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
           disabled={!newComment.trim() || createComment.isPending}
           className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          Post
+          {t('common.post')}
         </button>
       </div>
 
@@ -292,9 +294,9 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
 
       {/* Timeline */}
       {isLoading ? (
-        <p className="text-sm text-gray-500">Loading activity...</p>
+        <p className="text-sm text-gray-500">{t('activity.loadingActivity')}</p>
       ) : timeline.length === 0 ? (
-        <p className="text-sm text-gray-500">No activity yet.</p>
+        <p className="text-sm text-gray-500">{t('activity.noActivity')}</p>
       ) : (
         <div className="divide-y">
           {timeline.map((item) =>

--- a/frontend/src/components/task/TimelineCommentItem.tsx
+++ b/frontend/src/components/task/TimelineCommentItem.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getListCommentsQueryKey,
   useDeleteComment,
@@ -18,6 +19,7 @@ export function TimelineCommentItem({
   taskId: string;
   isOwner: boolean;
 }) {
+  const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -42,7 +44,7 @@ export function TimelineCommentItem({
       setEditing(false);
       invalidateComments();
     } catch {
-      addToast('error', 'Failed to update comment.');
+      addToast('error', t('activity.commentUpdateFailed'));
     }
   };
 
@@ -52,7 +54,7 @@ export function TimelineCommentItem({
       setShowDeleteConfirm(false);
       invalidateComments();
     } catch {
-      addToast('error', 'Failed to delete comment.');
+      addToast('error', t('activity.commentDeleteFailed'));
     }
   };
 
@@ -69,22 +71,22 @@ export function TimelineCommentItem({
             <div className="ml-auto flex gap-1">
               <button
                 type="button"
-                aria-label="Edit"
+                aria-label={t('common.edit')}
                 onClick={() => {
                   setEditing(true);
                   setEditValue(comment.content);
                 }}
                 className="text-xs text-gray-400 hover:text-gray-600"
               >
-                Edit
+                {t('common.edit')}
               </button>
               <button
                 type="button"
-                aria-label="Delete"
+                aria-label={t('common.delete')}
                 onClick={() => setShowDeleteConfirm(true)}
                 className="text-xs text-gray-400 hover:text-red-600"
               >
-                Delete
+                {t('common.delete')}
               </button>
             </div>
           )}
@@ -92,7 +94,7 @@ export function TimelineCommentItem({
         {editing ? (
           <div className="mt-1 space-y-1">
             <textarea
-              aria-label="Edit comment"
+              aria-label={t('task.editComment')}
               value={editValue}
               onChange={(e) => setEditValue(e.target.value)}
               rows={2}
@@ -104,33 +106,33 @@ export function TimelineCommentItem({
                 onClick={handleSave}
                 className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
               >
-                Save
+                {t('common.save')}
               </button>
               <button
                 type="button"
                 onClick={() => setEditing(false)}
                 className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
               >
-                Cancel
+                {t('common.cancel')}
               </button>
             </div>
           </div>
         ) : showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">Delete this comment?</span>
+            <span className="text-xs text-red-700">{t('activity.deleteCommentConfirm')}</span>
             <button
               type="button"
               onClick={handleDelete}
               className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
             >
-              Confirm
+              {t('common.confirm')}
             </button>
             <button
               type="button"
               onClick={() => setShowDeleteConfirm(false)}
               className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
           </div>
         ) : (

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,0 +1,25 @@
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
+import en from '@/locales/en.json';
+import ja from '@/locales/ja.json';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      ja: { translation: ja },
+    },
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+    },
+  });
+
+export default i18n;

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -4,22 +4,24 @@ import { initReactI18next } from 'react-i18next';
 import en from '@/locales/en.json';
 import ja from '@/locales/ja.json';
 
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources: {
-      en: { translation: en },
-      ja: { translation: ja },
-    },
-    fallbackLng: 'en',
-    interpolation: {
-      escapeValue: false,
-    },
-    detection: {
-      order: ['localStorage', 'navigator'],
-      caches: ['localStorage'],
-    },
-  });
+if (!i18n.isInitialized) {
+  i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      resources: {
+        en: { translation: en },
+        ja: { translation: ja },
+      },
+      fallbackLng: 'en',
+      interpolation: {
+        escapeValue: false,
+      },
+      detection: {
+        order: ['localStorage', 'navigator'],
+        caches: ['localStorage'],
+      },
+    });
+}
 
 export default i18n;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -21,7 +21,13 @@
     "noDescription": "No description",
     "unassigned": "Unassigned",
     "add": "Add",
-    "areYouSure": "Are you sure?"
+    "areYouSure": "Are you sure?",
+    "timeAgo": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}} min ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    }
   },
   "auth": {
     "signIn": "Sign in",
@@ -174,6 +180,12 @@
     "noOutput": "No output yet",
     "startFailed": "Failed to start agent session.",
     "stopFailed": "Failed to stop agent session.",
+    "pauseFailed": "Failed to pause agent session.",
+    "resumeFailed": "Failed to resume agent session.",
+    "prompt": "Prompt",
+    "pastSessions": "Past Sessions",
+    "pause": "Pause",
+    "resume": "Resume",
     "status": {
       "pending": "pending",
       "running": "running",
@@ -195,12 +207,31 @@
     "deleteConfirm": "Are you sure?",
     "invalid": "invalid"
   },
+  "comment": {
+    "loadingComments": "Loading comments...",
+    "noComments": "No comments yet.",
+    "addPlaceholder": "Add a comment...",
+    "postFailed": "Failed to post comment.",
+    "updateFailed": "Failed to update comment.",
+    "deleteFailed": "Failed to delete comment.",
+    "deleteConfirm": "Delete this comment?"
+  },
   "preview": {
+    "dockerPreviews": "Docker Previews",
     "start": "Start",
     "stop": "Stop",
     "restart": "Restart",
     "delete": "Delete",
     "worktreeName": "Worktree name",
+    "worktreeNameLabel": "Worktree Name",
+    "createFailed": "Failed to create preview",
+    "startFailed": "Failed to start preview",
+    "stopFailed": "Failed to stop preview",
+    "restartFailed": "Failed to restart preview",
+    "deleteFailed": "Failed to delete preview",
+    "loadingPreviews": "Loading previews...",
+    "loadFailed": "Failed to load previews",
+    "noPreviews": "No previews",
     "status": {
       "pending": "pending",
       "building": "building",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -170,6 +170,8 @@
     "claudeCode": "Claude Code",
     "geminiCli": "Gemini CLI",
     "promptPlaceholder": "Enter prompt for the agent...",
+    "loadingOutput": "Loading output...",
+    "noOutput": "No output yet",
     "startFailed": "Failed to start agent session.",
     "stopFailed": "Failed to stop agent session.",
     "status": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,221 @@
+{
+  "common": {
+    "loading": "Loading...",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "save": "Save",
+    "delete": "Delete",
+    "create": "Create",
+    "edit": "Edit",
+    "close": "Close",
+    "back": "Back",
+    "send": "Send",
+    "post": "Post",
+    "start": "Start",
+    "stop": "Stop",
+    "remove": "Remove",
+    "search": "Search",
+    "clearAll": "Clear all",
+    "dismiss": "Dismiss",
+    "reloadPage": "Reload Page",
+    "noDescription": "No description",
+    "unassigned": "Unassigned"
+  },
+  "auth": {
+    "signIn": "Sign in",
+    "signInTo": "Sign in to Gantry Board",
+    "signingIn": "Signing in...",
+    "signUp": "Sign up",
+    "createAccount": "Create your account",
+    "creatingAccount": "Creating account...",
+    "createAccountBtn": "Create account",
+    "email": "Email",
+    "emailPlaceholder": "you@example.com",
+    "password": "Password",
+    "passwordPlaceholder": "Enter your password",
+    "passwordMinLength": "At least 8 characters",
+    "name": "Name",
+    "namePlaceholder": "Your name",
+    "noAccount": "Don't have an account?",
+    "hasAccount": "Already have an account?",
+    "invalidCredentials": "Invalid email or password. Please try again.",
+    "registrationFailed": "Registration failed. The email may already be in use.",
+    "passwordTooShort": "Password must be at least 8 characters",
+    "logout": "Logout"
+  },
+  "invitation": {
+    "title": "Project Invitation",
+    "invalidLink": "Invalid invitation link.",
+    "loadingInvitation": "Loading invitation...",
+    "expiredOrInvalid": "Invalid or expired invitation link.",
+    "invitedYou": "invited you to join",
+    "role": "Role:",
+    "alreadyAccepted": "This invitation has already been accepted.",
+    "expired": "This invitation has expired.",
+    "loginRequired": "Please log in to accept this invitation.",
+    "logIn": "Log In",
+    "accept": "Accept Invitation",
+    "accepting": "Accepting...",
+    "acceptFailed": "Failed to accept invitation. It may have expired or already been used."
+  },
+  "project": {
+    "projects": "Projects",
+    "newProject": "New Project",
+    "createProject": "Create Project",
+    "noProjects": "No projects yet",
+    "createFirst": "Create your first project",
+    "settings": "Project Settings",
+    "projectSettings": "Project settings",
+    "name": "Name",
+    "description": "Description",
+    "repositoryPath": "Repository Path",
+    "repositoryPathPlaceholder": "/path/to/git/repo (optional)",
+    "notSetGlobal": "Not set (using global)",
+    "fieldUpdated": "Project {{field}} updated.",
+    "fieldUpdateFailed": "Failed to update {{field}}.",
+    "deleted": "Project deleted.",
+    "deleteFailed": "Failed to delete project.",
+    "createFailed": "Failed to create project. Please try again.",
+    "deleteConfirm": "Are you sure? This cannot be undone.",
+    "deleteProject": "Delete Project",
+    "loadingProjects": "Loading projects...",
+    "loadFailed": "Failed to load project."
+  },
+  "members": {
+    "members": "Members",
+    "searchPlaceholder": "Search users by name or email...",
+    "addedSuccess": "{{name}} added.",
+    "addFailed": "Failed to add member.",
+    "roleUpdateFailed": "Failed to update role.",
+    "removed": "Member removed.",
+    "removeFailed": "Failed to remove member.",
+    "inviteCopied": "Invitation link copied to clipboard!",
+    "inviteCreated": "Invitation created: {{url}}",
+    "inviteFailed": "Failed to create invitation.",
+    "revokeFailed": "Failed to revoke invitation.",
+    "revoke": "Revoke",
+    "pendingInvitations": "Pending Invitations",
+    "inviteMember": "Invite Member",
+    "role": {
+      "owner": "Owner",
+      "admin": "Admin",
+      "member": "Member"
+    }
+  },
+  "board": {
+    "loadingTasks": "Loading tasks...",
+    "loadFailed": "Failed to load tasks",
+    "noTasks": "No tasks",
+    "addTask": "Add Task",
+    "searchPlaceholder": "Search tasks...",
+    "assignee": "Assignee",
+    "priority": "Priority",
+    "status": {
+      "backlog": "Backlog",
+      "todo": "To Do",
+      "in_progress": "In Progress",
+      "in_review": "In Review",
+      "done": "Done"
+    },
+    "priorityLabel": {
+      "urgent": "Urgent",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low"
+    }
+  },
+  "task": {
+    "createTask": "Create Task",
+    "title": "Title",
+    "description": "Description",
+    "status": "Status",
+    "priority": "Priority",
+    "assignedTo": "Assigned To",
+    "createFailed": "Failed to create task. Please try again.",
+    "updateFailed": "Failed to update {{field}}. Please try again.",
+    "deleteFailed": "Failed to delete task. Please try again.",
+    "backToBoard": "Back to Board",
+    "editComment": "Edit comment"
+  },
+  "activity": {
+    "title": "Activity",
+    "filterAll": "All Activity",
+    "filterComments": "Comments Only",
+    "filterLabel": "Activity filter",
+    "noActivity": "No activity yet.",
+    "loadingActivity": "Loading activity...",
+    "commentPlaceholder": "Add a comment...",
+    "commentFailed": "Failed to post comment.",
+    "commentUpdateFailed": "Failed to update comment.",
+    "commentDeleteFailed": "Failed to delete comment."
+  },
+  "agent": {
+    "agentType": "Agent Type",
+    "claudeCode": "Claude Code",
+    "geminiCli": "Gemini CLI",
+    "promptPlaceholder": "Enter prompt for the agent...",
+    "startFailed": "Failed to start agent session.",
+    "stopFailed": "Failed to stop agent session.",
+    "status": {
+      "pending": "pending",
+      "running": "running",
+      "paused": "paused",
+      "completed": "completed",
+      "failed": "failed",
+      "cancelled": "cancelled"
+    }
+  },
+  "worktree": {
+    "worktrees": "Worktrees",
+    "namePlaceholder": "Worktree name...",
+    "createFailed": "Failed to create worktree.",
+    "deleteFailed": "Failed to delete worktree."
+  },
+  "preview": {
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "delete": "Delete",
+    "worktreeName": "Worktree name",
+    "status": {
+      "pending": "pending",
+      "building": "building",
+      "running": "running",
+      "stopped": "stopped",
+      "failed": "failed"
+    }
+  },
+  "github": {
+    "github": "GitHub",
+    "owner": "Owner",
+    "ownerPlaceholder": "owner",
+    "repoPlaceholder": "repo",
+    "linked": "GitHub repository linked.",
+    "linkFailed": "Failed to link repository.",
+    "syncComplete": "Sync complete: {{pushed}} pushed, {{pulled}} pulled.",
+    "syncFailed": "Sync failed.",
+    "unlinked": "GitHub repository unlinked.",
+    "unlinkFailed": "Failed to unlink repository.",
+    "link": "Link",
+    "unlink": "Unlink",
+    "sync": "Sync"
+  },
+  "chat": {
+    "projectChat": "Project Chat",
+    "placeholder": "Type a message...",
+    "sendFailed": "Failed to send message.",
+    "deleteFailed": "Failed to delete message."
+  },
+  "error": {
+    "somethingWrong": "Something went wrong",
+    "unexpectedError": "An unexpected error occurred. Please try reloading the page."
+  },
+  "language": {
+    "switchLanguage": "Language",
+    "en": "English",
+    "ja": "日本語"
+  },
+  "app": {
+    "title": "Gantry Board"
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -138,6 +138,9 @@
     "deleteConfirm": "Are you sure you want to delete this task?",
     "pullRequests": "Pull Requests",
     "backToBoard": "Back to Board",
+    "loadingTask": "Loading task...",
+    "loadFailed": "Failed to load task.",
+    "assigneeFailed": "Failed to update assignee. Please try again.",
     "editComment": "Edit comment"
   },
   "activity": {
@@ -150,7 +153,8 @@
     "commentPlaceholder": "Add a comment...",
     "commentFailed": "Failed to post comment.",
     "commentUpdateFailed": "Failed to update comment.",
-    "commentDeleteFailed": "Failed to delete comment."
+    "commentDeleteFailed": "Failed to delete comment.",
+    "deleteCommentConfirm": "Delete this comment?"
   },
   "agent": {
     "agentType": "Agent Type",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -134,6 +134,9 @@
     "createFailed": "Failed to create task. Please try again.",
     "updateFailed": "Failed to update {{field}}. Please try again.",
     "deleteFailed": "Failed to delete task. Please try again.",
+    "deleteTask": "Delete Task",
+    "deleteConfirm": "Are you sure you want to delete this task?",
+    "pullRequests": "Pull Requests",
     "backToBoard": "Back to Board",
     "editComment": "Edit comment"
   },
@@ -169,7 +172,12 @@
     "worktrees": "Worktrees",
     "namePlaceholder": "Worktree name...",
     "createFailed": "Failed to create worktree.",
-    "deleteFailed": "Failed to delete worktree."
+    "deleteFailed": "Failed to delete worktree.",
+    "loadingWorktrees": "Loading worktrees...",
+    "loadFailed": "Failed to load worktrees.",
+    "noWorktrees": "No worktrees",
+    "deleteConfirm": "Are you sure?",
+    "invalid": "invalid"
   },
   "preview": {
     "start": "Start",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -19,7 +19,9 @@
     "dismiss": "Dismiss",
     "reloadPage": "Reload Page",
     "noDescription": "No description",
-    "unassigned": "Unassigned"
+    "unassigned": "Unassigned",
+    "add": "Add",
+    "areYouSure": "Are you sure?"
   },
   "auth": {
     "signIn": "Sign in",
@@ -96,6 +98,13 @@
     "revoke": "Revoke",
     "pendingInvitations": "Pending Invitations",
     "inviteMember": "Invite Member",
+    "addExistingUser": "Add Existing User",
+    "invitationLinks": "Invitation Links",
+    "createLink": "Create Link",
+    "expired": "Expired",
+    "expires": "Expires {{date}}",
+    "noPendingInvitations": "No pending invitations.",
+    "loadFailed": "Failed to load members.",
     "role": {
       "owner": "Owner",
       "admin": "Admin",
@@ -174,6 +183,7 @@
   },
   "worktree": {
     "worktrees": "Worktrees",
+    "worktreeName": "Worktree Name",
     "namePlaceholder": "Worktree name...",
     "createFailed": "Failed to create worktree.",
     "deleteFailed": "Failed to delete worktree.",
@@ -200,8 +210,15 @@
   "github": {
     "github": "GitHub",
     "owner": "Owner",
+    "repository": "Repository",
     "ownerPlaceholder": "owner",
     "repoPlaceholder": "repo",
+    "loadingPullRequests": "Loading pull requests...",
+    "loadPullRequestsFailed": "Failed to load pull requests.",
+    "noPullRequests": "No pull requests",
+    "prOpen": "open",
+    "prMerged": "merged",
+    "prClosed": "closed",
     "linked": "GitHub repository linked.",
     "linkFailed": "Failed to link repository.",
     "syncComplete": "Sync complete: {{pushed}} pushed, {{pulled}} pulled.",
@@ -215,6 +232,9 @@
   "chat": {
     "projectChat": "Project Chat",
     "placeholder": "Type a message...",
+    "loadingMessages": "Loading messages...",
+    "noMessages": "No messages yet. Start the conversation!",
+    "deleteMessageConfirm": "Delete this message?",
     "sendFailed": "Failed to send message.",
     "deleteFailed": "Failed to delete message."
   },

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1,0 +1,221 @@
+{
+  "common": {
+    "loading": "読み込み中...",
+    "cancel": "キャンセル",
+    "confirm": "確認",
+    "save": "保存",
+    "delete": "削除",
+    "create": "作成",
+    "edit": "編集",
+    "close": "閉じる",
+    "back": "戻る",
+    "send": "送信",
+    "post": "投稿",
+    "start": "開始",
+    "stop": "停止",
+    "remove": "削除",
+    "search": "検索",
+    "clearAll": "すべてクリア",
+    "dismiss": "閉じる",
+    "reloadPage": "ページを再読み込み",
+    "noDescription": "説明なし",
+    "unassigned": "未割り当て"
+  },
+  "auth": {
+    "signIn": "ログイン",
+    "signInTo": "Gantry Board にログイン",
+    "signingIn": "ログイン中...",
+    "signUp": "新規登録",
+    "createAccount": "アカウントを作成",
+    "creatingAccount": "アカウント作成中...",
+    "createAccountBtn": "アカウントを作成",
+    "email": "メールアドレス",
+    "emailPlaceholder": "you@example.com",
+    "password": "パスワード",
+    "passwordPlaceholder": "パスワードを入力",
+    "passwordMinLength": "8文字以上",
+    "name": "名前",
+    "namePlaceholder": "お名前",
+    "noAccount": "アカウントをお持ちでないですか？",
+    "hasAccount": "すでにアカウントをお持ちですか？",
+    "invalidCredentials": "メールアドレスまたはパスワードが正しくありません。",
+    "registrationFailed": "登録に失敗しました。メールアドレスが既に使用されている可能性があります。",
+    "passwordTooShort": "パスワードは8文字以上にしてください",
+    "logout": "ログアウト"
+  },
+  "invitation": {
+    "title": "プロジェクト招待",
+    "invalidLink": "無効な招待リンクです。",
+    "loadingInvitation": "招待を読み込み中...",
+    "expiredOrInvalid": "無効または期限切れの招待リンクです。",
+    "invitedYou": "があなたを招待しました",
+    "role": "ロール:",
+    "alreadyAccepted": "この招待は既に受理されています。",
+    "expired": "この招待は期限切れです。",
+    "loginRequired": "招待を受けるにはログインしてください。",
+    "logIn": "ログイン",
+    "accept": "招待を受ける",
+    "accepting": "受理中...",
+    "acceptFailed": "招待の受理に失敗しました。期限切れまたは既に使用されている可能性があります。"
+  },
+  "project": {
+    "projects": "プロジェクト",
+    "newProject": "新規プロジェクト",
+    "createProject": "プロジェクトを作成",
+    "noProjects": "プロジェクトがありません",
+    "createFirst": "最初のプロジェクトを作成",
+    "settings": "プロジェクト設定",
+    "projectSettings": "プロジェクト設定",
+    "name": "名前",
+    "description": "説明",
+    "repositoryPath": "リポジトリパス",
+    "repositoryPathPlaceholder": "/path/to/git/repo (任意)",
+    "notSetGlobal": "未設定 (グローバル設定を使用)",
+    "fieldUpdated": "プロジェクトの{{field}}を更新しました。",
+    "fieldUpdateFailed": "{{field}}の更新に失敗しました。",
+    "deleted": "プロジェクトを削除しました。",
+    "deleteFailed": "プロジェクトの削除に失敗しました。",
+    "createFailed": "プロジェクトの作成に失敗しました。もう一度お試しください。",
+    "deleteConfirm": "本当に削除しますか？この操作は取り消せません。",
+    "deleteProject": "プロジェクトを削除",
+    "loadingProjects": "プロジェクトを読み込み中...",
+    "loadFailed": "プロジェクトの読み込みに失敗しました。"
+  },
+  "members": {
+    "members": "メンバー",
+    "searchPlaceholder": "名前またはメールで検索...",
+    "addedSuccess": "{{name}}を追加しました。",
+    "addFailed": "メンバーの追加に失敗しました。",
+    "roleUpdateFailed": "ロールの更新に失敗しました。",
+    "removed": "メンバーを削除しました。",
+    "removeFailed": "メンバーの削除に失敗しました。",
+    "inviteCopied": "招待リンクをクリップボードにコピーしました！",
+    "inviteCreated": "招待を作成しました: {{url}}",
+    "inviteFailed": "招待の作成に失敗しました。",
+    "revokeFailed": "招待の取り消しに失敗しました。",
+    "revoke": "取り消し",
+    "pendingInvitations": "保留中の招待",
+    "inviteMember": "メンバーを招待",
+    "role": {
+      "owner": "オーナー",
+      "admin": "管理者",
+      "member": "メンバー"
+    }
+  },
+  "board": {
+    "loadingTasks": "タスクを読み込み中...",
+    "loadFailed": "タスクの読み込みに失敗しました",
+    "noTasks": "タスクなし",
+    "addTask": "タスクを追加",
+    "searchPlaceholder": "タスクを検索...",
+    "assignee": "担当者",
+    "priority": "優先度",
+    "status": {
+      "backlog": "バックログ",
+      "todo": "未着手",
+      "in_progress": "進行中",
+      "in_review": "レビュー中",
+      "done": "完了"
+    },
+    "priorityLabel": {
+      "urgent": "緊急",
+      "high": "高",
+      "medium": "中",
+      "low": "低"
+    }
+  },
+  "task": {
+    "createTask": "タスクを作成",
+    "title": "タイトル",
+    "description": "説明",
+    "status": "ステータス",
+    "priority": "優先度",
+    "assignedTo": "担当者",
+    "createFailed": "タスクの作成に失敗しました。もう一度お試しください。",
+    "updateFailed": "{{field}}の更新に失敗しました。もう一度お試しください。",
+    "deleteFailed": "タスクの削除に失敗しました。もう一度お試しください。",
+    "backToBoard": "ボードに戻る",
+    "editComment": "コメントを編集"
+  },
+  "activity": {
+    "title": "アクティビティ",
+    "filterAll": "すべてのアクティビティ",
+    "filterComments": "コメントのみ",
+    "filterLabel": "アクティビティフィルタ",
+    "noActivity": "アクティビティはありません。",
+    "loadingActivity": "アクティビティを読み込み中...",
+    "commentPlaceholder": "コメントを追加...",
+    "commentFailed": "コメントの投稿に失敗しました。",
+    "commentUpdateFailed": "コメントの更新に失敗しました。",
+    "commentDeleteFailed": "コメントの削除に失敗しました。"
+  },
+  "agent": {
+    "agentType": "エージェントタイプ",
+    "claudeCode": "Claude Code",
+    "geminiCli": "Gemini CLI",
+    "promptPlaceholder": "エージェントへのプロンプトを入力...",
+    "startFailed": "エージェントセッションの開始に失敗しました。",
+    "stopFailed": "エージェントセッションの停止に失敗しました。",
+    "status": {
+      "pending": "待機中",
+      "running": "実行中",
+      "paused": "一時停止",
+      "completed": "完了",
+      "failed": "失敗",
+      "cancelled": "キャンセル"
+    }
+  },
+  "worktree": {
+    "worktrees": "ワークツリー",
+    "namePlaceholder": "ワークツリー名...",
+    "createFailed": "ワークツリーの作成に失敗しました。",
+    "deleteFailed": "ワークツリーの削除に失敗しました。"
+  },
+  "preview": {
+    "start": "開始",
+    "stop": "停止",
+    "restart": "再起動",
+    "delete": "削除",
+    "worktreeName": "ワークツリー名",
+    "status": {
+      "pending": "待機中",
+      "building": "ビルド中",
+      "running": "実行中",
+      "stopped": "停止済み",
+      "failed": "失敗"
+    }
+  },
+  "github": {
+    "github": "GitHub",
+    "owner": "オーナー",
+    "ownerPlaceholder": "owner",
+    "repoPlaceholder": "repo",
+    "linked": "GitHub リポジトリをリンクしました。",
+    "linkFailed": "リポジトリのリンクに失敗しました。",
+    "syncComplete": "同期完了: {{pushed}} プッシュ、{{pulled}} プル。",
+    "syncFailed": "同期に失敗しました。",
+    "unlinked": "GitHub リポジトリのリンクを解除しました。",
+    "unlinkFailed": "リポジトリのリンク解除に失敗しました。",
+    "link": "リンク",
+    "unlink": "リンク解除",
+    "sync": "同期"
+  },
+  "chat": {
+    "projectChat": "プロジェクトチャット",
+    "placeholder": "メッセージを入力...",
+    "sendFailed": "メッセージの送信に失敗しました。",
+    "deleteFailed": "メッセージの削除に失敗しました。"
+  },
+  "error": {
+    "somethingWrong": "問題が発生しました",
+    "unexpectedError": "予期しないエラーが発生しました。ページを再読み込みしてください。"
+  },
+  "language": {
+    "switchLanguage": "言語",
+    "en": "English",
+    "ja": "日本語"
+  },
+  "app": {
+    "title": "Gantry Board"
+  }
+}

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -138,6 +138,9 @@
     "deleteConfirm": "このタスクを削除してもよろしいですか？",
     "pullRequests": "プルリクエスト",
     "backToBoard": "ボードに戻る",
+    "loadingTask": "タスクを読み込み中...",
+    "loadFailed": "タスクの読み込みに失敗しました。",
+    "assigneeFailed": "担当者の更新に失敗しました。もう一度お試しください。",
     "editComment": "コメントを編集"
   },
   "activity": {
@@ -150,7 +153,8 @@
     "commentPlaceholder": "コメントを追加...",
     "commentFailed": "コメントの投稿に失敗しました。",
     "commentUpdateFailed": "コメントの更新に失敗しました。",
-    "commentDeleteFailed": "コメントの削除に失敗しました。"
+    "commentDeleteFailed": "コメントの削除に失敗しました。",
+    "deleteCommentConfirm": "このコメントを削除しますか？"
   },
   "agent": {
     "agentType": "エージェントタイプ",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -21,7 +21,13 @@
     "noDescription": "説明なし",
     "unassigned": "未割り当て",
     "add": "追加",
-    "areYouSure": "本当に削除しますか？"
+    "areYouSure": "本当に削除しますか？",
+    "timeAgo": {
+      "justNow": "たった今",
+      "minutesAgo": "{{count}}分前",
+      "hoursAgo": "{{count}}時間前",
+      "daysAgo": "{{count}}日前"
+    }
   },
   "auth": {
     "signIn": "ログイン",
@@ -174,6 +180,12 @@
     "noOutput": "まだ出力がありません",
     "startFailed": "エージェントセッションの開始に失敗しました。",
     "stopFailed": "エージェントセッションの停止に失敗しました。",
+    "pauseFailed": "エージェントセッションの一時停止に失敗しました。",
+    "resumeFailed": "エージェントセッションの再開に失敗しました。",
+    "prompt": "プロンプト",
+    "pastSessions": "過去のセッション",
+    "pause": "一時停止",
+    "resume": "再開",
     "status": {
       "pending": "待機中",
       "running": "実行中",
@@ -195,12 +207,31 @@
     "deleteConfirm": "本当に削除しますか？",
     "invalid": "無効"
   },
+  "comment": {
+    "loadingComments": "コメントを読み込み中...",
+    "noComments": "コメントはありません。",
+    "addPlaceholder": "コメントを追加...",
+    "postFailed": "コメントの投稿に失敗しました。",
+    "updateFailed": "コメントの更新に失敗しました。",
+    "deleteFailed": "コメントの削除に失敗しました。",
+    "deleteConfirm": "このコメントを削除しますか？"
+  },
   "preview": {
+    "dockerPreviews": "Docker プレビュー",
     "start": "開始",
     "stop": "停止",
     "restart": "再起動",
     "delete": "削除",
     "worktreeName": "ワークツリー名",
+    "worktreeNameLabel": "ワークツリー名",
+    "createFailed": "プレビューの作成に失敗しました",
+    "startFailed": "プレビューの開始に失敗しました",
+    "stopFailed": "プレビューの停止に失敗しました",
+    "restartFailed": "プレビューの再起動に失敗しました",
+    "deleteFailed": "プレビューの削除に失敗しました",
+    "loadingPreviews": "プレビューを読み込み中...",
+    "loadFailed": "プレビューの読み込みに失敗しました",
+    "noPreviews": "プレビューなし",
     "status": {
       "pending": "待機中",
       "building": "ビルド中",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -134,6 +134,9 @@
     "createFailed": "タスクの作成に失敗しました。もう一度お試しください。",
     "updateFailed": "{{field}}の更新に失敗しました。もう一度お試しください。",
     "deleteFailed": "タスクの削除に失敗しました。もう一度お試しください。",
+    "deleteTask": "タスクを削除",
+    "deleteConfirm": "このタスクを削除してもよろしいですか？",
+    "pullRequests": "プルリクエスト",
     "backToBoard": "ボードに戻る",
     "editComment": "コメントを編集"
   },
@@ -169,7 +172,12 @@
     "worktrees": "ワークツリー",
     "namePlaceholder": "ワークツリー名...",
     "createFailed": "ワークツリーの作成に失敗しました。",
-    "deleteFailed": "ワークツリーの削除に失敗しました。"
+    "deleteFailed": "ワークツリーの削除に失敗しました。",
+    "loadingWorktrees": "ワークツリーを読み込み中...",
+    "loadFailed": "ワークツリーの読み込みに失敗しました。",
+    "noWorktrees": "ワークツリーなし",
+    "deleteConfirm": "本当に削除しますか？",
+    "invalid": "無効"
   },
   "preview": {
     "start": "開始",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -170,6 +170,8 @@
     "claudeCode": "Claude Code",
     "geminiCli": "Gemini CLI",
     "promptPlaceholder": "エージェントへのプロンプトを入力...",
+    "loadingOutput": "出力を読み込み中...",
+    "noOutput": "まだ出力がありません",
     "startFailed": "エージェントセッションの開始に失敗しました。",
     "stopFailed": "エージェントセッションの停止に失敗しました。",
     "status": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -19,7 +19,9 @@
     "dismiss": "閉じる",
     "reloadPage": "ページを再読み込み",
     "noDescription": "説明なし",
-    "unassigned": "未割り当て"
+    "unassigned": "未割り当て",
+    "add": "追加",
+    "areYouSure": "本当に削除しますか？"
   },
   "auth": {
     "signIn": "ログイン",
@@ -96,6 +98,13 @@
     "revoke": "取り消し",
     "pendingInvitations": "保留中の招待",
     "inviteMember": "メンバーを招待",
+    "addExistingUser": "既存ユーザーを追加",
+    "invitationLinks": "招待リンク",
+    "createLink": "リンクを作成",
+    "expired": "期限切れ",
+    "expires": "{{date}} に期限切れ",
+    "noPendingInvitations": "保留中の招待はありません。",
+    "loadFailed": "メンバーの読み込みに失敗しました。",
     "role": {
       "owner": "オーナー",
       "admin": "管理者",
@@ -174,6 +183,7 @@
   },
   "worktree": {
     "worktrees": "ワークツリー",
+    "worktreeName": "ワークツリー名",
     "namePlaceholder": "ワークツリー名...",
     "createFailed": "ワークツリーの作成に失敗しました。",
     "deleteFailed": "ワークツリーの削除に失敗しました。",
@@ -200,8 +210,15 @@
   "github": {
     "github": "GitHub",
     "owner": "オーナー",
+    "repository": "リポジトリ",
     "ownerPlaceholder": "owner",
     "repoPlaceholder": "repo",
+    "loadingPullRequests": "プルリクエストを読み込み中...",
+    "loadPullRequestsFailed": "プルリクエストの読み込みに失敗しました。",
+    "noPullRequests": "プルリクエストなし",
+    "prOpen": "オープン",
+    "prMerged": "マージ済み",
+    "prClosed": "クローズ",
     "linked": "GitHub リポジトリをリンクしました。",
     "linkFailed": "リポジトリのリンクに失敗しました。",
     "syncComplete": "同期完了: {{pushed}} プッシュ、{{pulled}} プル。",
@@ -215,6 +232,9 @@
   "chat": {
     "projectChat": "プロジェクトチャット",
     "placeholder": "メッセージを入力...",
+    "loadingMessages": "メッセージを読み込み中...",
+    "noMessages": "メッセージはありません。会話を始めましょう！",
+    "deleteMessageConfirm": "このメッセージを削除しますか？",
     "sendFailed": "メッセージの送信に失敗しました。",
     "deleteFailed": "メッセージの削除に失敗しました。"
   },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import '@/lib/i18n';
 import '@/styles/index.css';
 import App from '@/App';
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,15 @@
 import '@testing-library/jest-dom/vitest';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import { afterAll, afterEach, beforeAll } from 'vitest';
+import en from '../locales/en.json';
+
+i18n.use(initReactI18next).init({
+  resources: { en: { translation: en } },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
 
 import { useAgentStore } from '../stores/agentStore';
 import { useAuthStore } from '../stores/authStore';


### PR DESCRIPTION
## Summary
Epic #312 Phase 4: Internationalize entire frontend (Japanese + English)

### i18n infrastructure
- Set up `i18next` + `react-i18next` + `i18next-browser-languagedetector`
- `LanguageSwitcher` component in header
- Test setup loads real English translations (no `vi.mock` needed)

### Translation files
- `locales/en.json` — English (15 categories, 200+ keys)
- `locales/ja.json` — Japanese

### Components covered (30+ files)
- Auth: LoginPage, RegisterPage
- Project: ProjectListPage, ProjectCard, ProjectSettingsModal, ProjectCreateDialog, ProjectMembersPanel, ProjectChatPanel
- Board: KanbanColumn, TaskCard, TaskFilterBar, ProjectBoardPage
- Task: TaskCreateDialog, TaskDetailPage, TaskDetailModal, TaskTimeline, TimelineCommentItem, TimelineAgentSessionItem, ActivityFilter
- Agent: AgentPanel, AgentOutputViewer
- Preview: PreviewPanel, WorktreePanel
- GitHub: GitHubLinkSettings, PullRequestList
- Common: CommentSection, ErrorBoundary, ToastContainer
- Layout: AppLayout, ProtectedRoute, GuestRoute, InvitationAcceptPage

> Stacked PR: depends on #315

## Test plan
- [x] Language switcher toggles between Japanese and English
- [x] Language preference persists across page reloads
- [x] All 385 tests pass (`task check` green)