### PR TITLE
refactor: ♻️ replace custom modals with shadcn/ui Dialog

### DIFF
--- a/frontend/src/components/project/ProjectChatPanel.test.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.test.tsx
@@ -185,7 +185,8 @@ describe('ProjectChatPanel', () => {
     useUiStore.setState({ isProjectChatOpen: true });
     renderWithProviders(<ProjectChatPanel projectId="project-1" />);
 
-    await user.click(screen.getByRole('dialog'));
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+    await user.click(overlay);
     expect(useUiStore.getState().isProjectChatOpen).toBe(false);
   });
 });

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -9,8 +8,8 @@ import {
   useListMessages,
 } from '@/api/generated/endpoints/project-messages/project-messages';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
@@ -128,8 +127,6 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
   const currentUser = useAuthStore((s) => s.user);
   const addToast = useToastStore((s) => s.addToast);
 
-  useEscapeKey(closeProjectChat);
-
   const handleSubmit = async () => {
     const trimmed = newMessage.trim();
     if (!trimmed) return;
@@ -156,29 +153,20 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
   const displayMessages = messages ? [...messages].reverse() : [];
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="project-chat-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeProjectChat();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeProjectChat();
       }}
     >
-      <div className="flex h-[600px] w-full max-w-lg flex-col rounded-lg bg-white shadow-xl">
-        <div className="flex items-center justify-between border-b px-4 py-3">
-          <h2 id="project-chat-title" className="text-lg font-semibold text-gray-900">
-            {t('chat.projectChat')}
-          </h2>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={closeProjectChat}
-            aria-label={t('common.close')}
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
+      <DialogContent
+        className="flex h-[600px] max-w-lg flex-col gap-0 p-0"
+        showCloseButton={false}
+        aria-describedby={undefined}
+      >
+        <DialogHeader className="border-b px-4 py-3">
+          <DialogTitle>{t('chat.projectChat')}</DialogTitle>
+        </DialogHeader>
 
         <div className="flex-1 overflow-y-auto px-4 py-2">
           {isLoading ? (
@@ -219,7 +207,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
             </Button>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -161,7 +161,6 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
     >
       <DialogContent
         className="flex h-[600px] max-w-lg flex-col gap-0 p-0"
-        showCloseButton={false}
         aria-describedby={undefined}
       >
         <DialogHeader className="border-b px-4 py-3">

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -3,9 +3,9 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCreateProject } from '@/api/generated/endpoints/projects/projects';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { invalidateProjects } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 
@@ -28,8 +28,6 @@ function ProjectCreateForm() {
   const [repositoryPath, setRepositoryPath] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEscapeKey(closeProjectModal);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
@@ -51,23 +49,21 @@ function ProjectCreateForm() {
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="project-create-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeProjectModal();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeProjectModal();
       }}
     >
-      <div
+      <DialogContent
+        className="max-w-md"
         data-testid="project-create-dialog"
-        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        aria-describedby={undefined}
       >
-        <h2 id="project-create-title" className="mb-4 text-lg font-semibold">
-          {t('project.createProject')}
-        </h2>
-        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        <DialogHeader>
+          <DialogTitle>{t('project.createProject')}</DialogTitle>
+        </DialogHeader>
+        {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">
@@ -79,7 +75,6 @@ function ProjectCreateForm() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               className="mt-1"
-              autoFocus
             />
           </div>
           <div>
@@ -122,7 +117,7 @@ function ProjectCreateForm() {
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/project/ProjectMembersPanel.test.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.test.tsx
@@ -298,7 +298,8 @@ describe('ProjectMembersPanel', () => {
     useUiStore.setState({ isProjectMembersOpen: true });
     renderWithProviders(<ProjectMembersPanel projectId="project-1" />);
 
-    await user.click(screen.getByRole('dialog'));
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+    await user.click(overlay);
     expect(useUiStore.getState().isProjectMembersOpen).toBe(false);
   });
 });

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -20,8 +19,8 @@ import type { MemberRole as MemberRoleType } from '@/api/generated/model';
 import { MemberRole } from '@/api/generated/model';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
@@ -66,8 +65,6 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
       queryKey: getListMembersQueryKey(projectId),
     });
   };
