### PR TITLE
refactor: ♻️ migrate buttons and form inputs to shadcn/ui

### DIFF
--- a/frontend/src/components/board/KanbanColumn.tsx
+++ b/frontend/src/components/board/KanbanColumn.tsx
@@ -3,6 +3,8 @@ import { Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { ProjectMember, Task } from '@/api/generated/model';
 import { TaskStatus } from '@/api/generated/model';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { useUiStore } from '@/stores/uiStore';
 import { TaskCard } from './TaskCard';
 
@@ -44,11 +46,7 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
     >
       <div className="flex items-center justify-between p-3">
         <h2 className="text-sm font-semibold text-gray-700">{t(statusLabelKeys[status])}</h2>
-        <span
-          className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[status].badge}`}
-        >
-          {tasks.length}
-        </span>
+        <Badge className={statusColors[status].badge}>{tasks.length}</Badge>
       </div>
       <div ref={setNodeRef} className="flex-1 space-y-2 overflow-y-auto p-2">
         {tasks.length === 0 ? (
@@ -70,13 +68,14 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
         )}
       </div>
       <div className="p-2">
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => openTaskModal(status)}
-          className="flex w-full items-center justify-center gap-1 rounded-md py-1.5 text-sm text-gray-500 hover:bg-gray-200 hover:text-gray-700"
+          className="w-full text-muted-foreground"
         >
           <Plus className="h-4 w-4" /> {t('board.addTask')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
 import { TaskCreateDialog } from '@/components/task';
+import { Button } from '@/components/ui/button';
 import { useUiStore } from '@/stores/uiStore';
 import { KanbanBoard } from './KanbanBoard';
 
@@ -19,27 +20,15 @@ export function ProjectBoardPage() {
   return (
     <>
       <div className="mx-auto flex max-w-7xl items-center gap-3 px-4 pt-4">
-        <button
-          type="button"
-          onClick={openProjectSettings}
-          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-        >
+        <Button variant="outline" size="sm" onClick={openProjectSettings}>
           <Settings className="h-4 w-4" /> {t('project.settings')}
-        </button>
-        <button
-          type="button"
-          onClick={openProjectMembers}
-          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-        >
+        </Button>
+        <Button variant="outline" size="sm" onClick={openProjectMembers}>
           <Users className="h-4 w-4" /> {t('members.members')}
-        </button>
-        <button
-          type="button"
-          onClick={openProjectChat}
-          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
-        >
+        </Button>
+        <Button variant="outline" size="sm" onClick={openProjectChat}>
           <MessageSquare className="h-4 w-4" /> {t('chat.projectChat')}
-        </button>
+        </Button>
       </div>
       <KanbanBoard projectId={projectId} />
       <TaskCreateDialog projectId={projectId} />

--- a/frontend/src/components/board/TaskCard.tsx
+++ b/frontend/src/components/board/TaskCard.tsx
@@ -2,6 +2,7 @@ import { useDraggable } from '@dnd-kit/core';
 import { useRef } from 'react';
 import type { ProjectMember, Task } from '@/api/generated/model';
 import { TaskPriority } from '@/api/generated/model';
+import { Badge } from '@/components/ui/badge';
 import { useUiStore } from '@/stores/uiStore';
 
 interface TaskCardProps {
@@ -81,11 +82,7 @@ export function TaskCard({ task, isDragging, members }: TaskCardProps) {
     >
       <div className="mb-2 flex items-start justify-between">
         <h3 className="text-sm font-medium text-gray-900">{task.title}</h3>
-        <span
-          className={`rounded px-2 py-0.5 text-xs font-medium ${priorityStyles[task.priority]}`}
-        >
-          {task.priority}
-        </span>
+        <Badge className={`rounded ${priorityStyles[task.priority]}`}>{task.priority}</Badge>
       </div>
       {task.description && (
         <p data-testid="task-description" className="text-xs text-gray-500">

--- a/frontend/src/components/board/TaskFilterBar.tsx
+++ b/frontend/src/components/board/TaskFilterBar.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ProjectMember } from '@/api/generated/model';
 import { TaskPriority } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useBoardStore } from '@/stores/boardStore';
 
 interface TaskFilterBarProps {
@@ -48,26 +50,26 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
     <div className="flex items-center gap-3">
       <div className="relative">
         <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-        <input
+        <Input
           type="text"
           placeholder={t('board.searchPlaceholder')}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
-          className="rounded-md border border-gray-300 py-1.5 pl-8 pr-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="pl-8 pr-3"
         />
       </div>
 
       <div className="relative">
-        <button
-          type="button"
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => {
             setAssigneeOpen(!assigneeOpen);
             setPriorityOpen(false);
           }}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
         >
           {t('board.assignee')}
-        </button>
+        </Button>
         {assigneeOpen && (
           <div
             data-testid="assignee-dropdown"
@@ -99,16 +101,16 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
       </div>
 
       <div className="relative">
-        <button
-          type="button"
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => {
             setPriorityOpen(!priorityOpen);
             setAssigneeOpen(false);
           }}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-50"
         >
           {t('board.priority')}
-        </button>
+        </Button>
         {priorityOpen && (
           <div
             data-testid="priority-dropdown"
@@ -132,13 +134,9 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
       </div>
 
       {hasActive() && (
-        <button
-          type="button"
-          onClick={clearFilters}
-          className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-        >
+        <Button variant="ghost" size="sm" onClick={clearFilters}>
           {t('common.clearAll')}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/components/common/CommentSection.tsx
+++ b/frontend/src/components/common/CommentSection.tsx
@@ -8,6 +8,8 @@ import {
   useListComments,
   useUpdateComment,
 } from '@/api/generated/endpoints/task-comments/task-comments';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 
@@ -98,67 +100,52 @@ function CommentItem({
           <span className="text-xs text-gray-500">{timeAgo(comment.created_at, t)}</span>
           {isOwner && !editing && !showDeleteConfirm && (
             <div className="ml-auto flex gap-1">
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="xs"
                 aria-label={t('common.edit')}
                 onClick={handleEdit}
-                className="text-xs text-gray-400 hover:text-gray-600"
+                className="text-muted-foreground"
               >
                 {t('common.edit')}
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
                 aria-label={t('common.delete')}
                 onClick={() => setShowDeleteConfirm(true)}
-                className="text-xs text-gray-400 hover:text-red-600"
+                className="text-muted-foreground hover:text-destructive"
               >
                 {t('common.delete')}
-              </button>
+              </Button>
             </div>
           )}
         </div>
         {editing ? (
           <div className="mt-1 space-y-1">
-            <textarea
+            <Textarea
               value={editValue}
               onChange={(e) => setEditValue(e.target.value)}
               rows={2}
-              className="block w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
             <div className="flex gap-1">
-              <button
-                type="button"
-                onClick={handleSave}
-                className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
-              >
+              <Button size="xs" onClick={handleSave}>
                 {t('common.save')}
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
-              >
+              </Button>
+              <Button variant="outline" size="xs" onClick={() => setEditing(false)}>
                 {t('common.cancel')}
-              </button>
+              </Button>
             </div>
           </div>
         ) : showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
             <span className="text-xs text-red-700">{t('comment.deleteConfirm')}</span>
-            <button
-              type="button"
-              onClick={handleDelete}
-              className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
-            >
+            <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(false)}
-              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
-            >
+            </Button>
+            <Button variant="outline" size="xs" onClick={() => setShowDeleteConfirm(false)}>
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         ) : (
           <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
@@ -208,21 +195,20 @@ export function CommentSection({ taskId }: { taskId: string }) {
         <p className="text-sm text-gray-500">{t('comment.noComments')}</p>
       )}
       <div className="mt-3 flex gap-2">
-        <textarea
+        <Textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
           placeholder={t('comment.addPlaceholder')}
           rows={2}
-          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="flex-1"
         />
-        <button
-          type="button"
+        <Button
           onClick={handleSubmit}
           disabled={!newComment.trim() || createComment.isPending}
-          className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          className="self-end"
         >
           {t('common.post')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/common/CommentSection.tsx
+++ b/frontend/src/components/common/CommentSection.tsx
@@ -123,11 +123,7 @@ function CommentItem({
         </div>
         {editing ? (
           <div className="mt-1 space-y-1">
-            <Textarea
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              rows={2}
-            />
+            <Textarea value={editValue} onChange={(e) => setEditValue(e.target.value)} rows={2} />
             <div className="flex gap-1">
               <Button size="xs" onClick={handleSave}>
                 {t('common.save')}

--- a/frontend/src/components/github/GitHubLinkSettings.tsx
+++ b/frontend/src/components/github/GitHubLinkSettings.tsx
@@ -8,6 +8,8 @@ import {
   useGetGithubLink,
   useSyncGithubLink,
 } from '@/api/generated/endpoints/github-links/github-links';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useToastStore } from '@/stores/toastStore';
 
 export function GitHubLinkSettings({ projectId }: { projectId: string }) {
@@ -77,37 +79,36 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
             <label htmlFor="github-owner" className="block text-xs font-medium text-gray-600">
               {t('github.owner')}
             </label>
-            <input
+            <Input
               id="github-owner"
               type="text"
               value={repoOwner}
               onChange={(e) => setRepoOwner(e.target.value)}
               placeholder={t('github.ownerPlaceholder')}
-              className="mt-0.5 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-0.5"
             />
           </div>
           <div className="flex-1">
             <label htmlFor="github-repo" className="block text-xs font-medium text-gray-600">
               {t('github.repository')}
             </label>
-            <input
+            <Input
               id="github-repo"
               type="text"
               value={repoName}
               onChange={(e) => setRepoName(e.target.value)}
               placeholder={t('github.repoPlaceholder')}
-              className="mt-0.5 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-0.5"
             />
           </div>
         </div>
-        <button
-          type="button"
+        <Button
+          size="sm"
           onClick={handleCreate}
           disabled={!repoOwner.trim() || !repoName.trim() || createLink.isPending}
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {t('github.link')}
-        </button>
+        </Button>
       </div>
     );
   }
@@ -119,42 +120,43 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
           {link.repo_owner}/{link.repo_name}
         </span>
         <div className="flex gap-2">
-          <button
-            type="button"
+          <Button
+            variant="outline"
+            size="xs"
             onClick={handleSync}
             disabled={syncLink.isPending}
-            className="rounded border border-blue-300 px-2 py-1 text-xs text-blue-700 hover:bg-blue-50 disabled:opacity-50"
           >
             {t('github.sync')}
-          </button>
+          </Button>
           {showUnlinkConfirm ? (
             <div className="flex items-center gap-2">
               <span className="text-xs text-red-600">{t('common.areYouSure')}</span>
-              <button
-                type="button"
+              <Button
+                variant="outline"
+                size="xs"
                 onClick={() => setShowUnlinkConfirm(false)}
                 disabled={deleteLink.isPending}
-                className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-50"
               >
                 {t('common.cancel')}
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="destructive"
+                size="xs"
                 onClick={handleUnlink}
                 disabled={deleteLink.isPending}
-                className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {t('common.confirm')}
-              </button>
+              </Button>
             </div>
           ) : (
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="xs"
               onClick={() => setShowUnlinkConfirm(true)}
-              className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+              className="border-red-300 text-red-700 hover:bg-red-50"
             >
               {t('github.unlink')}
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/frontend/src/components/github/GitHubLinkSettings.tsx
+++ b/frontend/src/components/github/GitHubLinkSettings.tsx
@@ -120,12 +120,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
           {link.repo_owner}/{link.repo_name}
         </span>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={handleSync}
-            disabled={syncLink.isPending}
-          >
+          <Button variant="outline" size="xs" onClick={handleSync} disabled={syncLink.isPending}>
             {t('github.sync')}
           </Button>
           {showUnlinkConfirm ? (

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, Outlet } from 'react-router-dom';
 import { useLogout } from '@/api/generated/endpoints/auth/auth';
 import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
+import { Button } from '@/components/ui/button';
 import { connectEventSource } from '@/hooks/useEventSource';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -41,14 +42,14 @@ export function AppLayout() {
           <div className="flex items-center gap-2 border-l pl-4">
             <LanguageSwitcher />
             <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={handleLogout}
               disabled={logout.isPending}
-              className="flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
             >
               <LogOut className="h-4 w-4" /> {t('auth.logout')}
-            </button>
+            </Button>
           </div>
         </div>
       </header>

--- a/frontend/src/components/layout/InvitationAcceptPage.tsx
+++ b/frontend/src/components/layout/InvitationAcceptPage.tsx
@@ -4,6 +4,7 @@ import {
   useAcceptInvitation,
   useGetInvitationByToken,
 } from '@/api/generated/endpoints/invitations/invitations';
+import { Button } from '@/components/ui/button';
 import { useAuthStore } from '@/stores/authStore';
 
 export function InvitationAcceptPage() {
@@ -66,31 +67,29 @@ export function InvitationAcceptPage() {
             ) : !isAuthenticated ? (
               <div className="space-y-2">
                 <p className="text-sm text-gray-600">{t('invitation.loginRequired')}</p>
-                <button
-                  type="button"
+                <Button
+                  className="w-full"
                   onClick={() => navigate(`/login?redirect=/invite/${token}`)}
-                  className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
                 >
                   {t('invitation.logIn')}
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full"
                   onClick={() => navigate(`/register?redirect=/invite/${token}`)}
-                  className="w-full rounded-md border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
                 >
                   {t('auth.createAccountBtn')}
-                </button>
+                </Button>
               </div>
             ) : (
               <div className="space-y-2">
-                <button
-                  type="button"
+                <Button
+                  className="w-full"
                   onClick={handleAccept}
                   disabled={acceptMutation.isPending}
-                  className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
                 >
                   {acceptMutation.isPending ? t('invitation.accepting') : t('invitation.accept')}
-                </button>
+                </Button>
                 {acceptMutation.isError && (
                   <p className="text-sm text-red-600">{t('invitation.acceptFailed')}</p>
                 )}

--- a/frontend/src/components/layout/LoginPage.tsx
+++ b/frontend/src/components/layout/LoginPage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useLogin } from '@/api/generated/endpoints/auth/auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useAuthStore } from '@/stores/authStore';
 
 export function LoginPage() {
@@ -50,13 +52,13 @@ export function LoginPage() {
             <label htmlFor="email" className="block text-sm font-medium text-gray-700">
               {t('auth.email')}
             </label>
-            <input
+            <Input
               id="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               placeholder={t('auth.emailPlaceholder')}
             />
           </div>
@@ -65,31 +67,27 @@ export function LoginPage() {
             <label htmlFor="password" className="block text-sm font-medium text-gray-700">
               {t('auth.password')}
             </label>
-            <input
+            <Input
               id="password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               placeholder={t('auth.passwordPlaceholder')}
             />
           </div>
 
-          <button
-            type="submit"
-            disabled={login.isPending}
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <Button type="submit" disabled={login.isPending} className="w-full">
             {login.isPending ? t('auth.signingIn') : t('auth.signIn')}
-          </button>
+          </Button>
         </form>
 
         <p className="mt-4 text-center text-sm text-gray-600">
           {t('auth.noAccount')}{' '}
           <Link
             to={redirectTo ? `/register?redirect=${encodeURIComponent(redirectTo)}` : '/register'}
-            className="text-blue-600 hover:text-blue-500"
+            className="text-primary hover:text-primary/80"
           >
             {t('auth.signUp')}
           </Link>

--- a/frontend/src/components/layout/RegisterPage.tsx
+++ b/frontend/src/components/layout/RegisterPage.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useRegister } from '@/api/generated/endpoints/auth/auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useAuthStore } from '@/stores/authStore';
 
 export function RegisterPage() {
@@ -58,13 +60,13 @@ export function RegisterPage() {
             <label htmlFor="name" className="block text-sm font-medium text-gray-700">
               {t('auth.name')}
             </label>
-            <input
+            <Input
               id="name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               placeholder={t('auth.namePlaceholder')}
             />
           </div>
@@ -73,13 +75,13 @@ export function RegisterPage() {
             <label htmlFor="email" className="block text-sm font-medium text-gray-700">
               {t('auth.email')}
             </label>
-            <input
+            <Input
               id="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               placeholder={t('auth.emailPlaceholder')}
             />
           </div>
@@ -88,32 +90,28 @@ export function RegisterPage() {
             <label htmlFor="password" className="block text-sm font-medium text-gray-700">
               {t('auth.password')}
             </label>
-            <input
+            <Input
               id="password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={8}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               placeholder={t('auth.passwordMinLength')}
             />
           </div>
 
-          <button
-            type="submit"
-            disabled={register.isPending}
-            className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <Button type="submit" disabled={register.isPending} className="w-full">
             {register.isPending ? t('auth.creatingAccount') : t('auth.createAccountBtn')}
-          </button>
+          </Button>
         </form>
 
         <p className="mt-4 text-center text-sm text-gray-600">
           {t('auth.hasAccount')}{' '}
           <Link
             to={redirectTo ? `/login?redirect=${encodeURIComponent(redirectTo)}` : '/login'}
-            className="text-blue-600 hover:text-blue-500"
+            className="text-primary hover:text-primary/80"
           >
             {t('auth.signIn')}
           </Link>

--- a/frontend/src/components/preview/PreviewPanel.tsx
+++ b/frontend/src/components/preview/PreviewPanel.tsx
@@ -40,11 +40,7 @@ function PreviewActions({
   return (
     <div className="flex gap-1">
       {(status === 'pending' || status === 'stopped' || status === 'failed') && (
-        <Button
-          size="xs"
-          onClick={() => onStart(id)}
-          className="bg-green-600 hover:bg-green-700"
-        >
+        <Button size="xs" onClick={() => onStart(id)} className="bg-green-600 hover:bg-green-700">
           {t('preview.start')}
         </Button>
       )}

--- a/frontend/src/components/preview/PreviewPanel.tsx
+++ b/frontend/src/components/preview/PreviewPanel.tsx
@@ -9,6 +9,9 @@ import {
   useStopPreview,
 } from '@/api/generated/endpoints/previews/previews';
 import type { DockerPreview } from '@/api/generated/model';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 const statusColors: Record<string, string> = {
   pending: 'bg-yellow-100 text-yellow-800',
@@ -37,39 +40,31 @@ function PreviewActions({
   return (
     <div className="flex gap-1">
       {(status === 'pending' || status === 'stopped' || status === 'failed') && (
-        <button
-          type="button"
+        <Button
+          size="xs"
           onClick={() => onStart(id)}
-          className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700"
+          className="bg-green-600 hover:bg-green-700"
         >
           {t('preview.start')}
-        </button>
+        </Button>
       )}
       {status === 'running' && (
         <>
-          <button
-            type="button"
+          <Button
+            size="xs"
             onClick={() => onStop(id)}
-            className="rounded bg-yellow-600 px-2 py-1 text-xs text-white hover:bg-yellow-700"
+            className="bg-yellow-600 hover:bg-yellow-700"
           >
             {t('preview.stop')}
-          </button>
-          <button
-            type="button"
-            onClick={() => onRestart(id)}
-            className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700"
-          >
+          </Button>
+          <Button size="xs" onClick={() => onRestart(id)}>
             {t('preview.restart')}
-          </button>
+          </Button>
         </>
       )}
-      <button
-        type="button"
-        onClick={() => onDelete(id)}
-        className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700"
-      >
+      <Button variant="destructive" size="xs" onClick={() => onDelete(id)}>
         {t('preview.delete')}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -149,22 +144,21 @@ export function PreviewPanel() {
         <label className="sr-only" htmlFor="preview-worktree-name">
           {t('preview.worktreeNameLabel')}
         </label>
-        <input
+        <Input
           id="preview-worktree-name"
           type="text"
           value={worktreeName}
           onChange={(e) => setWorktreeName(e.target.value)}
           placeholder={t('preview.worktreeName')}
-          className="flex-1 rounded border px-3 py-1 text-sm"
+          className="flex-1"
         />
-        <button
-          type="button"
+        <Button
           onClick={handleCreate}
           disabled={!worktreeName.trim() || isCreating}
-          className="rounded bg-indigo-600 px-3 py-1 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+          className="bg-indigo-600 hover:bg-indigo-700"
         >
           {t('common.create')}
-        </button>
+        </Button>
       </div>
 
       {error && <div className="text-sm text-red-500">{error}</div>}
@@ -179,11 +173,7 @@ export function PreviewPanel() {
           <div className="space-y-1">
             <div className="flex items-center gap-2">
               <span className="font-medium text-sm">{preview.worktree_name}</span>
-              <span
-                className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[preview.status] ?? ''}`}
-              >
-                {preview.status}
-              </span>
+              <Badge className={statusColors[preview.status] ?? ''}>{preview.status}</Badge>
             </div>
             {preview.status === 'running' && preview.preview_url && (
               <a

--- a/frontend/src/components/preview/WorktreePanel.tsx
+++ b/frontend/src/components/preview/WorktreePanel.tsx
@@ -7,6 +7,9 @@ import {
   useDeleteProjectWorktree,
   useListProjectWorktrees,
 } from '@/api/generated/endpoints/worktrees/worktrees';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 export function WorktreePanel({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
@@ -71,39 +74,38 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
                 <span className="font-medium text-gray-900">{wt.name}</span>
                 {wt.branch && <span className="text-gray-500">{wt.branch}</span>}
                 {!wt.is_valid && (
-                  <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800">
-                    {t('worktree.invalid')}
-                  </span>
+                  <Badge variant="destructive">{t('worktree.invalid')}</Badge>
                 )}
               </div>
               {deletingName === wt.name ? (
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-red-600">{t('worktree.deleteConfirm')}</span>
-                  <button
-                    type="button"
+                  <Button
+                    variant="outline"
+                    size="xs"
                     onClick={() => setDeletingName(null)}
                     disabled={deleteWorktree.isPending}
-                    className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                   >
                     {t('common.cancel')}
-                  </button>
-                  <button
-                    type="button"
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="xs"
                     onClick={() => handleDelete(wt.name)}
                     disabled={deleteWorktree.isPending}
-                    className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700 disabled:opacity-50"
                   >
                     {t('common.confirm')}
-                  </button>
+                  </Button>
                 </div>
               ) : (
-                <button
-                  type="button"
+                <Button
+                  variant="outline"
+                  size="xs"
                   onClick={() => setDeletingName(wt.name)}
-                  className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+                  className="border-red-300 text-red-700 hover:bg-red-50"
                 >
                   {t('common.delete')}
-                </button>
+                </Button>
               )}
             </div>
           ))}
@@ -117,23 +119,20 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
           <label htmlFor="worktree-name-input" className="sr-only">
             {t('worktree.worktreeName')}
           </label>
-          <input
+          <Input
             id="worktree-name-input"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder={t('worktree.namePlaceholder')}
-            className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
-        <button
-          type="button"
+        <Button
           onClick={handleCreate}
           disabled={!name.trim() || createWorktree.isPending}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {t('common.create')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/preview/WorktreePanel.tsx
+++ b/frontend/src/components/preview/WorktreePanel.tsx
@@ -73,9 +73,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
               <div className="flex items-center gap-2 text-sm">
                 <span className="font-medium text-gray-900">{wt.name}</span>
                 {wt.branch && <span className="text-gray-500">{wt.branch}</span>}
-                {!wt.is_valid && (
-                  <Badge variant="destructive">{t('worktree.invalid')}</Badge>
-                )}
+                {!wt.is_valid && <Badge variant="destructive">{t('worktree.invalid')}</Badge>}
               </div>
               {deletingName === wt.name ? (
                 <div className="flex items-center gap-2">
@@ -127,10 +125,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
             placeholder={t('worktree.namePlaceholder')}
           />
         </div>
-        <Button
-          onClick={handleCreate}
-          disabled={!name.trim() || createWorktree.isPending}
-        >
+        <Button onClick={handleCreate} disabled={!name.trim() || createWorktree.isPending}>
           {t('common.create')}
         </Button>
       </div>

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -2,6 +2,7 @@ import { Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Project } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
 
 interface ProjectCardProps {
   project: Project;
@@ -19,17 +20,18 @@ export function ProjectCard({ project, onSettings }: ProjectCardProps) {
         )}
       </Link>
       {onSettings && (
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon-xs"
           onClick={(e) => {
             e.stopPropagation();
             onSettings(project.id);
           }}
-          className="absolute right-3 top-3 rounded p-1 text-gray-400 opacity-0 hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
+          className="absolute right-3 top-3 opacity-0 group-hover:opacity-100"
           aria-label={t('project.projectSettings')}
         >
           <Settings className="h-4 w-4" />
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -8,6 +8,8 @@ import {
   useDeleteMessage,
   useListMessages,
 } from '@/api/generated/endpoints/project-messages/project-messages';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
@@ -81,33 +83,26 @@ function MessageItem({
           <span className="text-sm font-medium text-gray-900">{message.user_name}</span>
           <span className="text-xs text-gray-500">{timeAgo(message.created_at, t)}</span>
           {isOwner && !showDeleteConfirm && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="xs"
               aria-label={t('common.delete')}
               onClick={() => setShowDeleteConfirm(true)}
-              className="ml-auto text-xs text-gray-400 hover:text-red-600"
+              className="ml-auto text-muted-foreground hover:text-destructive"
             >
               {t('common.delete')}
-            </button>
+            </Button>
           )}
         </div>
         {showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
             <span className="text-xs text-red-700">{t('chat.deleteMessageConfirm')}</span>
-            <button
-              type="button"
-              onClick={handleDelete}
-              className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
-            >
+            <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(false)}
-              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
-            >
+            </Button>
+            <Button variant="outline" size="xs" onClick={() => setShowDeleteConfirm(false)}>
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         ) : (
           <p className="mt-0.5 text-sm text-gray-700">{message.content}</p>
@@ -175,14 +170,14 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
           <h2 id="project-chat-title" className="text-lg font-semibold text-gray-900">
             {t('chat.projectChat')}
           </h2>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={closeProjectChat}
-            className="text-gray-400 hover:text-gray-600"
             aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
-          </button>
+          </Button>
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 py-2">
@@ -206,23 +201,22 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
 
         <div className="border-t px-4 py-3">
           <div className="flex gap-2">
-            <textarea
+            <Textarea
               value={newMessage}
               onChange={(e) => setNewMessage(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={t('chat.placeholder')}
               rows={2}
-              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="flex-1"
             />
-            <button
-              type="button"
+            <Button
               aria-label={t('common.send')}
               onClick={handleSubmit}
               disabled={!newMessage.trim() || createMessage.isPending}
-              className="self-end rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+              className="self-end"
             >
               {t('common.send')}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -2,6 +2,9 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCreateProject } from '@/api/generated/endpoints/projects/projects';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { invalidateProjects } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
@@ -70,12 +73,12 @@ function ProjectCreateForm() {
             <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">
               {t('project.name')}
             </label>
-            <input
+            <Input
               id="project-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               autoFocus
             />
           </div>
@@ -86,12 +89,12 @@ function ProjectCreateForm() {
             >
               {t('project.description')}
             </label>
-            <textarea
+            <Textarea
               id="project-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
             />
           </div>
           <div>
@@ -101,30 +104,22 @@ function ProjectCreateForm() {
             >
               {t('project.repositoryPath')}
             </label>
-            <input
+            <Input
               id="project-repository-path"
               type="text"
               value={repositoryPath}
               onChange={(e) => setRepositoryPath(e.target.value)}
               placeholder={t('project.repositoryPathPlaceholder')}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
             />
           </div>
           <div className="flex justify-end gap-3 pt-2">
-            <button
-              type="button"
-              onClick={closeProjectModal}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
-            >
+            <Button type="button" variant="outline" onClick={closeProjectModal}>
               {t('common.cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={createProject.isPending}
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
-            >
+            </Button>
+            <Button type="submit" disabled={createProject.isPending}>
               {t('common.create')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/project/ProjectListPage.tsx
+++ b/frontend/src/components/project/ProjectListPage.tsx
@@ -1,6 +1,7 @@
 import { FolderPlus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useListProjects } from '@/api/generated/endpoints/projects/projects';
+import { Button } from '@/components/ui/button';
 import { useUiStore } from '@/stores/uiStore';
 import { ProjectCard } from './ProjectCard';
 
@@ -30,25 +31,17 @@ export function ProjectListPage() {
     <div className="mx-auto max-w-5xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-xl font-semibold text-gray-900">{t('project.projects')}</h2>
-        <button
-          type="button"
-          onClick={openProjectModal}
-          className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
-        >
+        <Button size="sm" onClick={openProjectModal}>
           <FolderPlus className="h-4 w-4" /> {t('project.newProject')}
-        </button>
+        </Button>
       </div>
 
       {!projects || projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 py-16">
           <p className="text-gray-500">{t('project.noProjects')}</p>
-          <button
-            type="button"
-            onClick={openProjectModal}
-            className="mt-4 flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-          >
+          <Button className="mt-4" onClick={openProjectModal}>
             <FolderPlus className="h-4 w-4" /> {t('project.createFirst')}
-          </button>
+          </Button>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -160,18 +160,10 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                   <Badge variant="secondary">{t(`members.role.${m.role}`)}</Badge>
                 ) : removingUserId === m.user_id ? (
                   <div className="flex items-center gap-1">
-                    <Button
-                      variant="destructive"
-                      size="xs"
-                      onClick={() => handleRemove(m.user_id)}
-                    >
+                    <Button variant="destructive" size="xs" onClick={() => handleRemove(m.user_id)}>
                       {t('common.confirm')}
                     </Button>
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      onClick={() => setRemovingUserId(null)}
-                    >
+                    <Button variant="outline" size="xs" onClick={() => setRemovingUserId(null)}>
                       {t('common.cancel')}
                     </Button>
                   </div>

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -18,6 +18,9 @@ import {
 import { useSearchUsers } from '@/api/generated/endpoints/users/users';
 import type { MemberRole as MemberRoleType } from '@/api/generated/model';
 import { MemberRole } from '@/api/generated/model';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
@@ -127,14 +130,14 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
           <h2 id="project-members-title" className="text-lg font-semibold text-gray-900">
             {t('members.members')}
           </h2>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={closeProjectMembers}
-            className="text-gray-400 hover:text-gray-600"
             aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
-          </button>
+          </Button>
         </div>
 
         {isLoading ? (
@@ -154,25 +157,23 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 </div>
 
                 {m.user_id === currentUser?.id || !canManageMember(m.role) ? (
-                  <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-                    {t(`members.role.${m.role}`)}
-                  </span>
+                  <Badge variant="secondary">{t(`members.role.${m.role}`)}</Badge>
                 ) : removingUserId === m.user_id ? (
                   <div className="flex items-center gap-1">
-                    <button
-                      type="button"
+                    <Button
+                      variant="destructive"
+                      size="xs"
                       onClick={() => handleRemove(m.user_id)}
-                      className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
                     >
                       {t('common.confirm')}
-                    </button>
-                    <button
-                      type="button"
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="xs"
                       onClick={() => setRemovingUserId(null)}
-                      className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
                     >
                       {t('common.cancel')}
-                    </button>
+                    </Button>
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">
@@ -187,14 +188,15 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                       <option value="admin">{t('members.role.admin')}</option>
                       <option value="member">{t('members.role.member')}</option>
                     </select>
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
+                      size="xs"
                       onClick={() => setRemovingUserId(m.user_id)}
-                      className="text-xs text-gray-400 hover:text-red-600"
                       aria-label={t('common.remove')}
+                      className="text-muted-foreground hover:text-destructive"
                     >
                       {t('common.remove')}
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>
@@ -210,7 +212,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
               {t('members.addExistingUser')}
             </h3>
             <div className="relative">
-              <input
+              <Input
                 type="text"
                 value={selectedUser ? selectedUser.name : searchQuery}
                 onChange={(e) => {
@@ -218,7 +220,6 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                   setSelectedUser(null);
                 }}
                 placeholder={t('members.searchPlaceholder')}
-                className="block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
               />
               {!selectedUser && filteredResults && filteredResults.length > 0 && (
                 <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
@@ -249,14 +250,13 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 <option value="member">{t('members.role.member')}</option>
                 <option value="admin">{t('members.role.admin')}</option>
               </select>
-              <button
-                type="button"
+              <Button
+                size="sm"
                 onClick={handleInvite}
                 disabled={!selectedUser || addMember.isPending}
-                className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 {t('common.add')}
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -316,15 +316,15 @@ function InvitationSection({ projectId }: { projectId: string }) {
     <div className="mt-4 border-t pt-4">
       <div className="mb-2 flex items-center justify-between">
         <h3 className="text-sm font-medium text-gray-700">{t('members.invitationLinks')}</h3>
-        <button
-          type="button"
+        <Button
+          size="xs"
           onClick={handleCreate}
           disabled={createInvitation.isPending}
-          className="rounded bg-green-600 px-2 py-1 text-xs text-white hover:bg-green-700 disabled:opacity-50"
+          className="bg-green-600 hover:bg-green-700"
           data-testid="create-invitation-btn"
         >
           {t('members.createLink')}
-        </button>
+        </Button>
       </div>
 
       {pendingInvitations.length > 0 ? (
@@ -349,14 +349,15 @@ function InvitationSection({ projectId }: { projectId: string }) {
                         })}
                   </p>
                 </div>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="xs"
                   onClick={() => handleDelete(inv.id)}
-                  className="text-xs text-gray-400 hover:text-red-600"
                   aria-label={t('members.revoke')}
+                  className="text-muted-foreground hover:text-destructive"
                 >
                   {t('members.revoke')}
-                </button>
+                </Button>
               </div>
             );
           })}

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -11,6 +11,9 @@ import {
   useUpdateProject,
 } from '@/api/generated/endpoints/projects/projects';
 import { MemberRole } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
@@ -136,14 +139,14 @@ function ProjectSettingsContent({
           <h2 id="project-settings-title" className="text-lg font-semibold text-gray-900">
             {t('project.settings')}
           </h2>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={closeProjectSettings}
-            className="text-gray-400 hover:text-gray-600"
             aria-label={t('common.close')}
           >
             <X className="h-5 w-5" />
-          </button>
+          </Button>
         </div>
 
         {isLoading ? (
@@ -155,12 +158,12 @@ function ProjectSettingsContent({
             <div>
               <h3 className="text-sm font-medium text-gray-700">{t('project.name')}</h3>
               {editingField === 'name' ? (
-                <input
+                <Input
                   type="text"
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
                   onBlur={() => saveField('name')}
-                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1"
                   autoFocus
                 />
               ) : canEdit ? (
@@ -179,12 +182,12 @@ function ProjectSettingsContent({
             <div>
               <h3 className="text-sm font-medium text-gray-700">{t('project.description')}</h3>
               {editingField === 'description' ? (
-                <textarea
+                <Textarea
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
                   onBlur={() => saveField('description')}
                   rows={3}
-                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1"
                   autoFocus
                 />
               ) : canEdit ? (
@@ -205,13 +208,13 @@ function ProjectSettingsContent({
             <div>
               <h3 className="text-sm font-medium text-gray-700">{t('project.repositoryPath')}</h3>
               {editingField === 'repository_path' ? (
-                <input
+                <Input
                   type="text"
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
                   onBlur={() => saveField('repository_path')}
                   placeholder="/path/to/git/repo"
-                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1"
                   autoFocus
                 />
               ) : canEdit ? (
@@ -242,30 +245,26 @@ function ProjectSettingsContent({
                   <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
                     <p className="text-sm text-red-700">{t('project.deleteConfirm')}</p>
                     <div className="flex gap-2">
-                      <button
-                        type="button"
+                      <Button
+                        variant="outline"
+                        size="sm"
                         onClick={() => setShowDeleteConfirm(false)}
-                        className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                       >
                         {t('common.cancel')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={handleDelete}
-                        className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-                      >
+                      </Button>
+                      <Button variant="destructive" size="sm" onClick={handleDelete}>
                         {t('common.confirm')}
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 ) : (
-                  <button
-                    type="button"
+                  <Button
+                    variant="outline"
+                    className="border-red-300 text-red-700 hover:bg-red-50"
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
                   >
                     {t('project.deleteProject')}
-                  </button>
+                  </Button>
                 )}
               </div>
             )}

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -4,6 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useCreateTask } from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
@@ -89,12 +92,12 @@ function TaskCreateForm({
             <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
               {t('task.title')}
             </label>
-            <input
+            <Input
               id="task-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
               autoFocus
             />
           </div>
@@ -102,12 +105,12 @@ function TaskCreateForm({
             <label htmlFor="task-description" className="block text-sm font-medium text-gray-700">
               {t('task.description')}
             </label>
-            <textarea
+            <Textarea
               id="task-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              className="mt-1"
             />
           </div>
           <div className="grid grid-cols-3 gap-4">
@@ -164,20 +167,12 @@ function TaskCreateForm({
             </div>
           </div>
           <div className="flex justify-end gap-3 pt-2">
-            <button
-              type="button"
-              onClick={closeTaskModal}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
-            >
+            <Button type="button" variant="outline" onClick={closeTaskModal}>
               {t('common.cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={createTask.isPending}
-              className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
-            >
+            </Button>
+            <Button type="submit" disabled={createTask.isPending}>
               {t('common.create')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -266,11 +266,7 @@ export function TaskDetailPage() {
               <div className="rounded-md bg-red-50 p-3">
                 <p className="mb-2 text-sm text-red-700">{t('task.deleteConfirm')}</p>
                 <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowDeleteConfirm(false)}
-                  >
+                  <Button variant="outline" size="sm" onClick={() => setShowDeleteConfirm(false)}>
                     {t('common.cancel')}
                   </Button>
                   <Button variant="destructive" size="sm" onClick={handleDelete}>

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -11,6 +11,9 @@ import {
   useUpdateTask,
 } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { PullRequestList } from '../github/PullRequestList';
 import { WorktreePanel } from '../preview/WorktreePanel';
@@ -144,12 +147,12 @@ export function TaskDetailPage() {
           {/* Title */}
           <div>
             {editingField === 'title' ? (
-              <input
+              <Input
                 type="text"
                 value={editValue}
                 onChange={(e) => setEditValue(e.target.value)}
                 onBlur={() => saveField('title')}
-                className="w-full rounded border border-blue-300 px-3 py-2 text-xl font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="text-xl font-semibold"
                 autoFocus
               />
             ) : (
@@ -167,12 +170,11 @@ export function TaskDetailPage() {
           <div>
             <h3 className="mb-1 text-sm font-medium text-gray-700">{t('task.description')}</h3>
             {editingField === 'description' ? (
-              <textarea
+              <Textarea
                 value={editValue}
                 onChange={(e) => setEditValue(e.target.value)}
                 onBlur={() => saveField('description')}
                 rows={4}
-                className="w-full rounded border border-blue-300 px-3 py-2 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 autoFocus
               />
             ) : (
@@ -264,30 +266,26 @@ export function TaskDetailPage() {
               <div className="rounded-md bg-red-50 p-3">
                 <p className="mb-2 text-sm text-red-700">{t('task.deleteConfirm')}</p>
                 <div className="flex gap-2">
-                  <button
-                    type="button"
+                  <Button
+                    variant="outline"
+                    size="sm"
                     onClick={() => setShowDeleteConfirm(false)}
-                    className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
                   >
                     {t('common.cancel')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleDelete}
-                    className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
-                  >
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={handleDelete}>
                     {t('common.confirm')}
-                  </button>
+                  </Button>
                 </div>
               </div>
             ) : (
-              <button
-                type="button"
+              <Button
+                variant="outline"
+                className="w-full border-red-300 text-red-700 hover:bg-red-50"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="w-full rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
               >
                 {t('task.deleteTask')}
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/frontend/src/components/task/TaskTimeline.tsx
+++ b/frontend/src/components/task/TaskTimeline.tsx
@@ -14,6 +14,8 @@ import {
   useListComments,
 } from '@/api/generated/endpoints/task-comments/task-comments';
 import type { AgentSession, AgentType } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { useAgentStore } from '@/stores/agentStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -174,14 +176,14 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 {activeSession.status}
               </span>
             </div>
-            <button
-              type="button"
+            <Button
+              variant="destructive"
+              size="sm"
               onClick={handleStopAgent}
               disabled={stopSession.isPending}
-              className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
             >
               {t('common.stop')}
-            </button>
+            </Button>
           </div>
           <AgentOutputViewer lines={outputLines} isLoading={false} />
         </div>
@@ -195,16 +197,16 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
           return (
             <div className="space-y-2 rounded-md border border-gray-200 p-3">
               <div className="flex items-center gap-2">
-                <button
-                  type="button"
+                <Button
+                  variant="link"
+                  size="sm"
                   onClick={() => {
                     setViewingSessionId(null);
                     reset();
                   }}
-                  className="text-sm text-blue-600 hover:text-blue-800"
                 >
                   {t('common.back')}
-                </button>
+                </Button>
                 <span className="text-sm text-gray-600">
                   {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
                 </span>
@@ -244,29 +246,26 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
               </select>
             </div>
             <div className="flex items-end">
-              <button
-                type="button"
+              <Button
                 onClick={handleStartAgent}
                 disabled={!prompt.trim() || startSession.isPending}
-                className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 {t('common.start')}
-              </button>
+              </Button>
             </div>
           </div>
-          <textarea
+          <Textarea
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder={t('agent.promptPlaceholder')}
             rows={2}
-            className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
           />
         </div>
       )}
 
       {/* Comment input */}
       <div className="flex gap-2">
-        <textarea
+        <Textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}
           onKeyDown={(e) => {
@@ -277,16 +276,15 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
           }}
           placeholder={t('activity.commentPlaceholder')}
           rows={2}
-          className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          className="flex-1"
         />
-        <button
-          type="button"
+        <Button
           onClick={handleSubmitComment}
           disabled={!newComment.trim() || createComment.isPending}
-          className="self-end rounded bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          className="self-end"
         >
           {t('common.post')}
-        </button>
+        </Button>
       </div>
 
       {/* Activity filter */}

--- a/frontend/src/components/task/TimelineCommentItem.tsx
+++ b/frontend/src/components/task/TimelineCommentItem.tsx
@@ -7,6 +7,8 @@ import {
   useUpdateComment,
 } from '@/api/generated/endpoints/task-comments/task-comments';
 import type { TaskComment } from '@/api/generated/model';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { useToastStore } from '@/stores/toastStore';
 import { getInitials, timeAgo } from './timelineUtils';
 
@@ -69,71 +71,56 @@ export function TimelineCommentItem({
           <span className="text-xs text-gray-500">{timeAgo(comment.created_at)}</span>
           {isOwner && !editing && !showDeleteConfirm && (
             <div className="ml-auto flex gap-1">
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="xs"
                 aria-label={t('common.edit')}
                 onClick={() => {
                   setEditing(true);
                   setEditValue(comment.content);
                 }}
-                className="text-xs text-gray-400 hover:text-gray-600"
+                className="text-muted-foreground"
               >
                 {t('common.edit')}
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
                 aria-label={t('common.delete')}
                 onClick={() => setShowDeleteConfirm(true)}
-                className="text-xs text-gray-400 hover:text-red-600"
+                className="text-muted-foreground hover:text-destructive"
               >
                 {t('common.delete')}
-              </button>
+              </Button>
             </div>
           )}
         </div>
         {editing ? (
           <div className="mt-1 space-y-1">
-            <textarea
+            <Textarea
               aria-label={t('task.editComment')}
               value={editValue}
               onChange={(e) => setEditValue(e.target.value)}
               rows={2}
-              className="block w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             />
             <div className="flex gap-1">
-              <button
-                type="button"
-                onClick={handleSave}
-                className="rounded bg-blue-600 px-2 py-0.5 text-xs text-white hover:bg-blue-700"
-              >
+              <Button size="xs" onClick={handleSave}>
                 {t('common.save')}
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
-              >
+              </Button>
+              <Button variant="outline" size="xs" onClick={() => setEditing(false)}>
                 {t('common.cancel')}
-              </button>
+              </Button>
             </div>
           </div>
         ) : showDeleteConfirm ? (
           <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
             <span className="text-xs text-red-700">{t('activity.deleteCommentConfirm')}</span>
-            <button
-              type="button"
-              onClick={handleDelete}
-              className="rounded bg-red-600 px-2 py-0.5 text-xs text-white hover:bg-red-700"
-            >
+            <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(false)}
-              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50"
-            >
+            </Button>
+            <Button variant="outline" size="xs" onClick={() => setShowDeleteConfirm(false)}>
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         ) : (
           <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -53,7 +53,7 @@
     --card-foreground: oklch(0.145 0 0);
     --popover: oklch(1 0 0);
     --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
+    --primary: oklch(0.546 0.245 262.881);
     --primary-foreground: oklch(0.985 0 0);
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
@@ -64,7 +64,7 @@
     --destructive: oklch(0.577 0.245 27.325);
     --border: oklch(0.922 0 0);
     --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
+    --ring: oklch(0.623 0.214 259.127);
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
     --chart-3: oklch(0.398 0.07 227.392);
@@ -87,8 +87,8 @@
     --card-foreground: oklch(0.985 0 0);
     --popover: oklch(0.205 0 0);
     --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
+    --primary: oklch(0.623 0.214 259.127);
+    --primary-foreground: oklch(0.985 0 0);
     --secondary: oklch(0.269 0 0);
     --secondary-foreground: oklch(0.985 0 0);
     --muted: oklch(0.269 0 0);
@@ -98,7 +98,7 @@
     --destructive: oklch(0.704 0.191 22.216);
     --border: oklch(1 0 0 / 10%);
     --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
+    --ring: oklch(0.546 0.245 262.881);
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);
     --chart-3: oklch(0.769 0.188 70.08);


### PR DESCRIPTION
## Summary
- Set primary theme color to blue (oklch) to match existing UI while using shadcn/ui semantic tokens
- Replace all `<button>` elements with `<Button>` component (variant: default, destructive, outline, ghost, link; size: default, xs, sm, icon-sm)
- Replace all `<input>` elements with `<Input>` component (text, email, password, search)
- Replace all `<textarea>` elements with `<Textarea>` component
- Replace badge-like `<span>` elements with `<Badge>` component (secondary, destructive variants)
- Migrate 22 component files across layout, project, board, task, preview, GitHub, and common modules
- Preserve all existing behavior, handlers, accessibility attributes, and test compatibility

## What's NOT migrated (intentional)
- `<select>` elements remain as native HTML (planned for #319 with shadcn/ui Select)
- `<input type="checkbox">` in filter dropdowns remain native
- ActivityFilter toggle buttons remain custom (specialized toggle group)
- Green/yellow/indigo buttons use custom className overrides since shadcn/ui lacks those variants

## Test plan
- [x] All 385 existing tests pass
- [x] Production build succeeds (CSS 38.4KB, JS 514KB)
- [x] Biome lint passes with no issues

Closes #318