### PR TITLE
fix: 🐛 replace anonymous volume with entrypoint-based npm ci

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - "3000:5173"
     volumes:
       - ./frontend:/app
-      - /app/node_modules
     environment:
       - VITE_API_BASE_URL=http://localhost:3001
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,5 +16,5 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 5173
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,10 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 5173
 
-# Vite dev server with host binding for Docker
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-# Install dependencies if node_modules is missing or package.json has changed
-if [ ! -d node_modules ] || [ package.json -nt node_modules/.package-lock.json ]; then
+# Install dependencies if node_modules is missing or package manifest/lockfile has changed
+if [ ! -d node_modules ] || [ package.json -nt node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
   echo "Installing dependencies..."
   npm ci
 fi

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install dependencies if node_modules is missing or package.json has changed
+if [ ! -d node_modules ] || [ package.json -nt node_modules/.package-lock.json ]; then
+  echo "Installing dependencies..."
+  npm ci
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Remove anonymous volume `/app/node_modules` from `docker-compose.yml` that masked host-mounted node_modules
- Add `docker-entrypoint.sh` that runs `npm ci` on startup when `package.json` has changed
- Update `frontend/Dockerfile` with `ENTRYPOINT` directive

Closes #378

## Test plan
- [ ] `docker compose build frontend`
- [ ] `docker compose up frontend` — verify it starts without module errors
- [ ] Access http://localhost:3000 and confirm normal rendering
- [ ] Modify `package.json` (add a dep), restart container, verify `npm ci` runs