### PR TITLE
fix: 🔒️ security hardening (#331-#349)

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -100,9 +100,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER gantry
 
-EXPOSE 80 3000
+EXPOSE 8080 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=10s \
-    CMD curl -f http://localhost:3000/health && curl -f http://localhost/ || exit 1
+    CMD curl -f http://localhost:3000/health && curl -f http://localhost:8080/ || exit 1
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/backend/migrations/20260227000001_add_is_admin_to_users.sql
+++ b/backend/migrations/20260227000001_add_is_admin_to_users.sql
@@ -1,0 +1,8 @@
+-- Add admin flag to users table.
+-- The first registered user is retroactively promoted to admin.
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Promote the earliest-registered user to admin
+UPDATE users
+SET is_admin = TRUE
+WHERE id = (SELECT id FROM users ORDER BY created_at ASC LIMIT 1);

--- a/backend/src/agent/executor.rs
+++ b/backend/src/agent/executor.rs
@@ -77,6 +77,19 @@ pub fn validate_config(config: &AgentConfig) -> AppResult<()> {
     Ok(())
 }
 
+/// Strip dangerous control characters from a prompt string.
+///
+/// Allows `\t` (0x09), `\n` (0x0a), and `\r` (0x0d) which are normal
+/// whitespace, but removes all other C0 control characters (0x00–0x08,
+/// 0x0b, 0x0c, 0x0e–0x1f) that could interfere with terminal handling
+/// or subprocess I/O.
+pub fn sanitize_prompt(input: &str) -> String {
+    input
+        .chars()
+        .filter(|c| !c.is_control() || matches!(*c, '\t' | '\n' | '\r'))
+        .collect()
+}
+
 /// Trait for agent execution backends.
 #[async_trait::async_trait]
 pub trait AgentExecutor: Send + Sync {
@@ -131,9 +144,10 @@ where
         .spawn()
         .map_err(|e| AppError::Internal(format!("failed to spawn {agent_name} CLI: {e}")))?;
 
-    // Write prompt to stdin and close it so the CLI starts processing.
+    // Sanitize and write prompt to stdin, then close it so the CLI starts processing.
+    let sanitized_prompt = sanitize_prompt(prompt);
     if let Some(mut stdin) = child.stdin.take() {
-        if let Err(e) = stdin.write_all(prompt.as_bytes()).await {
+        if let Err(e) = stdin.write_all(sanitized_prompt.as_bytes()).await {
             let _ = child.kill().await;
             let _ = child.wait().await; // reap to avoid zombie
             return Err(AppError::Internal(format!(
@@ -301,5 +315,27 @@ mod tests {
     fn test_validate_accepts_existing_directory() {
         let config = make_config(std::env::temp_dir(), vec![]);
         assert!(validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_sanitize_prompt_preserves_normal_text() {
+        assert_eq!(sanitize_prompt("Hello, world!"), "Hello, world!");
+    }
+
+    #[test]
+    fn test_sanitize_prompt_preserves_tabs_newlines() {
+        let input = "line1\n\tindented\r\nline3";
+        assert_eq!(sanitize_prompt(input), input);
+    }
+
+    #[test]
+    fn test_sanitize_prompt_removes_null_bytes() {
+        assert_eq!(sanitize_prompt("hello\x00world"), "helloworld");
+    }
+
+    #[test]
+    fn test_sanitize_prompt_removes_control_chars() {
+        // \x01 (SOH), \x08 (BS), \x0b (VT), \x1f (US) should be removed
+        assert_eq!(sanitize_prompt("a\x01b\x08c\x0bd\x1fe"), "abcde");
     }
 }

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -4,7 +4,7 @@ use axum_extra::extract::CookieJar;
 use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::services::session_service;
+use crate::services::{session_service, user_service};
 use crate::AppState;
 
 pub const SESSION_COOKIE_NAME: &str = "gantry_session";
@@ -68,6 +68,34 @@ impl FromRequestParts<AppState> for AuthUser {
         Ok(AuthUser {
             user_id,
             session_id,
+        })
+    }
+}
+
+/// Authenticated admin user — rejects non-admin users with 403 Forbidden.
+#[derive(Debug, Clone)]
+pub struct AdminUser {
+    pub user_id: Uuid,
+    pub session_id: Uuid,
+}
+
+impl FromRequestParts<AppState> for AdminUser {
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let auth_user = AuthUser::from_request_parts(parts, state).await?;
+
+        let user = user_service::get_user(&state.pool, auth_user.user_id).await?;
+        if !user.is_admin {
+            return Err(AppError::Forbidden("admin access required".to_string()));
+        }
+
+        Ok(AdminUser {
+            user_id: auth_user.user_id,
+            session_id: auth_user.session_id,
         })
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -148,6 +148,11 @@ pub struct Config {
     /// Audit log retention period in days (default: 90)
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u64,
+
+    /// Base URL for invitation links (e.g. "https://gantry.example.com").
+    /// Falls back to `cors_origin` if not set.
+    #[serde(default)]
+    pub invite_base_url: Option<String>,
 }
 
 fn default_bind_addr() -> String {
@@ -340,7 +345,10 @@ impl Config {
                     "backup_retention_count must be >= 1 to avoid deleting all backups".to_string(),
                 ));
             }
-            if self.backup_dir.contains("..") {
+            if std::path::Path::new(&self.backup_dir)
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
                 return Err(ConfigError::RateLimiter(
                     "backup_dir must not contain '..' path traversal sequences".to_string(),
                 ));
@@ -407,6 +415,7 @@ impl Default for Config {
             general_rate_limit_per_second: default_general_rate_limit_per_second(),
             general_rate_limit_burst: default_general_rate_limit_burst(),
             audit_retention_days: default_audit_retention_days(),
+            invite_base_url: None,
         }
     }
 }

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::auth::middleware::AuthUser;
+use crate::auth::middleware::AdminUser;
 use crate::error::AppError;
 use crate::services::audit_service;
 use crate::AppState;
@@ -28,7 +28,7 @@ pub struct AdminStatusResponse {
 }
 
 pub async fn admin_status(
-    _user: AuthUser,
+    _admin: AdminUser,
     State(state): State<AppState>,
 ) -> Result<Json<AdminStatusResponse>, AppError> {
     let pool_size = state.pool.size();
@@ -82,7 +82,7 @@ pub struct AuditLogQuery {
 }
 
 pub async fn audit_log(
-    _user: AuthUser,
+    _admin: AdminUser,
     State(state): State<AppState>,
     Query(params): Query<AuditLogQuery>,
 ) -> Result<(StatusCode, Json<audit_service::AuditLogResponse>), AppError> {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1,5 +1,5 @@
 use axum::extract::State;
-use axum::http::{header, StatusCode};
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::Json;
 use garde::Validate;
@@ -9,6 +9,31 @@ use crate::error::{AppError, AppResult};
 use crate::models::user::{AuthResponse, LoginRequest, RegisterRequest, User};
 use crate::services::{audit_service, session_service, user_service};
 use crate::AppState;
+
+/// Extract client IP from X-Forwarded-For or X-Real-IP headers.
+fn extract_client_ip(headers: &HeaderMap) -> Option<String> {
+    // X-Forwarded-For: client, proxy1, proxy2 — take the first (leftmost) entry
+    if let Some(xff) = headers.get("x-forwarded-for") {
+        if let Ok(val) = xff.to_str() {
+            if let Some(first) = val.split(',').next() {
+                let ip = first.trim();
+                if !ip.is_empty() {
+                    return Some(ip.to_string());
+                }
+            }
+        }
+    }
+    // Fallback to X-Real-IP
+    if let Some(xri) = headers.get("x-real-ip") {
+        if let Ok(val) = xri.to_str() {
+            let ip = val.trim();
+            if !ip.is_empty() {
+                return Some(ip.to_string());
+            }
+        }
+    }
+    None
+}
 
 #[utoipa::path(
     post,
@@ -23,6 +48,7 @@ use crate::AppState;
 )]
 pub async fn register(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<RegisterRequest>,
 ) -> AppResult<impl IntoResponse> {
     let ctx = body.password_context();
@@ -57,6 +83,7 @@ pub async fn register(
 
     let response = AuthResponse { user };
 
+    let client_ip = extract_client_ip(&headers);
     audit_service::log_event(
         state.pool.clone(),
         "auth.register",
@@ -64,7 +91,7 @@ pub async fn register(
         Some("user"),
         Some(&response.user.id.to_string()),
         None,
-        None,
+        client_ip.as_deref(),
     );
 
     Ok((
@@ -86,6 +113,7 @@ pub async fn register(
 )]
 pub async fn login(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<LoginRequest>,
 ) -> AppResult<impl IntoResponse> {
     body.validate()
@@ -111,6 +139,7 @@ pub async fn login(
 
     let response = AuthResponse { user };
 
+    let client_ip = extract_client_ip(&headers);
     audit_service::log_event(
         state.pool.clone(),
         "auth.login",
@@ -118,7 +147,7 @@ pub async fn login(
         Some("user"),
         Some(&response.user.id.to_string()),
         None,
-        None,
+        client_ip.as_deref(),
     );
 
     Ok((

--- a/backend/src/handlers/invitations.rs
+++ b/backend/src/handlers/invitations.rs
@@ -41,8 +41,9 @@ pub async fn create_invitation(
 
     let base_url = state
         .config
-        .cors_origin
+        .invite_base_url
         .as_deref()
+        .or(state.config.cors_origin.as_deref())
         .unwrap_or("http://localhost:5173");
     let invite_url = format!("{}/invite/{}", base_url, token);
 

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -35,6 +35,11 @@ pub async fn search_users(
     Query(params): Query<SearchUsersQuery>,
 ) -> AppResult<Json<Vec<User>>> {
     let query = params.q.as_deref().unwrap_or("");
+    if query.len() > 200 {
+        return Err(crate::error::AppError::Validation(
+            "search query must not exceed 200 characters".to_string(),
+        ));
+    }
     let limit = params.limit.clamp(1, 100);
     let users = user_service::search_users(&state.pool, query, limit).await?;
     Ok(Json(users))

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -8,9 +8,9 @@ pub mod handlers;
 pub mod models;
 pub mod observability;
 pub mod openapi;
+pub mod realtime;
 pub mod repositories;
 pub mod services;
-pub mod sse;
 #[cfg(test)]
 pub mod test_helpers;
 
@@ -35,9 +35,9 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::agent::orchestrator::AgentOrchestrator;
 use crate::github::api::GitHubApi;
+use crate::realtime::hub::SseHub;
 use crate::services::agent_session_output_service::OutputBuffer;
 use crate::services::preview_service::PreviewManager;
-use crate::sse::hub::SseHub;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -317,12 +317,12 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
         // SSE route: no timeout (long-lived streaming), own rate limit only
         .merge(Router::new().route(
             "/events",
-            get(sse::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
+            get(realtime::handler::sse_handler).layer(GovernorLayer::new(sse_governor)),
         ))
         // WebSocket route: no timeout (long-lived), own rate limit only
         .merge(Router::new().route(
             "/ws",
-            get(sse::ws_handler::ws_handler).layer(GovernorLayer::new(ws_governor)),
+            get(realtime::ws_handler::ws_handler).layer(GovernorLayer::new(ws_governor)),
         ));
 
     let metric_handle = init_metrics();
@@ -333,26 +333,34 @@ pub fn app(state: AppState) -> Result<Router, config::ConfigError> {
     // (must happen after recorder setup is fully complete)
     observability::init_metrics();
 
-    Ok(Router::new()
-        .route("/health", get(handlers::health::health_check))
-        .route("/health/live", get(handlers::health::liveness))
-        .route("/health/ready", get(handlers::health::readiness))
-        .route(
-            "/metrics",
-            get(move || async move { metric_handle.render() }),
-        )
-        .nest("/api", api_routes)
-        // Webhook route: no auth/CSRF, body limit 25MB
-        .route(
-            "/api/webhooks/github",
-            post(handlers::webhooks::github_webhook)
-                .layer(axum::extract::DefaultBodyLimit::max(25 * 1024 * 1024)),
-        )
-        // Default body size limit: 2 MB (webhook keeps its own 25 MB limit above)
-        .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
-        .merge(
-            SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
-        )
+    let router =
+        Router::new()
+            .route("/health", get(handlers::health::health_check))
+            .route("/health/live", get(handlers::health::liveness))
+            .route("/health/ready", get(handlers::health::readiness))
+            .route(
+                "/metrics",
+                get(move |_user: crate::auth::middleware::AuthUser| async move {
+                    metric_handle.render()
+                }),
+            )
+            .nest("/api", api_routes)
+            // Webhook route: no auth/CSRF, body limit 25MB
+            .route(
+                "/api/webhooks/github",
+                post(handlers::webhooks::github_webhook)
+                    .layer(axum::extract::DefaultBodyLimit::max(25 * 1024 * 1024)),
+            )
+            // Default body size limit: 2 MB (webhook keeps its own 25 MB limit above)
+            .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024));
+
+    // Swagger UI is only available in debug builds (development)
+    #[cfg(debug_assertions)]
+    let router = router.merge(
+        SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi::ApiDoc::openapi()),
+    );
+
+    Ok(router
         .layer(axum::middleware::from_fn(
             error::inject_request_id_into_errors,
         ))

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -9,6 +9,7 @@ pub struct User {
     pub id: Uuid,
     pub name: String,
     pub email: String,
+    pub is_admin: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -20,6 +21,7 @@ pub struct UserWithPassword {
     pub name: String,
     pub email: String,
     pub password_hash: String,
+    pub is_admin: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -32,6 +34,7 @@ impl TryFrom<UserWithPassword> for User {
             id: row.id.parse()?,
             name: row.name,
             email: row.email,
+            is_admin: row.is_admin,
             created_at: row.created_at,
             updated_at: row.updated_at,
         })

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use sqlx::SqlitePool;
@@ -42,6 +42,9 @@ pub async fn create_backup(pool: &SqlitePool, backup_dir: &Path) -> AppResult<Pa
         })?
         .to_string();
 
+    // Validate the resolved path contains no traversal or unexpected characters
+    validate_backup_path(&path_str)?;
+
     sqlx::query(&format!("VACUUM INTO '{}'", path_str.replace('\'', "''")))
         .execute(pool)
         .await?;
@@ -59,6 +62,33 @@ pub async fn create_backup(pool: &SqlitePool, backup_dir: &Path) -> AppResult<Pa
     );
 
     Ok(backup_path)
+}
+
+/// Validate that a backup path contains only safe characters and no traversal components.
+fn validate_backup_path(path_str: &str) -> AppResult<()> {
+    let path = Path::new(path_str);
+
+    // Reject any parent-dir components (e.g. ".." in any form)
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            return Err(crate::error::AppError::Validation(
+                "backup path must not contain '..' traversal".to_string(),
+            ));
+        }
+    }
+
+    // Allow only alphanumeric, slashes, hyphens, underscores, dots, and colons
+    // (colon for Windows drive letters, dot for file extensions)
+    if !path_str
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '/' | '-' | '_' | '.' | ':' | '\\'))
+    {
+        return Err(crate::error::AppError::Validation(
+            "backup path contains invalid characters".to_string(),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Rotate backup files, keeping only `retention_count` most recent.

--- a/backend/src/services/invitation_service.rs
+++ b/backend/src/services/invitation_service.rs
@@ -12,13 +12,21 @@ const TOKEN_BYTES: usize = 32; // 256-bit
 const EXPIRY_HOURS: i64 = 72;
 
 /// Generate a cryptographically random token (hex-encoded).
+///
+/// Uses `OsRng` directly for cryptographic randomness, avoiding the
+/// reseeding overhead of `thread_rng()`.
 pub fn generate_token() -> String {
     let mut bytes = [0u8; TOKEN_BYTES];
-    rand::thread_rng().fill(&mut bytes);
+    rand::rngs::OsRng.fill(&mut bytes);
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Hash a token with SHA-256 for DB storage.
+///
+/// Unsalted SHA-256 is safe here because the input token has 256 bits of
+/// entropy (from `generate_token`), making brute-force and rainbow-table
+/// attacks infeasible. HMAC would add no practical security benefit for
+/// high-entropy random tokens.
 pub fn hash_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
@@ -291,4 +299,186 @@ pub async fn accept_invitation(
     tx.commit().await?;
 
     get_invitation(pool, invitation.id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::user::RegisterRequest;
+    use crate::services::{project_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn setup_project_and_user(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let user = user_service::create_user(
+            pool,
+            &RegisterRequest {
+                email: "inviter@test.com".to_string(),
+                name: "Inviter".to_string(),
+                password: "password123".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        (project.id, user.id)
+    }
+
+    #[test]
+    fn test_generate_token_returns_64_hex_chars() {
+        let token = generate_token();
+        assert_eq!(token.len(), 64); // 32 bytes * 2 hex chars
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_generate_token_is_unique() {
+        let t1 = generate_token();
+        let t2 = generate_token();
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn test_hash_token_is_deterministic() {
+        let token = "abc123";
+        assert_eq!(hash_token(token), hash_token(token));
+    }
+
+    #[test]
+    fn test_hash_token_differs_for_different_input() {
+        assert_ne!(hash_token("token_a"), hash_token("token_b"));
+    }
+
+    #[tokio::test]
+    async fn test_create_invitation_succeeds() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let (invitation, token) = create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+
+        assert_eq!(invitation.project_id, project_id);
+        assert_eq!(invitation.invited_by, user_id);
+        assert!(!token.is_empty());
+        assert!(invitation.expires_at > Utc::now());
+        assert!(invitation.accepted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_invitation_by_token_returns_info() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let (_, token) = create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+
+        let info = get_invitation_by_token(&pool, &token).await.unwrap();
+        assert_eq!(info.project_name, "Test Project");
+        assert!(!info.expired);
+        assert!(!info.accepted);
+    }
+
+    #[tokio::test]
+    async fn test_get_invitation_by_invalid_token_fails() {
+        let pool = setup_test_db().await;
+
+        let result = get_invitation_by_token(&pool, "nonexistent_token").await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_list_invitations_returns_all() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+        create_invitation(&pool, project_id, user_id, MemberRole::Admin)
+            .await
+            .unwrap();
+
+        let list = list_invitations(&pool, project_id).await.unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_invitation_succeeds() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let (invitation, _) = create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+
+        delete_invitation(&pool, project_id, invitation.id)
+            .await
+            .unwrap();
+
+        let list = list_invitations(&pool, project_id).await.unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_accept_invitation_adds_member() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let acceptor = user_service::create_user(
+            &pool,
+            &RegisterRequest {
+                email: "acceptor@test.com".to_string(),
+                name: "Acceptor".to_string(),
+                password: "password123".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (_, token) = create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+
+        let accepted = accept_invitation(&pool, &token, acceptor.id).await.unwrap();
+        assert!(accepted.accepted_at.is_some());
+        assert_eq!(accepted.accepted_by, Some(acceptor.id));
+    }
+
+    #[tokio::test]
+    async fn test_accept_invitation_twice_fails() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let acceptor = user_service::create_user(
+            &pool,
+            &RegisterRequest {
+                email: "acceptor2@test.com".to_string(),
+                name: "Acceptor2".to_string(),
+                password: "password123".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let (_, token) = create_invitation(&pool, project_id, user_id, MemberRole::Member)
+            .await
+            .unwrap();
+
+        accept_invitation(&pool, &token, acceptor.id).await.unwrap();
+        let result = accept_invitation(&pool, &token, acceptor.id).await;
+        assert!(matches!(result, Err(AppError::Conflict(_))));
+    }
 }

--- a/backend/src/services/user_service.rs
+++ b/backend/src/services/user_service.rs
@@ -4,57 +4,36 @@ use uuid::Uuid;
 
 use crate::auth::password::{hash_password, verify_password};
 use crate::error::{AppError, AppResult};
-use crate::models::user::{RegisterRequest, User, UserWithPassword};
+use crate::models::user::{RegisterRequest, User};
+use crate::repositories::user_repository;
 
-/// Row type for queries that don't include password_hash.
-#[derive(sqlx::FromRow)]
-struct UserRow {
-    id: String,
-    name: String,
-    email: String,
-    created_at: chrono::DateTime<chrono::Utc>,
-    updated_at: chrono::DateTime<chrono::Utc>,
-}
-
-impl TryFrom<UserRow> for User {
-    type Error = uuid::Error;
-
-    fn try_from(row: UserRow) -> Result<Self, Self::Error> {
-        Ok(User {
-            id: row.id.parse()?,
-            name: row.name,
-            email: row.email,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
-
-/// Create a new user with hashed password
+/// Create a new user with hashed password.
+/// The first registered user is automatically promoted to admin.
 pub async fn create_user(pool: &SqlitePool, req: &RegisterRequest) -> AppResult<User> {
     let id = Uuid::new_v4();
     let now = Utc::now();
     let password_hash = hash_password(&req.password)?;
 
-    sqlx::query(
-        r#"
-        INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+    // First user becomes admin automatically
+    let user_count = user_repository::count(pool).await?;
+    let is_admin = user_count == 0;
+
+    user_repository::insert(
+        pool,
+        id,
+        &req.email,
+        &req.name,
+        &password_hash,
+        is_admin,
+        now,
     )
-    .bind(id.to_string())
-    .bind(&req.email)
-    .bind(&req.name)
-    .bind(&password_hash)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
     .await?;
 
     Ok(User {
         id,
         name: req.name.clone(),
         email: req.email.clone(),
+        is_admin,
         created_at: now,
         updated_at: now,
     })
@@ -62,16 +41,7 @@ pub async fn create_user(pool: &SqlitePool, req: &RegisterRequest) -> AppResult<
 
 /// Get user by ID
 pub async fn get_user(pool: &SqlitePool, id: Uuid) -> AppResult<User> {
-    let row = sqlx::query_as::<_, UserWithPassword>(
-        r#"
-        SELECT id, email, name, password_hash, created_at, updated_at
-        FROM users
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .fetch_optional(pool)
-    .await?;
+    let row = user_repository::find_by_id(pool, id).await?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -81,16 +51,7 @@ pub async fn get_user(pool: &SqlitePool, id: Uuid) -> AppResult<User> {
 
 /// Get user by email
 pub async fn get_user_by_email(pool: &SqlitePool, email: &str) -> AppResult<User> {
-    let row = sqlx::query_as::<_, UserWithPassword>(
-        r#"
-        SELECT id, email, name, password_hash, created_at, updated_at
-        FROM users
-        WHERE email = $1
-        "#,
-    )
-    .bind(email)
-    .fetch_optional(pool)
-    .await?;
+    let row = user_repository::find_by_email(pool, email).await?;
 
     row.map(|r| r.try_into())
         .transpose()
@@ -100,42 +61,15 @@ pub async fn get_user_by_email(pool: &SqlitePool, email: &str) -> AppResult<User
 
 /// Search users by name or email (LIKE match)
 pub async fn search_users(pool: &SqlitePool, query: &str, limit: i64) -> AppResult<Vec<User>> {
-    let pattern = format!("%{query}%");
-    let rows = sqlx::query_as::<_, UserRow>(
-        r#"
-        SELECT id, name, email, created_at, updated_at
-        FROM users
-        WHERE name LIKE $1 OR email LIKE $1
-        ORDER BY name ASC
-        LIMIT $2
-        "#,
-    )
-    .bind(&pattern)
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<User>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    user_repository::search(pool, query, limit).await
 }
 
 /// Authenticate user by email and password
 /// Returns user if credentials are valid, InvalidCredentials error otherwise
 pub async fn authenticate_user(pool: &SqlitePool, email: &str, password: &str) -> AppResult<User> {
-    let row = sqlx::query_as::<_, UserWithPassword>(
-        r#"
-        SELECT id, email, name, password_hash, created_at, updated_at
-        FROM users
-        WHERE email = $1
-        "#,
-    )
-    .bind(email)
-    .fetch_optional(pool)
-    .await?;
-
-    let user_with_password = row.ok_or(AppError::InvalidCredentials)?;
+    let user_with_password = user_repository::find_by_email(pool, email)
+        .await?
+        .ok_or(AppError::InvalidCredentials)?;
 
     if !verify_password(password, &user_with_password.password_hash)? {
         return Err(AppError::InvalidCredentials);

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.prod
     ports:
-      - "${GANTRY_PORT:-80}:80"
+      - "${GANTRY_PORT:-80}:8080"
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -17,7 +17,7 @@ RUN apk add --no-cache wget
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD wget -q --spider http://localhost/health || exit 1
+    CMD wget -q --spider http://localhost:8080/health || exit 1

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,8 +1,15 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'none'" always;
 
     # Gzip compression
     gzip on;


### PR DESCRIPTION
## Summary
- Add admin role system with first-user auto-promotion and `AdminUser` extractor (#345)
- Gate `/metrics` endpoint with auth and SwaggerUI with `#[cfg(debug_assertions)]` (#337, #341)
- Use `OsRng` for invitation token generation and document `hash_token` safety (#338, #347)
- Add strict path validation for backup paths and config traversal prevention (#344)
- Add nginx security headers (CSP, X-Frame-Options, etc.) and switch to non-privileged port 8080 (#348, #342)
- Extract client IP from `X-Forwarded-For` / `X-Real-IP` for audit logging (#340)
- Use `invite_base_url` config for invitation link generation (#336)
- Escape LIKE metacharacters in user search and limit query length to 200 chars (#335, #339)
- Sanitize agent prompts by stripping C0 control characters (#331, #332)

## Closes
#331, #332, #335, #336, #337, #338, #339, #340, #341, #342, #344, #345, #347, #348, #349

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All existing + new unit tests pass
- [ ] Verify admin endpoints require admin role
- [ ] Verify `/metrics` requires authentication
- [ ] Verify nginx security headers are present in production build