### PR TITLE
refactor: ♻️ consolidate react-router-dom to react-router

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4",
-        "react-router-dom": "^7.13.0",
+        "react-router": "^7.13.1",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.0"
       },
@@ -11705,9 +11705,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -11724,22 +11724,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.13.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
-    "react-router-dom": "^7.13.0",
+    "react-router": "^7.13.1",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.0"
   },

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppRoutes } from './App';
 import * as authApi from './api/generated/endpoints/auth/auth';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import { useMe } from '@/api/generated/endpoints/auth/auth';
 import { ProjectBoardPage } from '@/components/board';
 import { ErrorBoundary, ToastContainer } from '@/components/common';

--- a/frontend/src/components/board/ProjectBoardPage.tsx
+++ b/frontend/src/components/board/ProjectBoardPage.tsx
@@ -1,6 +1,6 @@
 import { MessageSquare, Settings, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { ProjectChatPanel, ProjectMembersPanel, ProjectSettingsModal } from '@/components/project';
 import { TaskCreateDialog } from '@/components/task';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/components/layout/AppLayout.test.tsx
+++ b/frontend/src/components/layout/AppLayout.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from '@/stores/authStore';
 import { AppLayout } from './AppLayout';

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet } from 'react-router';
 import { useLogout } from '@/api/generated/endpoints/auth/auth';
 import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/components/layout/GuestRoute.test.tsx
+++ b/frontend/src/components/layout/GuestRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import { useAuthStore } from '@/stores/authStore';
 import { GuestRoute } from './GuestRoute';

--- a/frontend/src/components/layout/GuestRoute.tsx
+++ b/frontend/src/components/layout/GuestRoute.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuthStore } from '@/stores/authStore';
 
 interface GuestRouteProps {

--- a/frontend/src/components/layout/InvitationAcceptPage.tsx
+++ b/frontend/src/components/layout/InvitationAcceptPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   useAcceptInvitation,
   useGetInvitationByToken,

--- a/frontend/src/components/layout/LoginPage.tsx
+++ b/frontend/src/components/layout/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { useLogin } from '@/api/generated/endpoints/auth/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useAuthStore } from '@/stores/authStore';
 
 interface ProtectedRouteProps {

--- a/frontend/src/components/layout/RegisterPage.tsx
+++ b/frontend/src/components/layout/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { useRegister } from '@/api/generated/endpoints/auth/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/frontend/src/components/project/ProjectCard.test.tsx
+++ b/frontend/src/components/project/ProjectCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import { ProjectCard } from './ProjectCard';
 

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { Project } from '@/api/generated/model';
 import { Button } from '@/components/ui/button';
 

--- a/frontend/src/components/project/ProjectListPage.test.tsx
+++ b/frontend/src/components/project/ProjectListPage.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import * as projectsApi from '@/api/generated/endpoints/projects/projects';
 import { ProjectListPage } from './ProjectListPage';

--- a/frontend/src/components/task/TaskDetailPage.test.tsx
+++ b/frontend/src/components/task/TaskDetailPage.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import * as tasksApi from '@/api/generated/endpoints/tasks/tasks';
 import { TaskPriority, TaskStatus } from '@/api/generated/model';

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import {
   getGetTaskQueryKey,


### PR DESCRIPTION
## Summary
- Replace `react-router-dom` with `react-router` (v7.13+ re-exports everything from a single package)
- Update all 16 source files to import from `react-router` instead of `react-router-dom`

Closes #365

## Test plan
- [x] `vitest run` — 385 tests passed
- [x] `biome lint` — no issues