### PR TITLE
chore: 🔧 fix env var names and clean up Docker/config (#329, #333, #334, #346)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@ Thumbs.db
 
 # Serena
 .serena/
-target

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,3 +1,6 @@
+# Backend-only production image (used by docker-compose.prod.yml).
+# For the all-in-one image (backend + frontend + nginx), see the root Dockerfile.prod.
+
 # Stage 1: Build
 FROM rust:1.85-slim-bookworm AS builder
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - GANTRY_BIND_ADDR=0.0.0.0:3000
       - GANTRY_DATABASE_URL=sqlite:/workspace/backend/data/gantry_board.db?mode=rwc
       - GANTRY_CORS_ORIGIN=http://localhost:3000
-      - GANTRY_COOKIE_SECURE=false
+      - GANTRY_COOKIE_SECURE=false  # DEV ONLY — set to true in production
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s
@@ -33,7 +33,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=http://localhost:3001
+      - VITE_API_BASE_URL=http://localhost:3001
     depends_on:
       backend:
         condition: service_healthy

--- a/process-compose.yml
+++ b/process-compose.yml
@@ -19,7 +19,7 @@ processes:
     command: npm run dev
     working_dir: frontend
     environment:
-      - "VITE_API_URL=http://localhost:3000"
+      - "VITE_API_BASE_URL=http://localhost:3000"
     depends_on:
       backend:
         condition: process_healthy


### PR DESCRIPTION
## Summary
- Fix `VITE_API_URL` → `VITE_API_BASE_URL` in docker-compose.yml and process-compose.yml (#346)
- Add `# DEV ONLY` comment for `GANTRY_COOKIE_SECURE=false` (#333)
- Remove duplicate `target` entry from .gitignore (#334)
- Add purpose comment to backend/Dockerfile.prod (#329)

## Closes
#329, #333, #334, #346

## Test plan
- [x] `docker-compose.yml` syntax valid
- [x] `process-compose.yml` syntax valid
- [x] No tracked .db files in git