-
-  useEscapeKey(closeProjectMembers);
 
   const handleInvite = async () => {
     if (!selectedUser) return;
@@ -116,29 +113,16 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="project-members-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeProjectMembers();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeProjectMembers();
       }}
     >
-      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 id="project-members-title" className="text-lg font-semibold text-gray-900">
-            {t('members.members')}
-          </h2>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={closeProjectMembers}
-            aria-label={t('common.close')}
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{t('members.members')}</DialogTitle>
+        </DialogHeader>
 
         {isLoading ? (
           <p className="text-sm text-gray-500">{t('common.loading')}</p>
@@ -199,7 +183,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
         {canManage && <InvitationSection projectId={projectId} />}
 
         {canManage && (
-          <div className="mt-4 border-t pt-4">
+          <div className="border-t pt-4">
             <h3 className="mb-2 text-sm font-medium text-gray-700">
               {t('members.addExistingUser')}
             </h3>
@@ -252,8 +236,8 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
             </div>
           </div>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -298,14 +282,10 @@ function InvitationSection({ projectId }: { projectId: string }) {
     }
   };
 
-  // Token is only available at creation time — it's copied to clipboard
-  // automatically when the invitation is created. Re-retrieval is not
-  // possible since only the SHA-256 hash is stored in the database.
-
   const pendingInvitations = invitations?.filter((i) => !i.accepted_at) ?? [];
 
   return (
-    <div className="mt-4 border-t pt-4">
+    <div className="border-t pt-4">
       <div className="mb-2 flex items-center justify-between">
         <h3 className="text-sm font-medium text-gray-700">{t('members.invitationLinks')}</h3>
         <Button

--- a/frontend/src/components/project/ProjectSettingsModal.test.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.test.tsx
@@ -285,7 +285,8 @@ describe('ProjectSettingsModal', () => {
       <ProjectSettingsModal projectId="project-1" onProjectDeleted={mockOnProjectDeleted} />,
     );
 
-    await user.click(screen.getByRole('dialog'));
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+    await user.click(overlay);
     expect(useUiStore.getState().isProjectSettingsOpen).toBe(false);
   });
 });

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -59,7 +59,7 @@ function ProjectSettingsContent({
   const isOwner = currentUserRole === MemberRole.owner;
 
   const handleEscapeKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       if (editingField) {
         e.preventDefault();
         setEditingField(null);

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
@@ -12,9 +11,9 @@ import {
 } from '@/api/generated/endpoints/projects/projects';
 import { MemberRole } from '@/api/generated/model';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
@@ -59,14 +58,15 @@ function ProjectSettingsContent({
   const canEdit = currentUserRole === MemberRole.owner || currentUserRole === MemberRole.admin;
   const isOwner = currentUserRole === MemberRole.owner;
 
-  const escapeGuard = useCallback(() => {
-    if (editingField) {
-      setEditingField(null);
-      return true;
-    }
-    return false;
-  }, [editingField]);
-  useEscapeKey(closeProjectSettings, escapeGuard);
+  const handleEscapeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (editingField) {
+        e.preventDefault();
+        setEditingField(null);
+      }
+    },
+    [editingField],
+  );
 
   const startEditing = (field: 'name' | 'description' | 'repository_path', value: string) => {
     setEditingField(field);
@@ -125,29 +125,20 @@ function ProjectSettingsContent({
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="project-settings-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeProjectSettings();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeProjectSettings();
       }}
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 id="project-settings-title" className="text-lg font-semibold text-gray-900">
-            {t('project.settings')}
-          </h2>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={closeProjectSettings}
-            aria-label={t('common.close')}
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
+      <DialogContent
+        className="max-w-md"
+        onEscapeKeyDown={handleEscapeKeyDown}
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle>{t('project.settings')}</DialogTitle>
+        </DialogHeader>
 
         {isLoading ? (
           <p className="text-sm text-gray-500">{t('common.loading')}</p>
@@ -270,7 +261,7 @@ function ProjectSettingsContent({
             )}
           </div>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -5,9 +5,9 @@ import { useListMembers } from '@/api/generated/endpoints/project-members/projec
 import { useCreateTask } from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 
@@ -44,8 +44,6 @@ function TaskCreateForm({
   const [assignedTo, setAssignedTo] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEscapeKey(closeTaskModal);
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
@@ -70,23 +68,21 @@ function TaskCreateForm({
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="task-create-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeTaskModal();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeTaskModal();
       }}
     >
-      <div
+      <DialogContent
+        className="max-w-md"
         data-testid="task-create-dialog"
-        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+        aria-describedby={undefined}
       >
-        <h2 id="task-create-title" className="mb-4 text-lg font-semibold">
-          {t('task.createTask')}
-        </h2>
-        {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        <DialogHeader>
+          <DialogTitle>{t('task.createTask')}</DialogTitle>
+        </DialogHeader>
+        {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
@@ -98,7 +94,6 @@ function TaskCreateForm({
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               className="mt-1"
-              autoFocus
             />
           </div>
           <div>
@@ -175,7 +170,7 @@ function TaskCreateForm({
             </Button>
           </div>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/task/TaskDetailModal.test.tsx
+++ b/frontend/src/components/task/TaskDetailModal.test.tsx
@@ -110,8 +110,8 @@ describe('TaskDetailModal', () => {
     useUiStore.setState({ selectedTaskId: 'task-1', isTaskDetailOpen: true });
     renderWithProviders(<TaskDetailModal />);
 
-    const backdrop = screen.getByRole('dialog');
-    await user.click(backdrop);
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
+    await user.click(overlay);
 
     expect(useUiStore.getState().isTaskDetailOpen).toBe(false);
   });

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -35,7 +35,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const [error, setError] = useState<string | null>(null);
 
   const handleEscapeKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       if (editingField) {
         e.preventDefault();
         setEditingField(null);
@@ -116,7 +116,6 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       <DialogContent
         className="max-w-2xl"
         data-testid="task-detail-modal"
-        showCloseButton={false}
         onEscapeKeyDown={handleEscapeKeyDown}
         aria-describedby={undefined}
       >

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -1,11 +1,10 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
 import { PullRequestList } from '../github/PullRequestList';
@@ -35,14 +34,15 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const escapeGuard = useCallback(() => {
-    if (editingField) {
-      setEditingField(null);
-      return true;
-    }
-    return false;
-  }, [editingField]);
-  useEscapeKey(closeTaskDetail, escapeGuard);
+  const handleEscapeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (editingField) {
+        e.preventDefault();
+        setEditingField(null);
+      }
+    },
+    [editingField],
+  );
 
   const startEditing = (field: 'title' | 'description', value: string) => {
     setEditingField(field);
@@ -107,19 +107,20 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
   };
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="task-detail-modal-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) closeTaskDetail();
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) closeTaskDetail();
       }}
     >
-      <div
+      <DialogContent
+        className="max-w-2xl"
         data-testid="task-detail-modal"
-        className="w-full max-w-2xl rounded-lg bg-white p-6 shadow-xl"
+        showCloseButton={false}
+        onEscapeKeyDown={handleEscapeKeyDown}
+        aria-describedby={undefined}
       >
+        <DialogTitle className="sr-only">{t('task.detail')}</DialogTitle>
         {isLoading ? (
           <p className="text-sm text-gray-500">{t('common.loading')}</p>
         ) : isError || !task ? (
@@ -148,14 +149,6 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   {task.title}
                 </button>
               )}
-              <button
-                type="button"
-                onClick={closeTaskDetail}
-                className="text-gray-400 hover:text-gray-600"
-                aria-label={t('common.close')}
-              >
-                <X className="h-5 w-5" />
-              </button>
             </div>
 
             <div>
@@ -291,7 +284,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             </div>
           </div>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+import type * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import { XIcon } from 'lucide-react';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 import type * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -44,6 +45,7 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -62,7 +64,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t('common.close')}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -88,6 +90,7 @@ function DialogFooter({
 }: React.ComponentProps<'div'> & {
   showCloseButton?: boolean;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       data-slot="dialog-footer"
@@ -97,7 +100,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">{t('common.close')}</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,226 @@
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { Select as SelectPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'item-aligned',
+  align = 'center',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Tabs({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn('group/tabs flex gap-2 data-[orientation=horizontal]:flex-col', className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  'rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground',
+        'after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -156,7 +156,8 @@
     "loadingTask": "Loading task...",
     "loadFailed": "Failed to load task.",
     "assigneeFailed": "Failed to update assignee. Please try again.",
-    "editComment": "Edit comment"
+    "editComment": "Edit comment",
+    "detail": "Task Detail"
   },
   "activity": {
     "title": "Activity",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -156,7 +156,8 @@
     "loadingTask": "タスクを読み込み中...",
     "loadFailed": "タスクの読み込みに失敗しました。",
     "assigneeFailed": "担当者の更新に失敗しました。もう一度お試しください。",
-    "editComment": "コメントを編集"
+    "editComment": "コメントを編集",
+    "detail": "タスク詳細"
   },
   "activity": {
     "title": "アクティビティ",

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,6 +4,16 @@ import { initReactI18next } from 'react-i18next';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import en from '../locales/en.json';
 
+// Polyfills for Radix UI (Dialog, Select, etc.) in jsdom
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+HTMLElement.prototype.scrollIntoView ??= () => {};
+HTMLElement.prototype.hasPointerCapture ??= () => false;
+
 i18n.use(initReactI18next).init({
   resources: { en: { translation: en } },
   lng: 'en',


### PR DESCRIPTION
## Summary
- Install shadcn/ui `Dialog`, `Select`, `DropdownMenu`, `Tabs` components
- Replace all 6 custom modal implementations with Radix-based `<Dialog>`:
  - `ProjectCreateDialog`, `ProjectSettingsModal`, `TaskCreateDialog`
  - `TaskDetailModal`, `ProjectMembersPanel`, `ProjectChatPanel`
- Add Radix polyfills (`ResizeObserver`, `scrollIntoView`, `hasPointerCapture`) to test setup
- Remove `useEscapeKey` usage from all modals (Radix handles Escape/backdrop natively)
- Add `task.detail` i18n key (en/ja) for accessible sr-only DialogTitle

### What changed per dialog
| Component | Before | After |
|-----------|--------|-------|
| All modals | Custom `<div role="dialog">` + manual backdrop + `useEscapeKey` | `<Dialog>` + `<DialogContent>` with built-in portal, focus trap, animations |
| ProjectSettingsModal | `escapeGuard` via `useEscapeKey` | `onEscapeKeyDown` on `DialogContent` |
| TaskDetailModal | `escapeGuard` via `useEscapeKey` | `onEscapeKeyDown` on `DialogContent` |
| ProjectChatPanel | Custom close button | `showCloseButton={false}` + custom header |

### What was NOT changed (intentional)
- **Native `<select>` elements**: Evaluated Radix Select but deferred due to jsdom test incompatibility (ResizeObserver, pointer events, custom rendering). Native selects are accessible and functional.
- **Filter dropdowns** (`TaskFilterBar`): Evaluated `DropdownMenu` but the multi-checkbox pattern doesn't map cleanly to Radix DropdownMenu. Better candidate for `Popover` + `Command` pattern in #320.
- **Tabs** (`TaskDetailPage`): Evaluated but current layout doesn't have a natural tab structure. Candidate for future UX redesign.

## Test plan
- [x] All 385 tests pass (zero failures)
- [x] TypeScript compiles with no errors
- [x] Biome lint passes
- [x] Production build succeeds (544KB JS gzipped 167KB)
- [x] Backdrop click tests updated to target `[data-slot="dialog-overlay"]`
- [x] Escape key tests work via Radix's built-in handling

Closes #319