### PR TITLE
test: ✅ add unit tests for audit, github_link, preview services

### DIFF
--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -146,11 +146,26 @@ mod tests {
     use super::*;
     use crate::test_helpers::setup_test_db;
 
+    /// Poll `list_events` until at least `expected` events appear (or timeout).
+    async fn wait_for_events(pool: &SqlitePool, expected: i64) {
+        for _ in 0..50 {
+            let result = list_events(pool, None, 100, 0).await.unwrap();
+            if result.total >= expected {
+                return;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+        panic!(
+            "timed out waiting for {} events, got {}",
+            expected,
+            list_events(pool, None, 100, 0).await.unwrap().total
+        );
+    }
+
     #[tokio::test]
     async fn test_log_event_and_list() {
         let pool = setup_test_db().await;
 
-        // log_event spawns a background task, so call it and wait briefly
         log_event(
             pool.clone(),
             "user.login",
@@ -161,8 +176,7 @@ mod tests {
             Some("127.0.0.1"),
         );
 
-        // Wait for the spawned task to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        wait_for_events(&pool, 1).await;
 
         let result = list_events(&pool, None, 10, 0).await.unwrap();
         assert_eq!(result.total, 1);
@@ -180,7 +194,7 @@ mod tests {
         log_event(pool.clone(), "user.logout", None, None, None, None, None);
         log_event(pool.clone(), "user.login", None, None, None, None, None);
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        wait_for_events(&pool, 3).await;
 
         let result = list_events(&pool, Some("user.login"), 10, 0).await.unwrap();
         assert_eq!(result.total, 2);
@@ -200,7 +214,7 @@ mod tests {
             log_event(pool.clone(), "test.event", None, None, None, None, None);
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        wait_for_events(&pool, 5).await;
 
         let page1 = list_events(&pool, None, 2, 0).await.unwrap();
         assert_eq!(page1.total, 5);
@@ -217,19 +231,25 @@ mod tests {
     async fn test_cleanup_old_events() {
         let pool = setup_test_db().await;
 
-        log_event(pool.clone(), "old.event", None, None, None, None, None);
+        // Insert an event and backdate it via SQL
+        let id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO audit_events (id, event_type, created_at)
+             VALUES ($1, 'old.event', datetime('now', '-10 days'))",
+        )
+        .bind(&id)
+        .execute(&pool)
+        .await
+        .unwrap();
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        let before = list_events(&pool, None, 10, 0).await.unwrap();
+        assert_eq!(before.total, 1);
 
-        // retention_days=0 should not delete events created just now
-        let deleted = cleanup_old_events(&pool, 0).await.unwrap();
-        // Events created within the same second may not be cleaned up with 0 days
-        // so just verify the function runs without error
-        assert!(deleted == 0 || deleted == 1);
+        let deleted = cleanup_old_events(&pool, 7).await.unwrap();
+        assert_eq!(deleted, 1);
 
-        // Verify list still works
-        let result = list_events(&pool, None, 10, 0).await.unwrap();
-        assert!(result.total >= 0);
+        let after = list_events(&pool, None, 10, 0).await.unwrap();
+        assert_eq!(after.total, 0);
     }
 
     #[tokio::test]
@@ -238,7 +258,7 @@ mod tests {
 
         log_event(pool.clone(), "system.startup", None, None, None, None, None);
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        wait_for_events(&pool, 1).await;
 
         let result = list_events(&pool, None, 10, 0).await.unwrap();
         assert_eq!(result.total, 1);

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -140,3 +140,111 @@ pub async fn cleanup_old_events(pool: &SqlitePool, retention_days: u64) -> AppRe
 
     Ok(result.rows_affected())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::setup_test_db;
+
+    #[tokio::test]
+    async fn test_log_event_and_list() {
+        let pool = setup_test_db().await;
+
+        // log_event spawns a background task, so call it and wait briefly
+        log_event(
+            pool.clone(),
+            "user.login",
+            Some("actor-1"),
+            Some("user"),
+            Some("target-1"),
+            Some(serde_json::json!({"key": "value"})),
+            Some("127.0.0.1"),
+        );
+
+        // Wait for the spawned task to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let result = list_events(&pool, None, 10, 0).await.unwrap();
+        assert_eq!(result.total, 1);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].event_type, "user.login");
+        assert_eq!(result.items[0].actor_id.as_deref(), Some("actor-1"));
+        assert_eq!(result.items[0].ip_address.as_deref(), Some("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn test_list_events_with_type_filter() {
+        let pool = setup_test_db().await;
+
+        log_event(pool.clone(), "user.login", None, None, None, None, None);
+        log_event(pool.clone(), "user.logout", None, None, None, None, None);
+        log_event(pool.clone(), "user.login", None, None, None, None, None);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let result = list_events(&pool, Some("user.login"), 10, 0).await.unwrap();
+        assert_eq!(result.total, 2);
+        assert_eq!(result.items.len(), 2);
+
+        let result = list_events(&pool, Some("user.logout"), 10, 0)
+            .await
+            .unwrap();
+        assert_eq!(result.total, 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_events_pagination() {
+        let pool = setup_test_db().await;
+
+        for _ in 0..5 {
+            log_event(pool.clone(), "test.event", None, None, None, None, None);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let page1 = list_events(&pool, None, 2, 0).await.unwrap();
+        assert_eq!(page1.total, 5);
+        assert_eq!(page1.items.len(), 2);
+        assert_eq!(page1.limit, 2);
+        assert_eq!(page1.offset, 0);
+
+        let page2 = list_events(&pool, None, 2, 2).await.unwrap();
+        assert_eq!(page2.items.len(), 2);
+        assert_eq!(page2.offset, 2);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_old_events() {
+        let pool = setup_test_db().await;
+
+        log_event(pool.clone(), "old.event", None, None, None, None, None);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // retention_days=0 should not delete events created just now
+        let deleted = cleanup_old_events(&pool, 0).await.unwrap();
+        // Events created within the same second may not be cleaned up with 0 days
+        // so just verify the function runs without error
+        assert!(deleted == 0 || deleted == 1);
+
+        // Verify list still works
+        let result = list_events(&pool, None, 10, 0).await.unwrap();
+        assert!(result.total >= 0);
+    }
+
+    #[tokio::test]
+    async fn test_log_event_without_optional_fields() {
+        let pool = setup_test_db().await;
+
+        log_event(pool.clone(), "system.startup", None, None, None, None, None);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let result = list_events(&pool, None, 10, 0).await.unwrap();
+        assert_eq!(result.total, 1);
+        assert_eq!(result.items[0].event_type, "system.startup");
+        assert!(result.items[0].actor_id.is_none());
+        assert!(result.items[0].target_type.is_none());
+        assert!(result.items[0].ip_address.is_none());
+    }
+}

--- a/backend/src/services/github_link_service.rs
+++ b/backend/src/services/github_link_service.rs
@@ -170,3 +170,147 @@ pub async fn update_last_synced(pool: &SqlitePool, project_id: Uuid) -> AppResul
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::services::project_service;
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_project(pool: &SqlitePool) -> Uuid {
+        let req = CreateProjectRequest {
+            name: "Test Project".to_string(),
+            description: None,
+            repository_path: None,
+        };
+        project_service::create_project(pool, &req)
+            .await
+            .expect("create project")
+            .id
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_github_link() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let req = CreateGitHubLinkRequest {
+            repo_owner: "octocat".to_string(),
+            repo_name: "hello-world".to_string(),
+        };
+
+        let link = create_github_link(&pool, project_id, &req).await.unwrap();
+        assert_eq!(link.project_id, project_id);
+        assert_eq!(link.repo_owner, "octocat");
+        assert_eq!(link.repo_name, "hello-world");
+        assert!(link.sync_enabled);
+
+        let fetched = get_github_link(&pool, project_id).await.unwrap();
+        assert_eq!(fetched.id, link.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_github_link_not_found() {
+        let pool = setup_test_db().await;
+        let fake_id = Uuid::new_v4();
+
+        let result = get_github_link(&pool, fake_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_github_link() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let req = CreateGitHubLinkRequest {
+            repo_owner: "octocat".to_string(),
+            repo_name: "hello-world".to_string(),
+        };
+        create_github_link(&pool, project_id, &req).await.unwrap();
+
+        delete_github_link(&pool, project_id).await.unwrap();
+
+        let result = get_github_link(&pool, project_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_github_link_not_found() {
+        let pool = setup_test_db().await;
+        let fake_id = Uuid::new_v4();
+
+        let result = delete_github_link(&pool, fake_id).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_sync_enabled() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        // Initially empty
+        let links = list_sync_enabled(&pool).await.unwrap();
+        assert!(links.is_empty());
+
+        // Create a link (sync_enabled defaults to true)
+        let req = CreateGitHubLinkRequest {
+            repo_owner: "octocat".to_string(),
+            repo_name: "hello-world".to_string(),
+        };
+        create_github_link(&pool, project_id, &req).await.unwrap();
+
+        let links = list_sync_enabled(&pool).await.unwrap();
+        assert_eq!(links.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_repo() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let req = CreateGitHubLinkRequest {
+            repo_owner: "octocat".to_string(),
+            repo_name: "hello-world".to_string(),
+        };
+        create_github_link(&pool, project_id, &req).await.unwrap();
+
+        let found = find_by_repo(&pool, "octocat", "hello-world").await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().project_id, project_id);
+
+        let not_found = find_by_repo(&pool, "octocat", "nonexistent").await.unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_last_synced() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let req = CreateGitHubLinkRequest {
+            repo_owner: "octocat".to_string(),
+            repo_name: "hello-world".to_string(),
+        };
+        create_github_link(&pool, project_id, &req).await.unwrap();
+
+        // Before update, last_synced_at should be None
+        let link = get_github_link(&pool, project_id).await.unwrap();
+        assert!(link.last_synced_at.is_none());
+
+        update_last_synced(&pool, project_id).await.unwrap();
+
+        let link = get_github_link(&pool, project_id).await.unwrap();
+        assert!(link.last_synced_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_update_last_synced_not_found() {
+        let pool = setup_test_db().await;
+        let fake_id = Uuid::new_v4();
+
+        let result = update_last_synced(&pool, fake_id).await;
+        assert!(result.is_err());
+    }
+}

--- a/backend/src/services/github_link_service.rs
+++ b/backend/src/services/github_link_service.rs
@@ -174,6 +174,7 @@ pub async fn update_last_synced(pool: &SqlitePool, project_id: Uuid) -> AppResul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::AppError;
     use crate::models::project::CreateProjectRequest;
     use crate::services::project_service;
     use crate::test_helpers::setup_test_db;
@@ -216,7 +217,7 @@ mod tests {
         let fake_id = Uuid::new_v4();
 
         let result = get_github_link(&pool, fake_id).await;
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AppError::NotFound(_))));
     }
 
     #[tokio::test]
@@ -242,7 +243,7 @@ mod tests {
         let fake_id = Uuid::new_v4();
 
         let result = delete_github_link(&pool, fake_id).await;
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AppError::NotFound(_))));
     }
 
     #[tokio::test]
@@ -311,6 +312,6 @@ mod tests {
         let fake_id = Uuid::new_v4();
 
         let result = update_last_synced(&pool, fake_id).await;
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AppError::NotFound(_))));
     }
 }

--- a/backend/src/services/preview_service.rs
+++ b/backend/src/services/preview_service.rs
@@ -427,6 +427,86 @@ impl PreviewManager {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circuit_breaker_starts_closed() {
+        let cb = DockerCircuitBreaker::new();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check().is_ok());
+    }
+
+    #[test]
+    fn circuit_breaker_opens_after_threshold_failures() {
+        let cb = DockerCircuitBreaker::new();
+
+        for _ in 0..FAILURE_THRESHOLD {
+            cb.record_failure();
+        }
+
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(cb.check().is_err());
+    }
+
+    #[test]
+    fn circuit_breaker_stays_closed_below_threshold() {
+        let cb = DockerCircuitBreaker::new();
+
+        for _ in 0..(FAILURE_THRESHOLD - 1) {
+            cb.record_failure();
+        }
+
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check().is_ok());
+    }
+
+    #[test]
+    fn circuit_breaker_resets_on_success() {
+        let cb = DockerCircuitBreaker::new();
+
+        for _ in 0..(FAILURE_THRESHOLD - 1) {
+            cb.record_failure();
+        }
+
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        // After reset, need full threshold again to open
+        for _ in 0..FAILURE_THRESHOLD {
+            cb.record_failure();
+        }
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn circuit_breaker_half_open_after_recovery_window() {
+        let cb = DockerCircuitBreaker::new();
+
+        // Record failures with a timestamp in the past
+        let past = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - RECOVERY_WINDOW_SECS
+            - 1;
+        cb.last_failure_epoch
+            .store(past, std::sync::atomic::Ordering::Release);
+        cb.consecutive_failures
+            .store(FAILURE_THRESHOLD, std::sync::atomic::Ordering::Release);
+
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+        assert!(cb.check().is_ok()); // HalfOpen allows a probe
+    }
+
+    #[test]
+    fn circuit_breaker_default_trait() {
+        let cb = DockerCircuitBreaker::default();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+}
+
 fn create_tar_context(dir: &std::path::Path) -> AppResult<Vec<u8>> {
     use std::io::Write;
 

--- a/backend/src/services/preview_service.rs
+++ b/backend/src/services/preview_service.rs
@@ -427,6 +427,22 @@ impl PreviewManager {
     }
 }
 
+fn create_tar_context(dir: &std::path::Path) -> AppResult<Vec<u8>> {
+    use std::io::Write;
+
+    let buf = Vec::new();
+    let mut archive = tar::Builder::new(buf);
+    archive
+        .append_dir_all(".", dir)
+        .map_err(|e| AppError::Internal(format!("tar creation error: {e}")))?;
+    let mut buf = archive
+        .into_inner()
+        .map_err(|e| AppError::Internal(format!("tar finalize error: {e}")))?;
+    buf.flush()
+        .map_err(|e| AppError::Internal(format!("tar flush error: {e}")))?;
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -505,20 +521,4 @@ mod tests {
         let cb = DockerCircuitBreaker::default();
         assert_eq!(cb.state(), CircuitState::Closed);
     }
-}
-
-fn create_tar_context(dir: &std::path::Path) -> AppResult<Vec<u8>> {
-    use std::io::Write;
-
-    let buf = Vec::new();
-    let mut archive = tar::Builder::new(buf);
-    archive
-        .append_dir_all(".", dir)
-        .map_err(|e| AppError::Internal(format!("tar creation error: {e}")))?;
-    let mut buf = archive
-        .into_inner()
-        .map_err(|e| AppError::Internal(format!("tar finalize error: {e}")))?;
-    buf.flush()
-        .map_err(|e| AppError::Internal(format!("tar flush error: {e}")))?;
-    Ok(buf)
 }


### PR DESCRIPTION
## Summary
Add missing unit tests for the 3 services that had no test coverage:

- **audit_service** (4 tests): log_event, list_events with filter, pagination, cleanup
- **github_link_service** (8 tests): CRUD operations, find_by_repo, update_last_synced, error cases
- **preview_service/CircuitBreaker** (6 tests): state transitions (Closed→Open→HalfOpen), reset on success, default trait

Closes #328

## Test plan
- [x] `cargo test` — all new 18 tests pass
- [x] `cargo clippy` — no warnings