### PR TITLE
refactor: ♻️ unify theming with CSS variables (#320)

### DIFF
--- a/frontend/src/components/agent/AgentOutputViewer.tsx
+++ b/frontend/src/components/agent/AgentOutputViewer.tsx
@@ -21,7 +21,7 @@ export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewe
 
   if (isLoading) {
     return (
-      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+      <div className="rounded-md bg-muted p-4 text-sm text-muted-foreground">
         {t('agent.loadingOutput')}
       </div>
     );
@@ -29,7 +29,9 @@ export function AgentOutputViewer({ lines, isLoading = false }: AgentOutputViewe
 
   if (lines.length === 0) {
     return (
-      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">{t('agent.noOutput')}</div>
+      <div className="rounded-md bg-muted p-4 text-sm text-muted-foreground">
+        {t('agent.noOutput')}
+      </div>
     );
   }
 

--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -20,12 +20,12 @@ interface AgentPanelProps {
 }
 
 const STATUS_COLORS: Record<AgentSessionStatus, string> = {
-  pending: 'bg-yellow-100 text-yellow-800',
-  running: 'bg-blue-100 text-blue-800',
-  paused: 'bg-orange-100 text-orange-800',
-  completed: 'bg-green-100 text-green-800',
-  failed: 'bg-red-100 text-red-800',
-  cancelled: 'bg-gray-100 text-gray-800',
+  pending: 'bg-warning/15 text-warning',
+  running: 'bg-primary/15 text-primary',
+  paused: 'bg-warning/25 text-warning',
+  completed: 'bg-success/15 text-success',
+  failed: 'bg-destructive/15 text-destructive',
+  cancelled: 'bg-muted text-muted-foreground',
 };
 
 const TERMINAL_STATUSES: AgentSessionStatus[] = ['completed', 'failed', 'cancelled'];
@@ -173,12 +173,14 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
 
   return (
     <div className="space-y-3">
-      {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
       {activeSession ? (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted-foreground">
                 {activeSession.agent_type === 'claude_code'
                   ? t('agent.claudeCode')
                   : t('agent.geminiCli')}
@@ -196,7 +198,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                     type="button"
                     onClick={handlePause}
                     disabled={pauseSession.isPending}
-                    className="rounded-md bg-yellow-600 px-3 py-1.5 text-sm text-white hover:bg-yellow-700 disabled:opacity-50"
+                    className="rounded-md bg-warning px-3 py-1.5 text-sm text-white hover:bg-warning/80 disabled:opacity-50"
                   >
                     {t('agent.pause')}
                   </button>
@@ -206,7 +208,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                     type="button"
                     onClick={handleResume}
                     disabled={resumeSession.isPending}
-                    className="rounded-md bg-green-600 px-3 py-1.5 text-sm text-white hover:bg-green-700 disabled:opacity-50"
+                    className="rounded-md bg-success px-3 py-1.5 text-sm text-white hover:bg-success/80 disabled:opacity-50"
                   >
                     {t('agent.resume')}
                   </button>
@@ -215,7 +217,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
                   type="button"
                   onClick={handleStop}
                   disabled={stopSession.isPending}
-                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+                  className="rounded-md bg-destructive px-3 py-1.5 text-sm text-white hover:bg-destructive/80 disabled:opacity-50"
                 >
                   {t('common.stop')}
                 </button>
@@ -231,11 +233,11 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               <button
                 type="button"
                 onClick={handleBackToInput}
-                className="text-sm text-blue-600 hover:text-blue-800"
+                className="text-sm text-primary hover:text-primary/80"
               >
                 {t('common.back')}
               </button>
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted-foreground">
                 {viewingSession.agent_type === 'claude_code'
                   ? t('agent.claudeCode')
                   : t('agent.geminiCli')}
@@ -252,14 +254,17 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
       ) : (
         <div className="space-y-3">
           <div>
-            <label htmlFor="agent-type-select" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="agent-type-select"
+              className="block text-sm font-medium text-foreground"
+            >
               {t('agent.agentType')}
             </label>
             <select
               id="agent-type-select"
               value={agentType}
               onChange={(e) => setAgentType(e.target.value as AgentType)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
             >
               <option value="claude_code">{t('agent.claudeCode')}</option>
               <option value="gemini_cli">{t('agent.geminiCli')}</option>
@@ -268,7 +273,7 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
           <div>
             <label
               htmlFor="agent-prompt-textarea"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-foreground"
             >
               {t('agent.prompt')}
             </label>
@@ -278,29 +283,29 @@ export function AgentPanel({ taskId }: AgentPanelProps) {
               onChange={(e) => setPrompt(e.target.value)}
               placeholder={t('agent.promptPlaceholder')}
               rows={3}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
             />
           </div>
           <button
             type="button"
             onClick={handleStart}
             disabled={!prompt.trim() || startSession.isPending}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm text-white hover:bg-primary/80 disabled:opacity-50"
           >
             {t('common.start')}
           </button>
           {pastSessions.length > 0 && (
             <div>
-              <h4 className="text-sm font-medium text-gray-700">{t('agent.pastSessions')}</h4>
+              <h4 className="text-sm font-medium text-foreground">{t('agent.pastSessions')}</h4>
               <div className="mt-1 space-y-1">
                 {pastSessions.map((session) => (
                   <button
                     key={session.id}
                     type="button"
                     onClick={() => handleViewSession(session)}
-                    className="flex w-full items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                    className="flex w-full items-center justify-between rounded-md border border-border px-3 py-2 text-left text-sm hover:bg-accent"
                   >
-                    <span className="truncate text-gray-600">{session.id.slice(0, 8)}</span>
+                    <span className="truncate text-muted-foreground">{session.id.slice(0, 8)}</span>
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[session.status]}`}
                     >

--- a/frontend/src/components/board/KanbanBoard.tsx
+++ b/frontend/src/components/board/KanbanBoard.tsx
@@ -164,7 +164,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   if (isLoading) {
     return (
       <div data-testid="kanban-loading" className="flex items-center justify-center p-8">
-        <div className="text-gray-500">{t('board.loadingTasks')}</div>
+        <div className="text-muted-foreground">{t('board.loadingTasks')}</div>
       </div>
     );
   }
@@ -172,7 +172,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   if (error) {
     return (
       <div data-testid="kanban-error" className="flex items-center justify-center p-8">
-        <div className="text-red-500">{t('board.loadFailed')}</div>
+        <div className="text-destructive">{t('board.loadFailed')}</div>
       </div>
     );
   }

--- a/frontend/src/components/board/KanbanColumn.test.tsx
+++ b/frontend/src/components/board/KanbanColumn.test.tsx
@@ -92,19 +92,19 @@ describe('KanbanColumn', () => {
   it('applies status-specific background color', () => {
     const { container, rerender } = render(<KanbanColumn status={TaskStatus.backlog} tasks={[]} />);
     const column = container.firstChild as HTMLElement;
-    expect(column.className).toContain('bg-slate-50');
+    expect(column.className).toContain('bg-muted');
 
     rerender(<KanbanColumn status={TaskStatus.todo} tasks={[]} />);
-    expect((container.firstChild as HTMLElement).className).toContain('bg-blue-50');
+    expect((container.firstChild as HTMLElement).className).toContain('bg-primary/10');
 
     rerender(<KanbanColumn status={TaskStatus.in_progress} tasks={[]} />);
-    expect((container.firstChild as HTMLElement).className).toContain('bg-amber-50');
+    expect((container.firstChild as HTMLElement).className).toContain('bg-warning/10');
 
     rerender(<KanbanColumn status={TaskStatus.in_review} tasks={[]} />);
     expect((container.firstChild as HTMLElement).className).toContain('bg-purple-50');
 
     rerender(<KanbanColumn status={TaskStatus.done} tasks={[]} />);
-    expect((container.firstChild as HTMLElement).className).toContain('bg-green-50');
+    expect((container.firstChild as HTMLElement).className).toContain('bg-success/10');
   });
 
   it('applies status-specific badge color', () => {
@@ -112,18 +112,18 @@ describe('KanbanColumn', () => {
 
     const getBadge = () => screen.getByText('0');
 
-    expect(getBadge().className).toContain('bg-slate-200');
+    expect(getBadge().className).toContain('bg-muted');
 
     rerender(<KanbanColumn status={TaskStatus.todo} tasks={[]} />);
-    expect(getBadge().className).toContain('bg-blue-200');
+    expect(getBadge().className).toContain('bg-primary/20');
 
     rerender(<KanbanColumn status={TaskStatus.in_progress} tasks={[]} />);
-    expect(getBadge().className).toContain('bg-amber-200');
+    expect(getBadge().className).toContain('bg-warning/20');
 
     rerender(<KanbanColumn status={TaskStatus.in_review} tasks={[]} />);
     expect(getBadge().className).toContain('bg-purple-200');
 
     rerender(<KanbanColumn status={TaskStatus.done} tasks={[]} />);
-    expect(getBadge().className).toContain('bg-green-200');
+    expect(getBadge().className).toContain('bg-success/20');
   });
 });

--- a/frontend/src/components/board/KanbanColumn.tsx
+++ b/frontend/src/components/board/KanbanColumn.tsx
@@ -24,11 +24,11 @@ const statusLabelKeys: Record<TaskStatus, string> = {
 };
 
 const statusColors: Record<TaskStatus, { bg: string; badge: string }> = {
-  [TaskStatus.backlog]: { bg: 'bg-slate-50', badge: 'bg-slate-200 text-slate-700' },
-  [TaskStatus.todo]: { bg: 'bg-blue-50', badge: 'bg-blue-200 text-blue-700' },
-  [TaskStatus.in_progress]: { bg: 'bg-amber-50', badge: 'bg-amber-200 text-amber-700' },
+  [TaskStatus.backlog]: { bg: 'bg-muted', badge: 'bg-muted text-muted-foreground' },
+  [TaskStatus.todo]: { bg: 'bg-primary/10', badge: 'bg-primary/20 text-primary' },
+  [TaskStatus.in_progress]: { bg: 'bg-warning/10', badge: 'bg-warning/20 text-warning' },
   [TaskStatus.in_review]: { bg: 'bg-purple-50', badge: 'bg-purple-200 text-purple-700' },
-  [TaskStatus.done]: { bg: 'bg-green-50', badge: 'bg-green-200 text-green-700' },
+  [TaskStatus.done]: { bg: 'bg-success/10', badge: 'bg-success/20 text-success' },
 };
 
 export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanColumnProps) {
@@ -41,18 +41,18 @@ export function KanbanColumn({ status, tasks, activeTaskId, members }: KanbanCol
   return (
     <div
       className={`flex min-h-[500px] w-72 flex-shrink-0 flex-col rounded-lg ${
-        isOver ? 'bg-blue-50 ring-2 ring-blue-400' : statusColors[status].bg
+        isOver ? 'bg-primary/10 ring-2 ring-ring' : statusColors[status].bg
       }`}
     >
       <div className="flex items-center justify-between p-3">
-        <h2 className="text-sm font-semibold text-gray-700">{t(statusLabelKeys[status])}</h2>
+        <h2 className="text-sm font-semibold text-foreground">{t(statusLabelKeys[status])}</h2>
         <Badge className={statusColors[status].badge}>{tasks.length}</Badge>
       </div>
       <div ref={setNodeRef} className="flex-1 space-y-2 overflow-y-auto p-2">
         {tasks.length === 0 ? (
           <div
             data-testid="column-empty"
-            className="flex h-24 items-center justify-center rounded border-2 border-dashed border-gray-300 text-sm text-gray-400"
+            className="flex h-24 items-center justify-center rounded border-2 border-dashed border-border text-sm text-muted-foreground"
           >
             {t('board.noTasks')}
           </div>

--- a/frontend/src/components/board/TaskCard.test.tsx
+++ b/frontend/src/components/board/TaskCard.test.tsx
@@ -60,7 +60,7 @@ describe('TaskCard', () => {
     render(<TaskCard task={task} />);
 
     const badge = screen.getByText('urgent');
-    expect(badge).toHaveClass('bg-red-100');
+    expect(badge).toHaveClass('bg-destructive/15');
   });
 
   it('applies high priority styling', () => {
@@ -68,7 +68,7 @@ describe('TaskCard', () => {
     render(<TaskCard task={task} />);
 
     const badge = screen.getByText('high');
-    expect(badge).toHaveClass('bg-orange-100');
+    expect(badge).toHaveClass('bg-warning/25');
   });
 
   it('applies medium priority styling', () => {
@@ -76,7 +76,7 @@ describe('TaskCard', () => {
     render(<TaskCard task={task} />);
 
     const badge = screen.getByText('medium');
-    expect(badge).toHaveClass('bg-yellow-100');
+    expect(badge).toHaveClass('bg-warning/15');
   });
 
   it('applies low priority styling', () => {
@@ -84,7 +84,7 @@ describe('TaskCard', () => {
     render(<TaskCard task={task} />);
 
     const badge = screen.getByText('low');
-    expect(badge).toHaveClass('bg-gray-100');
+    expect(badge).toHaveClass('bg-muted');
   });
 
   it('opens task detail on click', async () => {

--- a/frontend/src/components/board/TaskCard.tsx
+++ b/frontend/src/components/board/TaskCard.tsx
@@ -24,10 +24,10 @@ function getInitials(name: string): string {
 const CLICK_THRESHOLD = 5;
 
 const priorityStyles: Record<TaskPriority, string> = {
-  [TaskPriority.urgent]: 'bg-red-100 text-red-800',
-  [TaskPriority.high]: 'bg-orange-100 text-orange-800',
-  [TaskPriority.medium]: 'bg-yellow-100 text-yellow-800',
-  [TaskPriority.low]: 'bg-gray-100 text-gray-800',
+  [TaskPriority.urgent]: 'bg-destructive/15 text-destructive',
+  [TaskPriority.high]: 'bg-warning/25 text-warning',
+  [TaskPriority.medium]: 'bg-warning/15 text-warning',
+  [TaskPriority.low]: 'bg-muted text-muted-foreground',
 };
 
 export function TaskCard({ task, isDragging, members }: TaskCardProps) {
@@ -76,16 +76,16 @@ export function TaskCard({ task, isDragging, members }: TaskCardProps) {
         }
       }}
       data-testid="task-card"
-      className={`cursor-pointer rounded-lg border border-gray-200 bg-white p-3 shadow-sm ${
+      className={`cursor-pointer rounded-lg border border-border bg-background p-3 shadow-sm ${
         isDragging ? 'opacity-50' : ''
       }`}
     >
       <div className="mb-2 flex items-start justify-between">
-        <h3 className="text-sm font-medium text-gray-900">{task.title}</h3>
+        <h3 className="text-sm font-medium text-foreground">{task.title}</h3>
         <Badge className={`rounded ${priorityStyles[task.priority]}`}>{task.priority}</Badge>
       </div>
       {task.description && (
-        <p data-testid="task-description" className="text-xs text-gray-500">
+        <p data-testid="task-description" className="text-xs text-muted-foreground">
           {task.description}
         </p>
       )}
@@ -97,7 +97,7 @@ export function TaskCard({ task, isDragging, members }: TaskCardProps) {
             <div className="mt-2 flex justify-end">
               <div
                 data-testid="assignee-avatar"
-                className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-xs font-medium text-blue-800"
+                className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary"
                 title={member?.user_name}
               >
                 {initials}

--- a/frontend/src/components/board/TaskFilterBar.tsx
+++ b/frontend/src/components/board/TaskFilterBar.tsx
@@ -49,7 +49,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
   return (
     <div className="flex items-center gap-3">
       <div className="relative">
-        <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="text"
           placeholder={t('board.searchPlaceholder')}
@@ -73,9 +73,9 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
         {assigneeOpen && (
           <div
             data-testid="assignee-dropdown"
-            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-gray-200 bg-white p-2 shadow-lg"
+            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-border bg-background p-2 shadow-lg"
           >
-            <label className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50">
+            <label className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent">
               <input
                 type="checkbox"
                 checked={assigneeFilter.includes('unassigned')}
@@ -86,7 +86,7 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
             {members?.map((m) => (
               <label
                 key={m.user_id}
-                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50"
+                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
               >
                 <input
                   type="checkbox"
@@ -114,12 +114,12 @@ export function TaskFilterBar({ members }: TaskFilterBarProps) {
         {priorityOpen && (
           <div
             data-testid="priority-dropdown"
-            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-gray-200 bg-white p-2 shadow-lg"
+            className="absolute left-0 top-full z-10 mt-1 w-48 rounded-md border border-border bg-background p-2 shadow-lg"
           >
             {Object.values(TaskPriority).map((p) => (
               <label
                 key={p}
-                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-50"
+                className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
               >
                 <input
                   type="checkbox"

--- a/frontend/src/components/common/CommentSection.tsx
+++ b/frontend/src/components/common/CommentSection.tsx
@@ -91,13 +91,13 @@ function CommentItem({
 
   return (
     <div data-testid="comment-item" className="flex gap-3 py-2">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
         {initials}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-900">{comment.user_name}</span>
-          <span className="text-xs text-gray-500">{timeAgo(comment.created_at, t)}</span>
+          <span className="text-sm font-medium text-foreground">{comment.user_name}</span>
+          <span className="text-xs text-muted-foreground">{timeAgo(comment.created_at, t)}</span>
           {isOwner && !editing && !showDeleteConfirm && (
             <div className="ml-auto flex gap-1">
               <Button
@@ -134,8 +134,8 @@ function CommentItem({
             </div>
           </div>
         ) : showDeleteConfirm ? (
-          <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">{t('comment.deleteConfirm')}</span>
+          <div className="mt-1 flex items-center gap-2 rounded bg-destructive/10 px-2 py-1">
+            <span className="text-xs text-destructive">{t('comment.deleteConfirm')}</span>
             <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
             </Button>
@@ -144,7 +144,7 @@ function CommentItem({
             </Button>
           </div>
         ) : (
-          <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
+          <p className="mt-0.5 text-sm text-foreground">{comment.content}</p>
         )}
       </div>
     </div>
@@ -175,7 +175,7 @@ export function CommentSection({ taskId }: { taskId: string }) {
   return (
     <div>
       {isLoading ? (
-        <p className="text-sm text-gray-500">{t('comment.loadingComments')}</p>
+        <p className="text-sm text-muted-foreground">{t('comment.loadingComments')}</p>
       ) : comments && comments.length > 0 ? (
         <div className="divide-y">
           {comments.map((c) => (
@@ -188,7 +188,7 @@ export function CommentSection({ taskId }: { taskId: string }) {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-gray-500">{t('comment.noComments')}</p>
+        <p className="text-sm text-muted-foreground">{t('comment.noComments')}</p>
       )}
       <div className="mt-3 flex gap-2">
         <Textarea

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -25,16 +25,16 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex min-h-screen items-center justify-center bg-gray-100">
-          <div className="rounded-lg bg-white p-8 text-center shadow-lg">
-            <h1 className="mb-4 text-2xl font-bold text-gray-900">
+        <div className="flex min-h-screen items-center justify-center bg-muted">
+          <div className="rounded-lg bg-background p-8 text-center shadow-lg">
+            <h1 className="mb-4 text-2xl font-bold text-foreground">
               {i18n.t('error.somethingWrong')}
             </h1>
-            <p className="mb-6 text-gray-600">{i18n.t('error.unexpectedError')}</p>
+            <p className="mb-6 text-muted-foreground">{i18n.t('error.unexpectedError')}</p>
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              className="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
             >
               {i18n.t('common.reloadPage')}
             </button>

--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -13,7 +13,7 @@ export function LanguageSwitcher() {
       value={i18n.resolvedLanguage ?? i18n.language}
       onChange={(e) => i18n.changeLanguage(e.target.value)}
       aria-label={t('language.switchLanguage')}
-      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700"
+      className="rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
     >
       {LANGUAGES.map((lang) => (
         <option key={lang.code} value={lang.code}>

--- a/frontend/src/components/common/ToastContainer.test.tsx
+++ b/frontend/src/components/common/ToastContainer.test.tsx
@@ -42,30 +42,30 @@ describe('ToastContainer', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0);
   });
 
-  it('applies green styling for success toast', () => {
+  it('applies success styling for success toast', () => {
     useToastStore.setState({
       toasts: [{ id: '1', type: 'success', message: 'Success msg' }],
     });
     render(<ToastContainer />);
     const toast = screen.getByText('Success msg').closest('[data-testid="toast-item"]');
-    expect(toast).toHaveClass('bg-green-50');
+    expect(toast).toHaveClass('bg-success/10');
   });
 
-  it('applies red styling for error toast', () => {
+  it('applies destructive styling for error toast', () => {
     useToastStore.setState({
       toasts: [{ id: '1', type: 'error', message: 'Error msg' }],
     });
     render(<ToastContainer />);
     const toast = screen.getByText('Error msg').closest('[data-testid="toast-item"]');
-    expect(toast).toHaveClass('bg-red-50');
+    expect(toast).toHaveClass('bg-destructive/10');
   });
 
-  it('applies blue styling for info toast', () => {
+  it('applies primary styling for info toast', () => {
     useToastStore.setState({
       toasts: [{ id: '1', type: 'info', message: 'Info msg' }],
     });
     render(<ToastContainer />);
     const toast = screen.getByText('Info msg').closest('[data-testid="toast-item"]');
-    expect(toast).toHaveClass('bg-blue-50');
+    expect(toast).toHaveClass('bg-primary/10');
   });
 });

--- a/frontend/src/components/common/ToastContainer.tsx
+++ b/frontend/src/components/common/ToastContainer.tsx
@@ -2,9 +2,9 @@ import { useTranslation } from 'react-i18next';
 import { useToastStore } from '@/stores/toastStore';
 
 const typeStyles = {
-  success: 'bg-green-50 border-green-400 text-green-800',
-  error: 'bg-red-50 border-red-400 text-red-800',
-  info: 'bg-blue-50 border-blue-400 text-blue-800',
+  success: 'bg-success/10 border-success text-success',
+  error: 'bg-destructive/10 border-destructive text-destructive',
+  info: 'bg-primary/10 border-primary text-primary',
 };
 
 export function ToastContainer() {

--- a/frontend/src/components/github/GitHubLinkSettings.tsx
+++ b/frontend/src/components/github/GitHubLinkSettings.tsx
@@ -68,7 +68,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
   };
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">{t('common.loading')}</p>;
+    return <p className="text-sm text-muted-foreground">{t('common.loading')}</p>;
   }
 
   if (isError || !link) {
@@ -76,7 +76,10 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
       <div className="space-y-2">
         <div className="flex gap-2">
           <div className="flex-1">
-            <label htmlFor="github-owner" className="block text-xs font-medium text-gray-600">
+            <label
+              htmlFor="github-owner"
+              className="block text-xs font-medium text-muted-foreground"
+            >
               {t('github.owner')}
             </label>
             <Input
@@ -89,7 +92,10 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
             />
           </div>
           <div className="flex-1">
-            <label htmlFor="github-repo" className="block text-xs font-medium text-gray-600">
+            <label
+              htmlFor="github-repo"
+              className="block text-xs font-medium text-muted-foreground"
+            >
               {t('github.repository')}
             </label>
             <Input
@@ -115,8 +121,8 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2">
-        <span className="text-sm font-medium text-gray-900">
+      <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+        <span className="text-sm font-medium text-foreground">
           {link.repo_owner}/{link.repo_name}
         </span>
         <div className="flex gap-2">
@@ -125,7 +131,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
           </Button>
           {showUnlinkConfirm ? (
             <div className="flex items-center gap-2">
-              <span className="text-xs text-red-600">{t('common.areYouSure')}</span>
+              <span className="text-xs text-destructive">{t('common.areYouSure')}</span>
               <Button
                 variant="outline"
                 size="xs"
@@ -148,7 +154,7 @@ export function GitHubLinkSettings({ projectId }: { projectId: string }) {
               variant="outline"
               size="xs"
               onClick={() => setShowUnlinkConfirm(true)}
-              className="border-red-300 text-red-700 hover:bg-red-50"
+              className="border-destructive/30 text-destructive hover:bg-destructive/10"
             >
               {t('github.unlink')}
             </Button>

--- a/frontend/src/components/github/PullRequestList.tsx
+++ b/frontend/src/components/github/PullRequestList.tsx
@@ -7,15 +7,15 @@ export function PullRequestList({ taskId }: { taskId: string }) {
   const { data: pullRequests, isLoading, isError } = useListPullRequests(taskId);
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">{t('github.loadingPullRequests')}</p>;
+    return <p className="text-sm text-muted-foreground">{t('github.loadingPullRequests')}</p>;
   }
 
   if (isError) {
-    return <p className="text-sm text-red-500">{t('github.loadPullRequestsFailed')}</p>;
+    return <p className="text-sm text-destructive">{t('github.loadPullRequestsFailed')}</p>;
   }
 
   if (!pullRequests || pullRequests.length === 0) {
-    return <p className="text-sm text-gray-500">{t('github.noPullRequests')}</p>;
+    return <p className="text-sm text-muted-foreground">{t('github.noPullRequests')}</p>;
   }
 
   return (
@@ -32,18 +32,18 @@ function PullRequestItem({ pr }: { pr: GitHubPullRequest }) {
   const badge = getBadge(pr, t);
 
   return (
-    <div className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2">
+    <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
       <div className="flex items-center gap-2 text-sm min-w-0">
-        <span className="text-gray-500 shrink-0">#{pr.pr_number}</span>
+        <span className="text-muted-foreground shrink-0">#{pr.pr_number}</span>
         <a
           href={pr.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="truncate font-medium text-blue-600 hover:underline"
+          className="truncate font-medium text-primary hover:underline"
         >
           {pr.title}
         </a>
-        {pr.author && <span className="text-gray-400 shrink-0">{pr.author}</span>}
+        {pr.author && <span className="text-muted-foreground shrink-0">{pr.author}</span>}
       </div>
       <span
         className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ${badge.classes}`}
@@ -59,10 +59,10 @@ function getBadge(
   t: (key: string) => string,
 ): { label: string; classes: string } {
   if (pr.state === 'open') {
-    return { label: t('github.prOpen'), classes: 'bg-green-100 text-green-800' };
+    return { label: t('github.prOpen'), classes: 'bg-success/15 text-success' };
   }
   if (pr.is_merged) {
     return { label: t('github.prMerged'), classes: 'bg-purple-100 text-purple-800' };
   }
-  return { label: t('github.prClosed'), classes: 'bg-red-100 text-red-800' };
+  return { label: t('github.prClosed'), classes: 'bg-destructive/15 text-destructive' };
 }

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -33,15 +33,15 @@ export function AppLayout() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="bg-white shadow">
+    <div className="min-h-screen bg-muted">
+      <header className="bg-background shadow">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-          <Link to="/" className="text-2xl font-bold text-gray-900 hover:text-gray-700">
+          <Link to="/" className="text-2xl font-bold text-foreground hover:text-foreground/80">
             {t('app.title')}
           </Link>
           <div className="flex items-center gap-2 border-l pl-4">
             <LanguageSwitcher />
-            <span className="text-sm text-gray-600">{user?.name ?? user?.email}</span>
+            <span className="text-sm text-muted-foreground">{user?.name ?? user?.email}</span>
             <Button
               variant="secondary"
               size="sm"

--- a/frontend/src/components/layout/GuestRoute.tsx
+++ b/frontend/src/components/layout/GuestRoute.tsx
@@ -12,8 +12,8 @@ export function GuestRoute({ children }: GuestRouteProps) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <div className="text-gray-500">{t('common.loading')}</div>
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <div className="text-muted-foreground">{t('common.loading')}</div>
       </div>
     );
   }

--- a/frontend/src/components/layout/InvitationAcceptPage.tsx
+++ b/frontend/src/components/layout/InvitationAcceptPage.tsx
@@ -23,8 +23,8 @@ export function InvitationAcceptPage() {
 
   if (!token) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <p className="text-gray-500">{t('invitation.invalidLink')}</p>
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">{t('invitation.invalidLink')}</p>
       </div>
     );
   }
@@ -39,34 +39,34 @@ export function InvitationAcceptPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-2xl font-bold text-gray-900">{t('invitation.title')}</h1>
+    <div className="flex min-h-screen items-center justify-center bg-muted">
+      <div className="w-full max-w-md rounded-lg bg-background p-8 shadow-md">
+        <h1 className="mb-6 text-2xl font-bold text-foreground">{t('invitation.title')}</h1>
 
         {isLoading ? (
-          <p className="text-gray-500">{t('invitation.loadingInvitation')}</p>
+          <p className="text-muted-foreground">{t('invitation.loadingInvitation')}</p>
         ) : isError ? (
-          <p className="text-red-500">{t('invitation.expiredOrInvalid')}</p>
+          <p className="text-destructive">{t('invitation.expiredOrInvalid')}</p>
         ) : info ? (
           <div className="space-y-4">
-            <div className="rounded-md bg-blue-50 p-4">
-              <p className="text-sm text-gray-700">
+            <div className="rounded-md bg-primary/10 p-4">
+              <p className="text-sm text-foreground">
                 <span className="font-medium">{info.invited_by_name}</span>{' '}
                 {t('invitation.invitedYou')}
               </p>
-              <p className="mt-1 text-lg font-semibold text-gray-900">{info.project_name}</p>
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-lg font-semibold text-foreground">{info.project_name}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
                 {t('invitation.role')} <span className="font-medium">{info.role}</span>
               </p>
             </div>
 
             {info.accepted ? (
-              <p className="text-sm text-green-600">{t('invitation.alreadyAccepted')}</p>
+              <p className="text-sm text-success">{t('invitation.alreadyAccepted')}</p>
             ) : info.expired ? (
-              <p className="text-sm text-red-600">{t('invitation.expired')}</p>
+              <p className="text-sm text-destructive">{t('invitation.expired')}</p>
             ) : !isAuthenticated ? (
               <div className="space-y-2">
-                <p className="text-sm text-gray-600">{t('invitation.loginRequired')}</p>
+                <p className="text-sm text-muted-foreground">{t('invitation.loginRequired')}</p>
                 <Button
                   className="w-full"
                   onClick={() => navigate(`/login?redirect=/invite/${token}`)}
@@ -91,7 +91,7 @@ export function InvitationAcceptPage() {
                   {acceptMutation.isPending ? t('invitation.accepting') : t('invitation.accept')}
                 </Button>
                 {acceptMutation.isError && (
-                  <p className="text-sm text-red-600">{t('invitation.acceptFailed')}</p>
+                  <p className="text-sm text-destructive">{t('invitation.acceptFailed')}</p>
                 )}
               </div>
             )}

--- a/frontend/src/components/layout/LoginPage.tsx
+++ b/frontend/src/components/layout/LoginPage.tsx
@@ -34,14 +34,16 @@ export function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">{t('auth.signInTo')}</h1>
+    <div className="flex min-h-screen items-center justify-center bg-muted">
+      <div className="w-full max-w-md rounded-lg bg-background p-8 shadow-md">
+        <h1 className="mb-6 text-center text-2xl font-bold text-foreground">
+          {t('auth.signInTo')}
+        </h1>
 
         {error && (
           <div
             data-testid="login-error"
-            className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700"
+            className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
           >
             {error}
           </div>
@@ -49,7 +51,7 @@ export function LoginPage() {
 
         <form onSubmit={handleSubmit} data-testid="login-form" className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="email" className="block text-sm font-medium text-foreground">
               {t('auth.email')}
             </label>
             <Input
@@ -64,7 +66,7 @@ export function LoginPage() {
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="password" className="block text-sm font-medium text-foreground">
               {t('auth.password')}
             </label>
             <Input
@@ -83,7 +85,7 @@ export function LoginPage() {
           </Button>
         </form>
 
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-sm text-muted-foreground">
           {t('auth.noAccount')}{' '}
           <Link
             to={redirectTo ? `/register?redirect=${encodeURIComponent(redirectTo)}` : '/register'}

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -12,8 +12,8 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-100">
-        <div className="text-gray-500">{t('common.loading')}</div>
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <div className="text-muted-foreground">{t('common.loading')}</div>
       </div>
     );
   }

--- a/frontend/src/components/layout/RegisterPage.tsx
+++ b/frontend/src/components/layout/RegisterPage.tsx
@@ -40,16 +40,16 @@ export function RegisterPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-gray-900">
+    <div className="flex min-h-screen items-center justify-center bg-muted">
+      <div className="w-full max-w-md rounded-lg bg-background p-8 shadow-md">
+        <h1 className="mb-6 text-center text-2xl font-bold text-foreground">
           {t('auth.createAccount')}
         </h1>
 
         {error && (
           <div
             data-testid="register-error"
-            className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700"
+            className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
           >
             {error}
           </div>
@@ -57,7 +57,7 @@ export function RegisterPage() {
 
         <form onSubmit={handleSubmit} data-testid="register-form" className="space-y-4">
           <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="name" className="block text-sm font-medium text-foreground">
               {t('auth.name')}
             </label>
             <Input
@@ -72,7 +72,7 @@ export function RegisterPage() {
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="email" className="block text-sm font-medium text-foreground">
               {t('auth.email')}
             </label>
             <Input
@@ -87,7 +87,7 @@ export function RegisterPage() {
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="password" className="block text-sm font-medium text-foreground">
               {t('auth.password')}
             </label>
             <Input
@@ -107,7 +107,7 @@ export function RegisterPage() {
           </Button>
         </form>
 
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-sm text-muted-foreground">
           {t('auth.hasAccount')}{' '}
           <Link
             to={redirectTo ? `/login?redirect=${encodeURIComponent(redirectTo)}` : '/login'}

--- a/frontend/src/components/preview/PreviewPanel.tsx
+++ b/frontend/src/components/preview/PreviewPanel.tsx
@@ -14,11 +14,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 const statusColors: Record<string, string> = {
-  pending: 'bg-yellow-100 text-yellow-800',
-  building: 'bg-blue-100 text-blue-800',
-  running: 'bg-green-100 text-green-800',
-  stopped: 'bg-gray-100 text-gray-800',
-  failed: 'bg-red-100 text-red-800',
+  pending: 'bg-warning/15 text-warning',
+  building: 'bg-primary/15 text-primary',
+  running: 'bg-success/15 text-success',
+  stopped: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/15 text-destructive',
 };
 
 function PreviewActions({
@@ -40,17 +40,13 @@ function PreviewActions({
   return (
     <div className="flex gap-1">
       {(status === 'pending' || status === 'stopped' || status === 'failed') && (
-        <Button size="xs" onClick={() => onStart(id)} className="bg-green-600 hover:bg-green-700">
+        <Button size="xs" onClick={() => onStart(id)} className="bg-success hover:bg-success/80">
           {t('preview.start')}
         </Button>
       )}
       {status === 'running' && (
         <>
-          <Button
-            size="xs"
-            onClick={() => onStop(id)}
-            className="bg-yellow-600 hover:bg-yellow-700"
-          >
+          <Button size="xs" onClick={() => onStop(id)} className="bg-warning hover:bg-warning/80">
             {t('preview.stop')}
           </Button>
           <Button size="xs" onClick={() => onRestart(id)}>
@@ -124,11 +120,11 @@ export function PreviewPanel() {
   };
 
   if (isLoading) {
-    return <div className="p-4 text-gray-500">{t('preview.loadingPreviews')}</div>;
+    return <div className="p-4 text-muted-foreground">{t('preview.loadingPreviews')}</div>;
   }
 
   if (isError) {
-    return <div className="p-4 text-red-500">{t('preview.loadFailed')}</div>;
+    return <div className="p-4 text-destructive">{t('preview.loadFailed')}</div>;
   }
 
   return (
@@ -151,17 +147,17 @@ export function PreviewPanel() {
         <Button
           onClick={handleCreate}
           disabled={!worktreeName.trim() || isCreating}
-          className="bg-indigo-600 hover:bg-indigo-700"
+          className="bg-primary hover:bg-primary/80"
         >
           {t('common.create')}
         </Button>
       </div>
 
-      {error && <div className="text-sm text-red-500">{error}</div>}
+      {error && <div className="text-sm text-destructive">{error}</div>}
 
       {/* Preview list */}
       {previews && previews.length === 0 && (
-        <p className="text-sm text-gray-500">{t('preview.noPreviews')}</p>
+        <p className="text-sm text-muted-foreground">{t('preview.noPreviews')}</p>
       )}
 
       {previews?.map((preview) => (
@@ -176,13 +172,13 @@ export function PreviewPanel() {
                 href={preview.preview_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
+                className="text-xs text-primary hover:underline"
               >
                 {preview.preview_url}
               </a>
             )}
             {preview.status === 'failed' && preview.error_message && (
-              <p className="text-xs text-red-500">{preview.error_message}</p>
+              <p className="text-xs text-destructive">{preview.error_message}</p>
             )}
           </div>
           <PreviewActions

--- a/frontend/src/components/preview/WorktreePanel.tsx
+++ b/frontend/src/components/preview/WorktreePanel.tsx
@@ -52,32 +52,34 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
   };
 
   if (isLoading) {
-    return <p className="text-sm text-gray-500">{t('worktree.loadingWorktrees')}</p>;
+    return <p className="text-sm text-muted-foreground">{t('worktree.loadingWorktrees')}</p>;
   }
 
   if (isError) {
-    return <p className="text-sm text-red-500">{t('worktree.loadFailed')}</p>;
+    return <p className="text-sm text-destructive">{t('worktree.loadFailed')}</p>;
   }
 
   return (
     <div className="space-y-3">
-      {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+      )}
 
       {worktrees && worktrees.length > 0 ? (
         <div className="space-y-1">
           {worktrees.map((wt) => (
             <div
               key={wt.name}
-              className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2"
+              className="flex items-center justify-between rounded-md border border-border px-3 py-2"
             >
               <div className="flex items-center gap-2 text-sm">
-                <span className="font-medium text-gray-900">{wt.name}</span>
-                {wt.branch && <span className="text-gray-500">{wt.branch}</span>}
+                <span className="font-medium text-foreground">{wt.name}</span>
+                {wt.branch && <span className="text-muted-foreground">{wt.branch}</span>}
                 {!wt.is_valid && <Badge variant="destructive">{t('worktree.invalid')}</Badge>}
               </div>
               {deletingName === wt.name ? (
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-red-600">{t('worktree.deleteConfirm')}</span>
+                  <span className="text-xs text-destructive">{t('worktree.deleteConfirm')}</span>
                   <Button
                     variant="outline"
                     size="xs"
@@ -100,7 +102,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
                   variant="outline"
                   size="xs"
                   onClick={() => setDeletingName(wt.name)}
-                  className="border-red-300 text-red-700 hover:bg-red-50"
+                  className="border-destructive/30 text-destructive hover:bg-destructive/10"
                 >
                   {t('common.delete')}
                 </Button>
@@ -109,7 +111,7 @@ export function WorktreePanel({ projectId }: { projectId: string }) {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-gray-500">{t('worktree.noWorktrees')}</p>
+        <p className="text-sm text-muted-foreground">{t('worktree.noWorktrees')}</p>
       )}
 
       <div className="flex gap-2">

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -12,11 +12,11 @@ interface ProjectCardProps {
 export function ProjectCard({ project, onSettings }: ProjectCardProps) {
   const { t } = useTranslation();
   return (
-    <div className="group relative rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
+    <div className="group relative rounded-lg border border-border bg-background p-5 shadow-sm transition-shadow hover:shadow-md">
       <Link to={`/projects/${project.id}`} className="block">
-        <h3 className="text-lg font-semibold text-gray-900">{project.name}</h3>
+        <h3 className="text-lg font-semibold text-foreground">{project.name}</h3>
         {project.description && (
-          <p className="mt-1 line-clamp-2 text-sm text-gray-500">{project.description}</p>
+          <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{project.description}</p>
         )}
       </Link>
       {onSettings && (

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -74,13 +74,13 @@ function MessageItem({
 
   return (
     <div data-testid="message-item" className="flex gap-3 py-2">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-medium text-blue-700">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary">
         {initials}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-900">{message.user_name}</span>
-          <span className="text-xs text-gray-500">{timeAgo(message.created_at, t)}</span>
+          <span className="text-sm font-medium text-foreground">{message.user_name}</span>
+          <span className="text-xs text-muted-foreground">{timeAgo(message.created_at, t)}</span>
           {isOwner && !showDeleteConfirm && (
             <Button
               variant="ghost"
@@ -94,8 +94,8 @@ function MessageItem({
           )}
         </div>
         {showDeleteConfirm ? (
-          <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">{t('chat.deleteMessageConfirm')}</span>
+          <div className="mt-1 flex items-center gap-2 rounded bg-destructive/10 px-2 py-1">
+            <span className="text-xs text-destructive">{t('chat.deleteMessageConfirm')}</span>
             <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
             </Button>
@@ -104,7 +104,7 @@ function MessageItem({
             </Button>
           </div>
         ) : (
-          <p className="mt-0.5 text-sm text-gray-700">{message.content}</p>
+          <p className="mt-0.5 text-sm text-foreground">{message.content}</p>
         )}
       </div>
     </div>
@@ -169,7 +169,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
 
         <div className="flex-1 overflow-y-auto px-4 py-2">
           {isLoading ? (
-            <p className="text-sm text-gray-500">{t('chat.loadingMessages')}</p>
+            <p className="text-sm text-muted-foreground">{t('chat.loadingMessages')}</p>
           ) : displayMessages.length > 0 ? (
             <div className="divide-y">
               {displayMessages.map((m) => (
@@ -182,7 +182,7 @@ function ProjectChatContent({ projectId }: { projectId: string }) {
               ))}
             </div>
           ) : (
-            <p className="py-8 text-center text-sm text-gray-500">{t('chat.noMessages')}</p>
+            <p className="py-8 text-center text-sm text-muted-foreground">{t('chat.noMessages')}</p>
           )}
         </div>
 

--- a/frontend/src/components/project/ProjectCreateDialog.tsx
+++ b/frontend/src/components/project/ProjectCreateDialog.tsx
@@ -63,10 +63,12 @@ function ProjectCreateForm() {
         <DialogHeader>
           <DialogTitle>{t('project.createProject')}</DialogTitle>
         </DialogHeader>
-        {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        {error && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="project-name" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="project-name" className="block text-sm font-medium text-foreground">
               {t('project.name')}
             </label>
             <Input
@@ -80,7 +82,7 @@ function ProjectCreateForm() {
           <div>
             <label
               htmlFor="project-description"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-foreground"
             >
               {t('project.description')}
             </label>
@@ -95,7 +97,7 @@ function ProjectCreateForm() {
           <div>
             <label
               htmlFor="project-repository-path"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-foreground"
             >
               {t('project.repositoryPath')}
             </label>

--- a/frontend/src/components/project/ProjectListPage.tsx
+++ b/frontend/src/components/project/ProjectListPage.tsx
@@ -14,7 +14,7 @@ export function ProjectListPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-gray-500">{t('project.loadingProjects')}</p>
+        <p className="text-muted-foreground">{t('project.loadingProjects')}</p>
       </div>
     );
   }
@@ -22,7 +22,7 @@ export function ProjectListPage() {
   if (isError) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-red-500">{t('project.loadFailed')}</p>
+        <p className="text-destructive">{t('project.loadFailed')}</p>
       </div>
     );
   }
@@ -30,15 +30,15 @@ export function ProjectListPage() {
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-900">{t('project.projects')}</h2>
+        <h2 className="text-xl font-semibold text-foreground">{t('project.projects')}</h2>
         <Button size="sm" onClick={openProjectModal}>
           <FolderPlus className="h-4 w-4" /> {t('project.newProject')}
         </Button>
       </div>
 
       {!projects || projects.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 py-16">
-          <p className="text-gray-500">{t('project.noProjects')}</p>
+        <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-border py-16">
+          <p className="text-muted-foreground">{t('project.noProjects')}</p>
           <Button className="mt-4" onClick={openProjectModal}>
             <FolderPlus className="h-4 w-4" /> {t('project.createFirst')}
           </Button>

--- a/frontend/src/components/project/ProjectMembersPanel.tsx
+++ b/frontend/src/components/project/ProjectMembersPanel.tsx
@@ -125,19 +125,19 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
         </DialogHeader>
 
         {isLoading ? (
-          <p className="text-sm text-gray-500">{t('common.loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
         ) : isError ? (
-          <p className="text-sm text-red-500">{t('members.loadFailed')}</p>
+          <p className="text-sm text-destructive">{t('members.loadFailed')}</p>
         ) : (
           <div className="space-y-3">
             {members?.map((m) => (
               <div
                 key={m.user_id}
-                className="flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2"
+                className="flex items-center gap-3 rounded-md border border-border px-3 py-2"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-gray-900">{m.user_name}</p>
-                  <p className="text-xs text-gray-500">{m.user_email}</p>
+                  <p className="text-sm font-medium text-foreground">{m.user_name}</p>
+                  <p className="text-xs text-muted-foreground">{m.user_email}</p>
                 </div>
 
                 {m.user_id === currentUser?.id || !canManageMember(m.role) ? (
@@ -158,7 +158,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                       onChange={(e) =>
                         handleRoleChange(m.user_id, e.target.value as MemberRoleType)
                       }
-                      className="rounded border border-gray-300 px-1 py-0.5 text-xs"
+                      className="rounded border border-input px-1 py-0.5 text-xs"
                     >
                       <option value="owner">{t('members.role.owner')}</option>
                       <option value="admin">{t('members.role.admin')}</option>
@@ -184,7 +184,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
 
         {canManage && (
           <div className="border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">
+            <h3 className="mb-2 text-sm font-medium text-foreground">
               {t('members.addExistingUser')}
             </h3>
             <div className="relative">
@@ -198,7 +198,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                 placeholder={t('members.searchPlaceholder')}
               />
               {!selectedUser && filteredResults && filteredResults.length > 0 && (
-                <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                <div className="absolute z-10 mt-1 w-full rounded-md border border-border bg-background shadow-lg">
                   {filteredResults.map((u) => (
                     <button
                       key={u.id}
@@ -208,10 +208,10 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
                         setSelectedUser({ id: u.id, name: u.name });
                         setSearchQuery('');
                       }}
-                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50"
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent"
                     >
                       <span className="font-medium">{u.name}</span>
-                      <span className="text-xs text-gray-500">{u.email}</span>
+                      <span className="text-xs text-muted-foreground">{u.email}</span>
                     </button>
                   ))}
                 </div>
@@ -221,7 +221,7 @@ function ProjectMembersContent({ projectId }: { projectId: string }) {
               <select
                 value={inviteRole}
                 onChange={(e) => setInviteRole(e.target.value as MemberRoleType)}
-                className="rounded border border-gray-300 px-2 py-1.5 text-sm"
+                className="rounded border border-input px-2 py-1.5 text-sm"
               >
                 <option value="member">{t('members.role.member')}</option>
                 <option value="admin">{t('members.role.admin')}</option>
@@ -287,12 +287,12 @@ function InvitationSection({ projectId }: { projectId: string }) {
   return (
     <div className="border-t pt-4">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-gray-700">{t('members.invitationLinks')}</h3>
+        <h3 className="text-sm font-medium text-foreground">{t('members.invitationLinks')}</h3>
         <Button
           size="xs"
           onClick={handleCreate}
           disabled={createInvitation.isPending}
-          className="bg-green-600 hover:bg-green-700"
+          className="bg-success hover:bg-success/90"
           data-testid="create-invitation-btn"
         >
           {t('members.createLink')}
@@ -307,13 +307,15 @@ function InvitationSection({ projectId }: { projectId: string }) {
               <div
                 key={inv.id}
                 data-testid="invitation-item"
-                className="flex items-center gap-2 rounded border border-gray-200 px-2 py-1.5"
+                className="flex items-center gap-2 rounded border border-border px-2 py-1.5"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-xs text-gray-600">
+                  <p className="text-xs text-muted-foreground">
                     {inv.role} &middot; by {inv.invited_by_name}
                   </p>
-                  <p className={`text-xs ${isExpired ? 'text-red-500' : 'text-gray-400'}`}>
+                  <p
+                    className={`text-xs ${isExpired ? 'text-destructive' : 'text-muted-foreground'}`}
+                  >
                     {isExpired
                       ? t('members.expired')
                       : t('members.expires', {
@@ -335,7 +337,7 @@ function InvitationSection({ projectId }: { projectId: string }) {
           })}
         </div>
       ) : (
-        <p className="text-xs text-gray-500">{t('members.noPendingInvitations')}</p>
+        <p className="text-xs text-muted-foreground">{t('members.noPendingInvitations')}</p>
       )}
     </div>
   );

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -141,13 +141,13 @@ function ProjectSettingsContent({
         </DialogHeader>
 
         {isLoading ? (
-          <p className="text-sm text-gray-500">{t('common.loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
         ) : isError || !project ? (
-          <p className="text-sm text-red-500">{t('project.loadFailed')}</p>
+          <p className="text-sm text-destructive">{t('project.loadFailed')}</p>
         ) : (
           <div className="space-y-4">
             <div>
-              <h3 className="text-sm font-medium text-gray-700">{t('project.name')}</h3>
+              <h3 className="text-sm font-medium text-foreground">{t('project.name')}</h3>
               {editingField === 'name' ? (
                 <Input
                   type="text"
@@ -160,18 +160,18 @@ function ProjectSettingsContent({
               ) : canEdit ? (
                 <button
                   type="button"
-                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-900 hover:bg-gray-100"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-foreground hover:bg-accent"
                   onClick={() => startEditing('name', project.name)}
                 >
                   {project.name}
                 </button>
               ) : (
-                <p className="mt-1 px-1 text-sm text-gray-900">{project.name}</p>
+                <p className="mt-1 px-1 text-sm text-foreground">{project.name}</p>
               )}
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">{t('project.description')}</h3>
+              <h3 className="text-sm font-medium text-foreground">{t('project.description')}</h3>
               {editingField === 'description' ? (
                 <Textarea
                   value={editValue}
@@ -184,20 +184,20 @@ function ProjectSettingsContent({
               ) : canEdit ? (
                 <button
                   type="button"
-                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-muted-foreground hover:bg-accent"
                   onClick={() => startEditing('description', project.description ?? '')}
                 >
                   {project.description || t('common.noDescription')}
                 </button>
               ) : (
-                <p className="mt-1 px-1 text-sm text-gray-600">
+                <p className="mt-1 px-1 text-sm text-muted-foreground">
                   {project.description || t('common.noDescription')}
                 </p>
               )}
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">{t('project.repositoryPath')}</h3>
+              <h3 className="text-sm font-medium text-foreground">{t('project.repositoryPath')}</h3>
               {editingField === 'repository_path' ? (
                 <Input
                   type="text"
@@ -211,13 +211,13 @@ function ProjectSettingsContent({
               ) : canEdit ? (
                 <button
                   type="button"
-                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-muted-foreground hover:bg-accent"
                   onClick={() => startEditing('repository_path', project.repository_path ?? '')}
                 >
                   {project.repository_path || t('project.notSetGlobal')}
                 </button>
               ) : (
-                <p className="mt-1 px-1 text-sm text-gray-600">
+                <p className="mt-1 px-1 text-sm text-muted-foreground">
                   {project.repository_path || t('project.notSetGlobal')}
                 </p>
               )}
@@ -225,7 +225,7 @@ function ProjectSettingsContent({
 
             {canEdit && (
               <div className="border-t pt-4">
-                <h3 className="text-sm font-medium text-gray-700 mb-2">{t('github.github')}</h3>
+                <h3 className="text-sm font-medium text-foreground mb-2">{t('github.github')}</h3>
                 <GitHubLinkSettings projectId={projectId} />
               </div>
             )}
@@ -233,8 +233,8 @@ function ProjectSettingsContent({
             {isOwner && (
               <div className="border-t pt-4">
                 {showDeleteConfirm ? (
-                  <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
-                    <p className="text-sm text-red-700">{t('project.deleteConfirm')}</p>
+                  <div className="flex items-center justify-between rounded-md bg-destructive/10 p-3">
+                    <p className="text-sm text-destructive">{t('project.deleteConfirm')}</p>
                     <div className="flex gap-2">
                       <Button
                         variant="outline"
@@ -251,7 +251,7 @@ function ProjectSettingsContent({
                 ) : (
                   <Button
                     variant="outline"
-                    className="border-red-300 text-red-700 hover:bg-red-50"
+                    className="border-destructive/30 text-destructive hover:bg-destructive/10"
                     onClick={() => setShowDeleteConfirm(true)}
                   >
                     {t('project.deleteProject')}

--- a/frontend/src/components/task/ActivityFilter.tsx
+++ b/frontend/src/components/task/ActivityFilter.tsx
@@ -11,7 +11,7 @@ export function ActivityFilter({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="inline-flex rounded-md border border-gray-200">
+    <div className="inline-flex rounded-md border border-border">
       <button
         type="button"
         aria-pressed={value === 'all'}
@@ -19,7 +19,9 @@ export function ActivityFilter({
           if (value !== 'all') onChange('all');
         }}
         className={`rounded-l-md px-3 py-1 text-xs font-medium ${
-          value === 'all' ? 'bg-gray-100 text-gray-900' : 'bg-white text-gray-500 hover:bg-gray-50'
+          value === 'all'
+            ? 'bg-muted text-foreground'
+            : 'bg-background text-muted-foreground hover:bg-accent'
         }`}
       >
         {t('activity.filterAll')}
@@ -32,8 +34,8 @@ export function ActivityFilter({
         }}
         className={`rounded-r-md px-3 py-1 text-xs font-medium ${
           value === 'comments'
-            ? 'bg-gray-100 text-gray-900'
-            : 'bg-white text-gray-500 hover:bg-gray-50'
+            ? 'bg-muted text-foreground'
+            : 'bg-background text-muted-foreground hover:bg-accent'
         }`}
       >
         {t('activity.filterComments')}

--- a/frontend/src/components/task/TaskCreateDialog.tsx
+++ b/frontend/src/components/task/TaskCreateDialog.tsx
@@ -82,10 +82,12 @@ function TaskCreateForm({
         <DialogHeader>
           <DialogTitle>{t('task.createTask')}</DialogTitle>
         </DialogHeader>
-        {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+        {error && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="task-title" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="task-title" className="block text-sm font-medium text-foreground">
               {t('task.title')}
             </label>
             <Input
@@ -97,7 +99,7 @@ function TaskCreateForm({
             />
           </div>
           <div>
-            <label htmlFor="task-description" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="task-description" className="block text-sm font-medium text-foreground">
               {t('task.description')}
             </label>
             <Textarea
@@ -110,14 +112,14 @@ function TaskCreateForm({
           </div>
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="task-status" className="block text-sm font-medium text-foreground">
                 {t('task.status')}
               </label>
               <select
                 id="task-status"
                 value={status}
                 onChange={(e) => setStatus(e.target.value as TaskStatus)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
               >
                 <option value={TaskStatus.backlog}>{t('board.status.backlog')}</option>
                 <option value={TaskStatus.todo}>{t('board.status.todo')}</option>
@@ -127,14 +129,14 @@ function TaskCreateForm({
               </select>
             </div>
             <div>
-              <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="task-priority" className="block text-sm font-medium text-foreground">
                 {t('task.priority')}
               </label>
               <select
                 id="task-priority"
                 value={priority}
                 onChange={(e) => setPriority(e.target.value as TaskPriority)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
               >
                 <option value={TaskPriority.low}>{t('board.priorityLabel.low')}</option>
                 <option value={TaskPriority.medium}>{t('board.priorityLabel.medium')}</option>
@@ -143,14 +145,14 @@ function TaskCreateForm({
               </select>
             </div>
             <div>
-              <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="task-assignee" className="block text-sm font-medium text-foreground">
                 {t('board.assignee')}
               </label>
               <select
                 id="task-assignee"
                 value={assignedTo}
                 onChange={(e) => setAssignedTo(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
               >
                 <option value="">{t('common.unassigned')}</option>
                 {members?.map((m) => (

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -121,12 +121,16 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
       >
         <DialogTitle className="sr-only">{t('task.detail')}</DialogTitle>
         {isLoading ? (
-          <p className="text-sm text-gray-500">{t('common.loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
         ) : isError || !task ? (
-          <p className="text-sm text-red-500">{t('task.loadFailed')}</p>
+          <p className="text-sm text-destructive">{t('task.loadFailed')}</p>
         ) : (
           <div className="space-y-4">
-            {error && <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
             <div className="flex items-start justify-between">
               {editingField === 'title' ? (
                 <input
@@ -135,14 +139,14 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
                   onBlur={() => saveField('title')}
-                  className="flex-1 rounded border border-blue-300 px-2 py-1 text-lg font-semibold text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 rounded border border-primary/30 px-2 py-1 text-lg font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                   autoFocus
                 />
               ) : (
                 <button
                   id="task-detail-modal-title"
                   type="button"
-                  className="cursor-pointer rounded px-1 text-left text-lg font-semibold text-gray-900 hover:bg-gray-100"
+                  className="cursor-pointer rounded px-1 text-left text-lg font-semibold text-foreground hover:bg-accent"
                   onClick={() => startEditing('title', task.title)}
                 >
                   {task.title}
@@ -151,20 +155,20 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-gray-700">{t('task.description')}</h3>
+              <h3 className="text-sm font-medium text-foreground">{t('task.description')}</h3>
               {editingField === 'description' ? (
                 <textarea
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
                   onBlur={() => saveField('description')}
                   rows={3}
-                  className="mt-1 block w-full rounded border border-blue-300 px-2 py-1 text-sm text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1 block w-full rounded border border-primary/30 px-2 py-1 text-sm text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                   autoFocus
                 />
               ) : (
                 <button
                   type="button"
-                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                  className="mt-1 cursor-pointer rounded px-1 text-left text-sm text-muted-foreground hover:bg-accent"
                   onClick={() => startEditing('description', task.description ?? '')}
                 >
                   {task.description || t('common.noDescription')}
@@ -176,7 +180,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
               <div>
                 <label
                   htmlFor="task-detail-status"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-foreground"
                 >
                   {t('task.status')}
                 </label>
@@ -184,7 +188,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   id="task-detail-status"
                   value={task.status}
                   onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
                 >
                   <option value="backlog">{t('board.status.backlog')}</option>
                   <option value="todo">{t('board.status.todo')}</option>
@@ -196,7 +200,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
               <div>
                 <label
                   htmlFor="task-detail-priority"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-foreground"
                 >
                   {t('task.priority')}
                 </label>
@@ -204,7 +208,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   id="task-detail-priority"
                   value={task.priority}
                   onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
                 >
                   <option value="low">{t('board.priorityLabel.low')}</option>
                   <option value="medium">{t('board.priorityLabel.medium')}</option>
@@ -215,7 +219,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
               <div>
                 <label
                   htmlFor="task-detail-assignee"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-foreground"
                 >
                   {t('board.assignee')}
                 </label>
@@ -223,7 +227,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                   id="task-detail-assignee"
                   value={task.assigned_to ?? ''}
                   onChange={(e) => handleAssigneeChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
                 >
                   <option value="">{t('common.unassigned')}</option>
                   {members?.map((m) => (
@@ -236,36 +240,38 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('worktree.worktrees')}</h3>
+              <h3 className="text-sm font-medium text-foreground mb-2">
+                {t('worktree.worktrees')}
+              </h3>
               <WorktreePanel projectId={task.project_id} />
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('task.pullRequests')}</h3>
+              <h3 className="text-sm font-medium text-foreground mb-2">{t('task.pullRequests')}</h3>
               <PullRequestList taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">
-              <h3 className="text-sm font-medium text-gray-700 mb-2">{t('activity.title')}</h3>
+              <h3 className="text-sm font-medium text-foreground mb-2">{t('activity.title')}</h3>
               <TaskTimeline taskId={taskId} />
             </div>
 
             <div className="border-t pt-4">
               {showDeleteConfirm ? (
-                <div className="flex items-center justify-between rounded-md bg-red-50 p-3">
-                  <p className="text-sm text-red-700">{t('task.deleteConfirm')}</p>
+                <div className="flex items-center justify-between rounded-md bg-destructive/10 p-3">
+                  <p className="text-sm text-destructive">{t('task.deleteConfirm')}</p>
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() => setShowDeleteConfirm(false)}
-                      className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                      className="rounded-md border border-input px-3 py-1 text-sm text-foreground hover:bg-accent"
                     >
                       {t('common.cancel')}
                     </button>
                     <button
                       type="button"
                       onClick={handleDelete}
-                      className="rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+                      className="rounded-md bg-destructive px-3 py-1 text-sm text-white hover:bg-destructive/80"
                     >
                       {t('common.confirm')}
                     </button>
@@ -275,7 +281,7 @@ function TaskDetailContent({ taskId }: { taskId: string }) {
                 <button
                   type="button"
                   onClick={() => setShowDeleteConfirm(true)}
-                  className="rounded-md border border-red-300 px-4 py-2 text-sm text-red-700 hover:bg-red-50"
+                  className="rounded-md border border-destructive/30 px-4 py-2 text-sm text-destructive hover:bg-destructive/10"
                 >
                   {t('common.delete')}
                 </button>

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -111,7 +111,7 @@ export function TaskDetailPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center p-12">
-        <p className="text-gray-500">{t('task.loadingTask')}</p>
+        <p className="text-muted-foreground">{t('task.loadingTask')}</p>
       </div>
     );
   }
@@ -121,11 +121,11 @@ export function TaskDetailPage() {
       <div className="mx-auto max-w-4xl px-4 py-8">
         <Link
           to={`/projects/${projectId}`}
-          className="mb-4 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" /> {t('task.backToBoard')}
         </Link>
-        <p className="text-red-500">{t('task.loadFailed')}</p>
+        <p className="text-destructive">{t('task.loadFailed')}</p>
       </div>
     );
   }
@@ -134,12 +134,16 @@ export function TaskDetailPage() {
     <div className="mx-auto max-w-4xl px-4 py-8">
       <Link
         to={`/projects/${projectId}`}
-        className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
       >
         <ArrowLeft className="h-4 w-4" /> {t('task.backToBoard')}
       </Link>
 
-      {error && <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {error && (
+        <div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
         {/* Main content */}
@@ -158,7 +162,7 @@ export function TaskDetailPage() {
             ) : (
               <button
                 type="button"
-                className="w-full cursor-pointer rounded px-2 py-1 text-left text-xl font-semibold text-gray-900 hover:bg-gray-100"
+                className="w-full cursor-pointer rounded px-2 py-1 text-left text-xl font-semibold text-foreground hover:bg-accent"
                 onClick={() => startEditing('title', task.title)}
               >
                 {task.title}
@@ -168,7 +172,7 @@ export function TaskDetailPage() {
 
           {/* Description */}
           <div>
-            <h3 className="mb-1 text-sm font-medium text-gray-700">{t('task.description')}</h3>
+            <h3 className="mb-1 text-sm font-medium text-foreground">{t('task.description')}</h3>
             {editingField === 'description' ? (
               <Textarea
                 value={editValue}
@@ -180,7 +184,7 @@ export function TaskDetailPage() {
             ) : (
               <button
                 type="button"
-                className="w-full cursor-pointer rounded px-2 py-1 text-left text-sm text-gray-600 hover:bg-gray-100"
+                className="w-full cursor-pointer rounded px-2 py-1 text-left text-sm text-muted-foreground hover:bg-accent"
                 onClick={() => startEditing('description', task.description ?? '')}
               >
                 {task.description || t('common.noDescription')}
@@ -190,7 +194,7 @@ export function TaskDetailPage() {
 
           {/* Activity */}
           <div className="border-t pt-6">
-            <h3 className="mb-3 text-sm font-medium text-gray-700">{t('activity.title')}</h3>
+            <h3 className="mb-3 text-sm font-medium text-foreground">{t('activity.title')}</h3>
             <TaskTimeline taskId={task.id} />
           </div>
         </div>
@@ -198,14 +202,14 @@ export function TaskDetailPage() {
         {/* Sidebar */}
         <div className="space-y-6">
           <div>
-            <label htmlFor="task-status" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="task-status" className="block text-sm font-medium text-foreground">
               {t('task.status')}
             </label>
             <select
               id="task-status"
               value={task.status}
               onChange={(e) => handleSelectChange('status', e.target.value as TaskStatus)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
             >
               <option value="backlog">{t('board.status.backlog')}</option>
               <option value="todo">{t('board.status.todo')}</option>
@@ -216,14 +220,14 @@ export function TaskDetailPage() {
           </div>
 
           <div>
-            <label htmlFor="task-priority" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="task-priority" className="block text-sm font-medium text-foreground">
               {t('task.priority')}
             </label>
             <select
               id="task-priority"
               value={task.priority}
               onChange={(e) => handleSelectChange('priority', e.target.value as TaskPriority)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
             >
               <option value="low">{t('board.priorityLabel.low')}</option>
               <option value="medium">{t('board.priorityLabel.medium')}</option>
@@ -233,14 +237,14 @@ export function TaskDetailPage() {
           </div>
 
           <div>
-            <label htmlFor="task-assignee" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="task-assignee" className="block text-sm font-medium text-foreground">
               {t('board.assignee')}
             </label>
             <select
               id="task-assignee"
               value={task.assigned_to ?? ''}
               onChange={(e) => handleAssigneeChange(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
             >
               <option value="">{t('common.unassigned')}</option>
               {members?.map((m) => (
@@ -252,19 +256,19 @@ export function TaskDetailPage() {
           </div>
 
           <div className="border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('worktree.worktrees')}</h3>
+            <h3 className="mb-2 text-sm font-medium text-foreground">{t('worktree.worktrees')}</h3>
             <WorktreePanel projectId={projectId ?? ''} />
           </div>
 
           <div className="border-t pt-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-700">{t('task.pullRequests')}</h3>
+            <h3 className="mb-2 text-sm font-medium text-foreground">{t('task.pullRequests')}</h3>
             <PullRequestList taskId={task.id} />
           </div>
 
           <div className="border-t pt-4">
             {showDeleteConfirm ? (
-              <div className="rounded-md bg-red-50 p-3">
-                <p className="mb-2 text-sm text-red-700">{t('task.deleteConfirm')}</p>
+              <div className="rounded-md bg-destructive/10 p-3">
+                <p className="mb-2 text-sm text-destructive">{t('task.deleteConfirm')}</p>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={() => setShowDeleteConfirm(false)}>
                     {t('common.cancel')}
@@ -277,7 +281,7 @@ export function TaskDetailPage() {
             ) : (
               <Button
                 variant="outline"
-                className="w-full border-red-300 text-red-700 hover:bg-red-50"
+                className="w-full border-destructive/30 text-destructive hover:bg-destructive/10"
                 onClick={() => setShowDeleteConfirm(true)}
               >
                 {t('task.deleteTask')}

--- a/frontend/src/components/task/TaskTimeline.tsx
+++ b/frontend/src/components/task/TaskTimeline.tsx
@@ -164,10 +164,10 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
     <div className="space-y-4">
       {/* Active session */}
       {activeSession && !TERMINAL_STATUSES.includes(activeSession.status) && (
-        <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-3">
+        <div className="space-y-2 rounded-md border border-primary/20 bg-primary/10 p-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">
+              <span className="text-sm text-muted-foreground">
                 {AGENT_LABELS[activeSession.agent_type] ?? activeSession.agent_type}
               </span>
               <span
@@ -195,7 +195,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
           const viewingSession = sessions?.find((s) => s.id === viewingSessionId);
           if (!viewingSession) return null;
           return (
-            <div className="space-y-2 rounded-md border border-gray-200 p-3">
+            <div className="space-y-2 rounded-md border border-border p-3">
               <div className="flex items-center gap-2">
                 <Button
                   variant="link"
@@ -207,7 +207,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 >
                   {t('common.back')}
                 </Button>
-                <span className="text-sm text-gray-600">
+                <span className="text-sm text-muted-foreground">
                   {AGENT_LABELS[viewingSession.agent_type] ?? viewingSession.agent_type}
                 </span>
                 <span
@@ -223,15 +223,17 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
 
       {/* Agent start section */}
       {!activeSession && !viewingSessionId && (
-        <div className="space-y-2 rounded-md border border-gray-200 p-3">
+        <div className="space-y-2 rounded-md border border-border p-3">
           {agentError && (
-            <div className="rounded-md bg-red-50 p-2 text-sm text-red-700">{agentError}</div>
+            <div className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">
+              {agentError}
+            </div>
           )}
           <div className="grid grid-cols-2 gap-2">
             <div>
               <label
                 htmlFor="timeline-agent-type"
-                className="block text-sm font-medium text-gray-700"
+                className="block text-sm font-medium text-foreground"
               >
                 {t('agent.agentType')}
               </label>
@@ -239,7 +241,7 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
                 id="timeline-agent-type"
                 value={agentType}
                 onChange={(e) => setAgentType(e.target.value as AgentType)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                className="mt-1 block w-full rounded-md border border-input px-3 py-2 text-sm"
               >
                 <option value="claude_code">{t('agent.claudeCode')}</option>
                 <option value="gemini_cli">{t('agent.geminiCli')}</option>
@@ -292,9 +294,9 @@ export function TaskTimeline({ taskId }: { taskId: string }) {
 
       {/* Timeline */}
       {isLoading ? (
-        <p className="text-sm text-gray-500">{t('activity.loadingActivity')}</p>
+        <p className="text-sm text-muted-foreground">{t('activity.loadingActivity')}</p>
       ) : timeline.length === 0 ? (
-        <p className="text-sm text-gray-500">{t('activity.noActivity')}</p>
+        <p className="text-sm text-muted-foreground">{t('activity.noActivity')}</p>
       ) : (
         <div className="divide-y">
           {timeline.map((item) =>

--- a/frontend/src/components/task/TimelineAgentSessionItem.tsx
+++ b/frontend/src/components/task/TimelineAgentSessionItem.tsx
@@ -12,14 +12,14 @@ export function TimelineAgentSessionItem({
     <button
       type="button"
       data-testid="timeline-session"
-      className="flex w-full items-center gap-3 rounded-md bg-gray-50 px-3 py-2 text-left hover:bg-gray-100"
+      className="flex w-full items-center gap-3 rounded-md bg-muted px-3 py-2 text-left hover:bg-accent"
       onClick={() => onView(session)}
     >
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-purple-100 text-xs font-medium text-purple-800">
         AI
       </div>
       <div className="flex flex-1 items-center gap-2">
-        <span className="text-sm font-medium text-gray-900">
+        <span className="text-sm font-medium text-foreground">
           {AGENT_LABELS[session.agent_type] ?? session.agent_type}
         </span>
         <span
@@ -27,7 +27,7 @@ export function TimelineAgentSessionItem({
         >
           {session.status}
         </span>
-        <span className="text-xs text-gray-500">{timeAgo(session.created_at)}</span>
+        <span className="text-xs text-muted-foreground">{timeAgo(session.created_at)}</span>
       </div>
     </button>
   );

--- a/frontend/src/components/task/TimelineCommentItem.tsx
+++ b/frontend/src/components/task/TimelineCommentItem.tsx
@@ -62,13 +62,13 @@ export function TimelineCommentItem({
 
   return (
     <div data-testid="timeline-comment" className="flex gap-3 py-2">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
         {getInitials(comment.user_name)}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-900">{comment.user_name}</span>
-          <span className="text-xs text-gray-500">{timeAgo(comment.created_at)}</span>
+          <span className="text-sm font-medium text-foreground">{comment.user_name}</span>
+          <span className="text-xs text-muted-foreground">{timeAgo(comment.created_at)}</span>
           {isOwner && !editing && !showDeleteConfirm && (
             <div className="ml-auto flex gap-1">
               <Button
@@ -113,8 +113,8 @@ export function TimelineCommentItem({
             </div>
           </div>
         ) : showDeleteConfirm ? (
-          <div className="mt-1 flex items-center gap-2 rounded bg-red-50 px-2 py-1">
-            <span className="text-xs text-red-700">{t('activity.deleteCommentConfirm')}</span>
+          <div className="mt-1 flex items-center gap-2 rounded bg-destructive/10 px-2 py-1">
+            <span className="text-xs text-destructive">{t('activity.deleteCommentConfirm')}</span>
             <Button variant="destructive" size="xs" onClick={handleDelete}>
               {t('common.confirm')}
             </Button>
@@ -123,7 +123,7 @@ export function TimelineCommentItem({
             </Button>
           </div>
         ) : (
-          <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
+          <p className="mt-0.5 text-sm text-foreground">{comment.content}</p>
         )}
       </div>
     </div>

--- a/frontend/src/components/task/timelineUtils.ts
+++ b/frontend/src/components/task/timelineUtils.ts
@@ -21,12 +21,12 @@ export function mergeTimeline(comments: TaskComment[], sessions: AgentSession[])
 }
 
 export const STATUS_COLORS: Record<AgentSessionStatus, string> = {
-  pending: 'bg-yellow-100 text-yellow-800',
-  running: 'bg-blue-100 text-blue-800',
+  pending: 'bg-warning/15 text-warning',
+  running: 'bg-primary/15 text-primary',
   paused: 'bg-purple-100 text-purple-800',
-  completed: 'bg-green-100 text-green-800',
-  failed: 'bg-red-100 text-red-800',
-  cancelled: 'bg-gray-100 text-gray-800',
+  completed: 'bg-success/15 text-success',
+  failed: 'bg-destructive/15 text-destructive',
+  cancelled: 'bg-muted text-muted-foreground',
 };
 
 export const AGENT_LABELS: Record<AgentType, string> = {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -27,6 +27,8 @@
     --color-accent: var(--accent);
     --color-accent-foreground: var(--accent-foreground);
     --color-destructive: var(--destructive);
+    --color-success: var(--success);
+    --color-warning: var(--warning);
     --color-border: var(--border);
     --color-input: var(--input);
     --color-ring: var(--ring);
@@ -62,6 +64,8 @@
     --accent: oklch(0.97 0 0);
     --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.577 0.245 27.325);
+    --success: oklch(0.5 0.15 155);
+    --warning: oklch(0.68 0.16 80);
     --border: oklch(0.922 0 0);
     --input: oklch(0.922 0 0);
     --ring: oklch(0.623 0.214 259.127);
@@ -96,6 +100,8 @@
     --accent: oklch(0.269 0 0);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
+    --success: oklch(0.65 0.15 155);
+    --warning: oklch(0.75 0.16 80);
     --border: oklch(1 0 0 / 10%);
     --input: oklch(1 0 0 / 15%);
     --ring: oklch(0.546 0.245 262.881);


### PR DESCRIPTION
## Summary
- Add `--success` and `--warning` CSS custom properties (OKLCH, light + dark) to `index.css`
- Replace all hardcoded Tailwind color classes (`bg-gray-*`, `text-red-*`, `bg-blue-*`, etc.) with semantic CSS variable-based tokens across 35 component files
- Update 3 test files to assert new semantic class names
- Keep intentional categorical colors (purple for `in_review` status, merged PRs, AI avatars) and terminal styling (`bg-gray-900 text-green-400`)

### Color mapping applied
| Hardcoded | Semantic |
|-----------|----------|
| `text-gray-900/700` | `text-foreground` |
| `text-gray-600/500/400` | `text-muted-foreground` |
| `bg-gray-100/50` | `bg-muted` / `bg-background` |
| `hover:bg-gray-*` | `hover:bg-accent` |
| `border-gray-200` | `border-border` |
| `border-gray-300` | `border-input` |
| `text-red-*` | `text-destructive` |
| `bg-red-50` | `bg-destructive/10` |
| `text-blue-*` | `text-primary` |
| `bg-blue-50/100` | `bg-primary/10` |
| `text-green-*` | `text-success` |
| `bg-green-*` | `bg-success` / `bg-success/15` |
| `text-yellow-*` | `text-warning` |
| `bg-yellow-*` | `bg-warning` / `bg-warning/15` |

Closes #320

## Test plan
- [x] All 385 frontend tests pass
- [x] All 588 backend tests pass
- [x] `task check` passes (fmt + lint + build + test)
- [ ] Visual regression: verify light mode appearance unchanged
- [ ] Visual regression: verify dark mode tokens resolve correctly