### PR TITLE
chore: ⬆️ update Docker images (Rust 1.93, Node 24, Debian trixie)

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Stage 1: Build backend
-FROM rust:1.85-slim-bookworm AS backend-builder
+FROM rust:1.93-slim-trixie AS backend-builder
 
 WORKDIR /workspace
 
@@ -25,7 +25,7 @@ COPY backend/migrations backend/migrations
 RUN cargo build --release -p gantry-board
 
 # Stage 2: Build frontend
-FROM node:22-slim AS frontend-builder
+FROM node:24-slim AS frontend-builder
 
 WORKDIR /app
 
@@ -36,10 +36,10 @@ COPY frontend/ .
 RUN npm run build
 
 # Stage 3: Runtime
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y \
-    libssl3 \
+    libssl3t64 \
     ca-certificates \
     curl \
     nginx \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-slim-bookworm
+FROM rust:1.93-slim-trixie
 
 WORKDIR /workspace
 

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -2,7 +2,7 @@
 # For the all-in-one image (backend + frontend + nginx), see the root Dockerfile.prod.
 
 # Stage 1: Build
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:1.93-slim-trixie AS builder
 
 WORKDIR /workspace
 
@@ -28,10 +28,10 @@ COPY backend/migrations backend/migrations
 RUN cargo build --release -p gantry-board
 
 # Stage 2: Runtime
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y \
-    libssl3 \
+    libssl3t64 \
     ca-certificates \
     curl \
     && rm -rf /var/lib/apt/lists/*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:22-slim AS builder
+FROM node:24-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Rust Docker image: 1.85-slim-bookworm → 1.93-slim-trixie
- Node Docker image: 22-slim → 24-slim (LTS)
- Debian runtime: bookworm-slim → trixie-slim
- Runtime libssl3 → libssl3t64 (Debian trixie time_t 64-bit transition)

Closes #359
Closes #361
Closes #367

## Test plan
- [ ] `docker compose build` succeeds
- [ ] `docker compose -f docker-compose.prod.yml build` succeeds
- [ ] Health check passes after container start