### PR TITLE
refactor: ♻️ extract session, task, member repositories (1/3)

### DIFF
--- a/backend/src/models/project.rs
+++ b/backend/src/models/project.rs
@@ -16,7 +16,7 @@ pub struct Project {
 // ProjectMember types - used in PR 2 (Project Member API)
 // Defined here alongside the migration schema for consistency.
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, sqlx::Type)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, sqlx::Type)]
 #[sqlx(type_name = "TEXT", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum MemberRole {

--- a/backend/src/repositories/member_repository.rs
+++ b/backend/src/repositories/member_repository.rs
@@ -141,7 +141,7 @@ pub async fn find_role(
     pool: &SqlitePool,
     project_id: Uuid,
     user_id: Uuid,
-) -> AppResult<Option<String>> {
+) -> AppResult<Option<MemberRole>> {
     let row = sqlx::query_scalar::<_, String>(
         "SELECT role FROM project_members WHERE project_id = $1 AND user_id = $2",
     )
@@ -150,18 +150,21 @@ pub async fn find_role(
     .fetch_optional(pool)
     .await?;
 
-    Ok(row)
+    row.map(|s| {
+        serde_json::from_value(serde_json::Value::String(s))
+            .map_err(|e| AppError::Internal(e.to_string()))
+    })
+    .transpose()
 }
 
 pub async fn has_any_membership(pool: &SqlitePool, user_id: Uuid) -> AppResult<bool> {
-    let count = sqlx::query_scalar::<_, i32>(
-        "SELECT COUNT(*) FROM project_members WHERE user_id = $1 LIMIT 1",
-    )
-    .bind(user_id.to_string())
-    .fetch_one(pool)
-    .await?;
+    let exists: Option<(i32,)> =
+        sqlx::query_as("SELECT 1 FROM project_members WHERE user_id = $1 LIMIT 1")
+            .bind(user_id.to_string())
+            .fetch_optional(pool)
+            .await?;
 
-    Ok(count > 0)
+    Ok(exists.is_some())
 }
 
 pub async fn list_project_ids_by_user(pool: &SqlitePool, user_id: Uuid) -> AppResult<Vec<Uuid>> {
@@ -181,14 +184,14 @@ pub async fn list_project_ids_by_user(pool: &SqlitePool, user_id: Uuid) -> AppRe
 }
 
 pub async fn count_owners(pool: &SqlitePool, project_id: Uuid) -> AppResult<i64> {
-    let count = sqlx::query_scalar::<_, i32>(
+    let count = sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*) FROM project_members WHERE project_id = $1 AND role = 'owner'",
     )
     .bind(project_id.to_string())
     .fetch_one(pool)
     .await?;
 
-    Ok(count as i64)
+    Ok(count)
 }
 
 pub async fn user_exists_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<bool> {
@@ -242,7 +245,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             project_id,
             user_id,
             &MemberRole::Member,
@@ -279,10 +282,10 @@ mod tests {
         let u2 = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        insert_tx(&mut *tx, project_id, u1, &MemberRole::Owner, Utc::now())
+        insert_tx(&mut tx, project_id, u1, &MemberRole::Owner, Utc::now())
             .await
             .unwrap();
-        insert_tx(&mut *tx, project_id, u2, &MemberRole::Member, Utc::now())
+        insert_tx(&mut tx, project_id, u2, &MemberRole::Member, Utc::now())
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -301,7 +304,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             project_id,
             user_id,
             &MemberRole::Member,
@@ -330,7 +333,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             project_id,
             user_id,
             &MemberRole::Member,
@@ -356,22 +359,16 @@ mod tests {
         let user_id = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        insert_tx(
-            &mut *tx,
-            project_id,
-            user_id,
-            &MemberRole::Admin,
-            Utc::now(),
-        )
-        .await
-        .unwrap();
+        insert_tx(&mut tx, project_id, user_id, &MemberRole::Admin, Utc::now())
+            .await
+            .unwrap();
         tx.commit().await.unwrap();
 
         let role = find_role(&pool, project_id, user_id)
             .await
             .expect("find_role")
             .expect("should have role");
-        assert_eq!(role, "admin");
+        assert_eq!(role, MemberRole::Admin);
 
         assert!(find_role(&pool, project_id, Uuid::new_v4())
             .await
@@ -389,7 +386,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             project_id,
             user_id,
             &MemberRole::Member,
@@ -410,10 +407,10 @@ mod tests {
         let user_id = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        insert_tx(&mut *tx, p1, user_id, &MemberRole::Owner, Utc::now())
+        insert_tx(&mut tx, p1, user_id, &MemberRole::Owner, Utc::now())
             .await
             .unwrap();
-        insert_tx(&mut *tx, p2, user_id, &MemberRole::Member, Utc::now())
+        insert_tx(&mut tx, p2, user_id, &MemberRole::Member, Utc::now())
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -433,13 +430,13 @@ mod tests {
         let u3 = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        insert_tx(&mut *tx, project_id, u1, &MemberRole::Owner, Utc::now())
+        insert_tx(&mut tx, project_id, u1, &MemberRole::Owner, Utc::now())
             .await
             .unwrap();
-        insert_tx(&mut *tx, project_id, u2, &MemberRole::Owner, Utc::now())
+        insert_tx(&mut tx, project_id, u2, &MemberRole::Owner, Utc::now())
             .await
             .unwrap();
-        insert_tx(&mut *tx, project_id, u3, &MemberRole::Admin, Utc::now())
+        insert_tx(&mut tx, project_id, u3, &MemberRole::Admin, Utc::now())
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -454,8 +451,8 @@ mod tests {
         let user_id = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        assert!(user_exists_tx(&mut *tx, user_id).await.unwrap());
-        assert!(!user_exists_tx(&mut *tx, Uuid::new_v4()).await.unwrap());
+        assert!(user_exists_tx(&mut tx, user_id).await.unwrap());
+        assert!(!user_exists_tx(&mut tx, Uuid::new_v4()).await.unwrap());
         tx.commit().await.unwrap();
     }
 }

--- a/backend/src/repositories/member_repository.rs
+++ b/backend/src/repositories/member_repository.rs
@@ -1,0 +1,461 @@
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::sqlite::SqliteConnection;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::project::{MemberRole, ProjectMember};
+
+#[derive(FromRow)]
+struct MemberRow {
+    project_id: String,
+    user_id: String,
+    role: MemberRole,
+    user_name: String,
+    user_email: String,
+    created_at: DateTime<Utc>,
+}
+
+impl TryFrom<MemberRow> for ProjectMember {
+    type Error = uuid::Error;
+
+    fn try_from(row: MemberRow) -> Result<Self, Self::Error> {
+        Ok(ProjectMember {
+            project_id: row.project_id.parse()?,
+            user_id: row.user_id.parse()?,
+            role: row.role,
+            user_name: row.user_name,
+            user_email: row.user_email,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn row_to_member(row: MemberRow) -> AppResult<ProjectMember> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+pub async fn insert_tx(
+    conn: &mut SqliteConnection,
+    project_id: Uuid,
+    user_id: Uuid,
+    role: &MemberRole,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO project_members (project_id, user_id, role, created_at)
+        VALUES ($1, $2, $3, $4)
+        "#,
+    )
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .bind(role)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn find_by_project_and_user(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    user_id: Uuid,
+) -> AppResult<Option<ProjectMember>> {
+    let row = sqlx::query_as::<_, MemberRow>(
+        r#"
+        SELECT pm.project_id, pm.user_id, pm.role,
+               u.name as user_name, u.email as user_email,
+               pm.created_at
+        FROM project_members pm
+        JOIN users u ON pm.user_id = u.id
+        WHERE pm.project_id = $1 AND pm.user_id = $2
+        "#,
+    )
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_member).transpose()
+}
+
+pub async fn find_all_by_project(
+    pool: &SqlitePool,
+    project_id: Uuid,
+) -> AppResult<Vec<ProjectMember>> {
+    let rows = sqlx::query_as::<_, MemberRow>(
+        r#"
+        SELECT pm.project_id, pm.user_id, pm.role,
+               u.name as user_name, u.email as user_email,
+               pm.created_at
+        FROM project_members pm
+        JOIN users u ON pm.user_id = u.id
+        WHERE pm.project_id = $1
+        ORDER BY pm.created_at ASC
+        "#,
+    )
+    .bind(project_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_member).collect()
+}
+
+pub async fn update_role(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    user_id: Uuid,
+    role: &MemberRole,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        UPDATE project_members
+        SET role = $1
+        WHERE project_id = $2 AND user_id = $3
+        "#,
+    )
+    .bind(role)
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn delete(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) -> AppResult<u64> {
+    let result = sqlx::query("DELETE FROM project_members WHERE project_id = $1 AND user_id = $2")
+        .bind(project_id.to_string())
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn find_role(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    user_id: Uuid,
+) -> AppResult<Option<String>> {
+    let row = sqlx::query_scalar::<_, String>(
+        "SELECT role FROM project_members WHERE project_id = $1 AND user_id = $2",
+    )
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row)
+}
+
+pub async fn has_any_membership(pool: &SqlitePool, user_id: Uuid) -> AppResult<bool> {
+    let count = sqlx::query_scalar::<_, i32>(
+        "SELECT COUNT(*) FROM project_members WHERE user_id = $1 LIMIT 1",
+    )
+    .bind(user_id.to_string())
+    .fetch_one(pool)
+    .await?;
+
+    Ok(count > 0)
+}
+
+pub async fn list_project_ids_by_user(pool: &SqlitePool, user_id: Uuid) -> AppResult<Vec<Uuid>> {
+    let rows = sqlx::query_scalar::<_, String>(
+        "SELECT project_id FROM project_members WHERE user_id = $1",
+    )
+    .bind(user_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|s| {
+            s.parse()
+                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+        })
+        .collect()
+}
+
+pub async fn count_owners(pool: &SqlitePool, project_id: Uuid) -> AppResult<i64> {
+    let count = sqlx::query_scalar::<_, i32>(
+        "SELECT COUNT(*) FROM project_members WHERE project_id = $1 AND role = 'owner'",
+    )
+    .bind(project_id.to_string())
+    .fetch_one(pool)
+    .await?;
+
+    Ok(count as i64)
+}
+
+pub async fn user_exists_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<bool> {
+    let exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
+        .bind(user_id.to_string())
+        .fetch_optional(&mut *conn)
+        .await?;
+
+    Ok(exists.is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::user::RegisterRequest;
+    use crate::services::{project_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_project(pool: &SqlitePool) -> Uuid {
+        project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .expect("create project")
+        .id
+    }
+
+    async fn create_test_user(pool: &SqlitePool) -> Uuid {
+        let req = RegisterRequest {
+            email: format!("test-{}@example.com", Uuid::new_v4()),
+            name: "Test User".to_string(),
+            password: "correct horse battery staple purple".to_string(),
+        };
+        user_service::create_user(pool, &req)
+            .await
+            .expect("create user")
+            .id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            project_id,
+            user_id,
+            &MemberRole::Member,
+            Utc::now(),
+        )
+        .await
+        .expect("insert");
+        tx.commit().await.unwrap();
+
+        let member = find_by_project_and_user(&pool, project_id, user_id)
+            .await
+            .expect("find")
+            .expect("should exist");
+        assert_eq!(member.project_id, project_id);
+        assert_eq!(member.user_id, user_id);
+        assert!(matches!(member.role, MemberRole::Member));
+    }
+
+    #[tokio::test]
+    async fn test_find_returns_none_for_nonexistent() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let result = find_by_project_and_user(&pool, project_id, Uuid::new_v4())
+            .await
+            .expect("find");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_project() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let u1 = create_test_user(&pool).await;
+        let u2 = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(&mut *tx, project_id, u1, &MemberRole::Owner, Utc::now())
+            .await
+            .unwrap();
+        insert_tx(&mut *tx, project_id, u2, &MemberRole::Member, Utc::now())
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let members = find_all_by_project(&pool, project_id)
+            .await
+            .expect("find all");
+        assert_eq!(members.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_update_role() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            project_id,
+            user_id,
+            &MemberRole::Member,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        update_role(&pool, project_id, user_id, &MemberRole::Admin)
+            .await
+            .expect("update");
+
+        let member = find_by_project_and_user(&pool, project_id, user_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(member.role, MemberRole::Admin));
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            project_id,
+            user_id,
+            &MemberRole::Member,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let rows = delete(&pool, project_id, user_id).await.expect("delete");
+        assert_eq!(rows, 1);
+
+        assert!(find_by_project_and_user(&pool, project_id, user_id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_role() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            project_id,
+            user_id,
+            &MemberRole::Admin,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        let role = find_role(&pool, project_id, user_id)
+            .await
+            .expect("find_role")
+            .expect("should have role");
+        assert_eq!(role, "admin");
+
+        assert!(find_role(&pool, project_id, Uuid::new_v4())
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_has_any_membership() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        assert!(!has_any_membership(&pool, user_id).await.unwrap());
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            project_id,
+            user_id,
+            &MemberRole::Member,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+
+        assert!(has_any_membership(&pool, user_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_list_project_ids_by_user() {
+        let pool = setup_test_db().await;
+        let p1 = create_test_project(&pool).await;
+        let p2 = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(&mut *tx, p1, user_id, &MemberRole::Owner, Utc::now())
+            .await
+            .unwrap();
+        insert_tx(&mut *tx, p2, user_id, &MemberRole::Member, Utc::now())
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let ids = list_project_ids_by_user(&pool, user_id).await.unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&p1));
+        assert!(ids.contains(&p2));
+    }
+
+    #[tokio::test]
+    async fn test_count_owners() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let u1 = create_test_user(&pool).await;
+        let u2 = create_test_user(&pool).await;
+        let u3 = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(&mut *tx, project_id, u1, &MemberRole::Owner, Utc::now())
+            .await
+            .unwrap();
+        insert_tx(&mut *tx, project_id, u2, &MemberRole::Owner, Utc::now())
+            .await
+            .unwrap();
+        insert_tx(&mut *tx, project_id, u3, &MemberRole::Admin, Utc::now())
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let count = count_owners(&pool, project_id).await.unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_user_exists_tx() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        assert!(user_exists_tx(&mut *tx, user_id).await.unwrap());
+        assert!(!user_exists_tx(&mut *tx, Uuid::new_v4()).await.unwrap());
+        tx.commit().await.unwrap();
+    }
+}

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_repository;
 pub mod github_link_repository;
+pub mod member_repository;
 pub mod preview_repository;
 pub mod session_repository;
 pub mod task_repository;

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_repository;
 pub mod github_link_repository;
 pub mod preview_repository;
+pub mod session_repository;
 pub mod user_repository;

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -2,4 +2,5 @@ pub mod audit_repository;
 pub mod github_link_repository;
 pub mod preview_repository;
 pub mod session_repository;
+pub mod task_repository;
 pub mod user_repository;

--- a/backend/src/repositories/session_repository.rs
+++ b/backend/src/repositories/session_repository.rs
@@ -13,7 +13,21 @@ pub async fn insert(
     now: DateTime<Utc>,
     expires_at: DateTime<Utc>,
 ) -> AppResult<()> {
-    todo!()
+    sqlx::query(
+        r#"
+        INSERT INTO sessions (id, user_id, created_at, expires_at, last_active_at)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(user_id.to_string())
+    .bind(now)
+    .bind(expires_at)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 pub async fn insert_tx(
@@ -23,7 +37,21 @@ pub async fn insert_tx(
     now: DateTime<Utc>,
     expires_at: DateTime<Utc>,
 ) -> AppResult<()> {
-    todo!()
+    sqlx::query(
+        r#"
+        INSERT INTO sessions (id, user_id, created_at, expires_at, last_active_at)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(user_id.to_string())
+    .bind(now)
+    .bind(expires_at)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
 }
 
 pub async fn find_by_id_not_expired(
@@ -31,7 +59,19 @@ pub async fn find_by_id_not_expired(
     session_id: Uuid,
     now: DateTime<Utc>,
 ) -> AppResult<Option<Session>> {
-    todo!()
+    let session = sqlx::query_as::<_, Session>(
+        r#"
+        SELECT id, user_id, created_at, expires_at, last_active_at
+        FROM sessions
+        WHERE id = $1 AND expires_at > $2
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(now)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(session)
 }
 
 pub async fn update_last_active_at(
@@ -39,23 +79,55 @@ pub async fn update_last_active_at(
     session_id: Uuid,
     now: DateTime<Utc>,
 ) -> AppResult<()> {
-    todo!()
+    sqlx::query(
+        r#"
+        UPDATE sessions
+        SET last_active_at = $1
+        WHERE id = $2
+        "#,
+    )
+    .bind(now)
+    .bind(session_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 pub async fn delete_by_id(pool: &SqlitePool, session_id: Uuid) -> AppResult<()> {
-    todo!()
+    sqlx::query("DELETE FROM sessions WHERE id = $1")
+        .bind(session_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(())
 }
 
 pub async fn delete_by_user_id(pool: &SqlitePool, user_id: Uuid) -> AppResult<()> {
-    todo!()
+    sqlx::query("DELETE FROM sessions WHERE user_id = $1")
+        .bind(user_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(())
 }
 
 pub async fn delete_by_user_id_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<()> {
-    todo!()
+    sqlx::query("DELETE FROM sessions WHERE user_id = $1")
+        .bind(user_id.to_string())
+        .execute(&mut *conn)
+        .await?;
+
+    Ok(())
 }
 
 pub async fn delete_expired(pool: &SqlitePool, now: DateTime<Utc>) -> AppResult<u64> {
-    todo!()
+    let result = sqlx::query("DELETE FROM sessions WHERE expires_at <= $1")
+        .bind(now)
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
 }
 
 #[cfg(test)]

--- a/backend/src/repositories/session_repository.rs
+++ b/backend/src/repositories/session_repository.rs
@@ -1,0 +1,266 @@
+use chrono::{DateTime, Utc};
+use sqlx::sqlite::SqliteConnection;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::AppResult;
+use crate::models::user::Session;
+
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    user_id: Uuid,
+    now: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn insert_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    user_id: Uuid,
+    now: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn find_by_id_not_expired(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    now: DateTime<Utc>,
+) -> AppResult<Option<Session>> {
+    todo!()
+}
+
+pub async fn update_last_active_at(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn delete_by_id(pool: &SqlitePool, session_id: Uuid) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn delete_by_user_id(pool: &SqlitePool, user_id: Uuid) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn delete_by_user_id_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn delete_expired(pool: &SqlitePool, now: DateTime<Utc>) -> AppResult<u64> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user::RegisterRequest;
+    use crate::services::user_service;
+    use crate::test_helpers::setup_test_db;
+    use chrono::Duration;
+
+    async fn create_test_user(pool: &SqlitePool) -> Uuid {
+        let req = RegisterRequest {
+            email: format!("test-{}@example.com", Uuid::new_v4()),
+            name: "Test User".to_string(),
+            password: "correct horse battery staple purple".to_string(),
+        };
+        let user = user_service::create_user(pool, &req)
+            .await
+            .expect("create user");
+        user.id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let expires_at = now + Duration::hours(24);
+
+        insert(&pool, id, user_id, now, expires_at)
+            .await
+            .expect("insert");
+
+        let session = find_by_id_not_expired(&pool, id, now)
+            .await
+            .expect("find")
+            .expect("should exist");
+
+        assert_eq!(session.id, id.to_string());
+        assert_eq!(session.user_id, user_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_find_returns_none_for_expired() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let expires_at = now - Duration::hours(1);
+
+        insert(&pool, id, user_id, now, expires_at)
+            .await
+            .expect("insert");
+
+        let result = find_by_id_not_expired(&pool, id, now).await.expect("find");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_returns_none_for_nonexistent() {
+        let pool = setup_test_db().await;
+        let result = find_by_id_not_expired(&pool, Uuid::new_v4(), Utc::now())
+            .await
+            .expect("find");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_last_active_at() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let expires_at = now + Duration::hours(24);
+
+        insert(&pool, id, user_id, now, expires_at)
+            .await
+            .expect("insert");
+
+        let later = now + Duration::seconds(10);
+        update_last_active_at(&pool, id, later)
+            .await
+            .expect("update");
+
+        let session = find_by_id_not_expired(&pool, id, now)
+            .await
+            .expect("find")
+            .expect("should exist");
+        assert!(session.last_active_at >= now);
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_id() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let expires_at = now + Duration::hours(24);
+
+        insert(&pool, id, user_id, now, expires_at)
+            .await
+            .expect("insert");
+
+        delete_by_id(&pool, id).await.expect("delete");
+
+        let result = find_by_id_not_expired(&pool, id, now).await.expect("find");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_user_id() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let now = Utc::now();
+        let expires_at = now + Duration::hours(24);
+
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        insert(&pool, id1, user_id, now, expires_at)
+            .await
+            .expect("insert 1");
+        insert(&pool, id2, user_id, now, expires_at)
+            .await
+            .expect("insert 2");
+
+        delete_by_user_id(&pool, user_id).await.expect("delete");
+
+        assert!(find_by_id_not_expired(&pool, id1, now)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(find_by_id_not_expired(&pool, id2, now)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_insert_tx_and_delete_by_user_id_tx() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let now = Utc::now();
+        let expires_at = now + Duration::hours(24);
+
+        // Insert via transaction
+        let id = Uuid::new_v4();
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(&mut *tx, id, user_id, now, expires_at)
+            .await
+            .expect("insert_tx");
+        tx.commit().await.unwrap();
+
+        let session = find_by_id_not_expired(&pool, id, now)
+            .await
+            .unwrap()
+            .expect("should exist");
+        assert_eq!(session.id, id.to_string());
+
+        // Delete via transaction
+        let mut tx = pool.begin().await.unwrap();
+        delete_by_user_id_tx(&mut *tx, user_id)
+            .await
+            .expect("delete_tx");
+        tx.commit().await.unwrap();
+
+        assert!(find_by_id_not_expired(&pool, id, now)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let now = Utc::now();
+        // Insert an already-expired session
+        let id = Uuid::new_v4();
+        let past = now - Duration::hours(2);
+        let expired_at = now - Duration::hours(1);
+        insert(&pool, id, user_id, past, expired_at)
+            .await
+            .expect("insert expired");
+
+        // Insert a valid session
+        let valid_id = Uuid::new_v4();
+        insert(&pool, valid_id, user_id, now, now + Duration::hours(24))
+            .await
+            .expect("insert valid");
+
+        let deleted = delete_expired(&pool, now).await.expect("delete_expired");
+        assert_eq!(deleted, 1);
+
+        // Valid session should still exist
+        assert!(find_by_id_not_expired(&pool, valid_id, now)
+            .await
+            .unwrap()
+            .is_some());
+    }
+}

--- a/backend/src/repositories/session_repository.rs
+++ b/backend/src/repositories/session_repository.rs
@@ -282,7 +282,7 @@ mod tests {
         // Insert via transaction
         let id = Uuid::new_v4();
         let mut tx = pool.begin().await.unwrap();
-        insert_tx(&mut *tx, id, user_id, now, expires_at)
+        insert_tx(&mut tx, id, user_id, now, expires_at)
             .await
             .expect("insert_tx");
         tx.commit().await.unwrap();
@@ -295,7 +295,7 @@ mod tests {
 
         // Delete via transaction
         let mut tx = pool.begin().await.unwrap();
-        delete_by_user_id_tx(&mut *tx, user_id)
+        delete_by_user_id_tx(&mut tx, user_id)
             .await
             .expect("delete_tx");
         tx.commit().await.unwrap();

--- a/backend/src/repositories/task_repository.rs
+++ b/backend/src/repositories/task_repository.rs
@@ -59,23 +59,86 @@ pub async fn insert_tx(
     assigned_to: Option<Uuid>,
     now: DateTime<Utc>,
 ) -> AppResult<()> {
-    todo!()
+    sqlx::query(
+        r#"
+        INSERT INTO tasks (id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(project_id.to_string())
+    .bind(title)
+    .bind(description)
+    .bind(status)
+    .bind(priority)
+    .bind(parent_id.map(|u| u.to_string()))
+    .bind(assigned_to.map(|u| u.to_string()))
+    .bind(0i32)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
 }
 
 pub async fn find_by_id(pool: &SqlitePool, id: Uuid) -> AppResult<Task> {
-    todo!()
+    let row = sqlx::query_as::<_, TaskRow>(
+        r#"
+        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
+        FROM tasks
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_task)
+        .transpose()?
+        .ok_or_else(|| AppError::NotFound(format!("task {} not found", id)))
 }
 
 pub async fn find_by_id_tx(conn: &mut SqliteConnection, id: Uuid) -> AppResult<Task> {
-    todo!()
+    let row = sqlx::query_as::<_, TaskRow>(
+        r#"
+        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
+        FROM tasks
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    row.map(row_to_task)
+        .transpose()?
+        .ok_or_else(|| AppError::NotFound(format!("task {} not found", id)))
 }
 
 pub async fn find_all_by_project(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<Task>> {
-    todo!()
+    let rows = sqlx::query_as::<_, TaskRow>(
+        r#"
+        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
+        FROM tasks
+        WHERE project_id = $1
+        ORDER BY position ASC, created_at ASC
+        "#,
+    )
+    .bind(project_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_task).collect()
 }
 
 pub async fn count_by_project(pool: &SqlitePool, project_id: Uuid) -> AppResult<i64> {
-    todo!()
+    let total: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE project_id = $1")
+        .bind(project_id.to_string())
+        .fetch_one(pool)
+        .await?;
+
+    Ok(total.0)
 }
 
 pub async fn find_paginated_by_project(
@@ -84,7 +147,22 @@ pub async fn find_paginated_by_project(
     limit: i64,
     offset: i64,
 ) -> AppResult<Vec<Task>> {
-    todo!()
+    let rows = sqlx::query_as::<_, TaskRow>(
+        r#"
+        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
+        FROM tasks
+        WHERE project_id = $1
+        ORDER BY position ASC, created_at ASC
+        LIMIT $2 OFFSET $3
+        "#,
+    )
+    .bind(project_id.to_string())
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_task).collect()
 }
 
 pub async fn update_tx(
@@ -99,15 +177,48 @@ pub async fn update_tx(
     position: i32,
     now: DateTime<Utc>,
 ) -> AppResult<()> {
-    todo!()
+    sqlx::query(
+        r#"
+        UPDATE tasks
+        SET title = $1, description = $2, status = $3, priority = $4, parent_id = $5, assigned_to = $6, position = $7, updated_at = $8
+        WHERE id = $9
+        "#,
+    )
+    .bind(title)
+    .bind(description)
+    .bind(status)
+    .bind(priority)
+    .bind(parent_id.map(|u| u.to_string()))
+    .bind(assigned_to.map(|u| u.to_string()))
+    .bind(position)
+    .bind(now)
+    .bind(id.to_string())
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
 }
 
 pub async fn delete(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
-    todo!()
+    let result = sqlx::query("DELETE FROM tasks WHERE id = $1")
+        .bind(id.to_string())
+        .execute(pool)
+        .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!("task {} not found", id)));
+    }
+
+    Ok(())
 }
 
 pub async fn user_exists_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<bool> {
-    todo!()
+    let exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
+        .bind(user_id.to_string())
+        .fetch_optional(&mut *conn)
+        .await?;
+
+    Ok(exists.is_some())
 }
 
 pub async fn is_project_member_tx(
@@ -115,7 +226,14 @@ pub async fn is_project_member_tx(
     project_id: Uuid,
     user_id: Uuid,
 ) -> AppResult<bool> {
-    todo!()
+    let exists: Option<(i32,)> =
+        sqlx::query_as("SELECT 1 FROM project_members WHERE project_id = $1 AND user_id = $2")
+            .bind(project_id.to_string())
+            .bind(user_id.to_string())
+            .fetch_optional(&mut *conn)
+            .await?;
+
+    Ok(exists.is_some())
 }
 
 #[cfg(test)]

--- a/backend/src/repositories/task_repository.rs
+++ b/backend/src/repositories/task_repository.rs
@@ -47,6 +47,7 @@ fn row_to_task(row: TaskRow) -> AppResult<Task> {
         .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_tx(
     conn: &mut SqliteConnection,
     id: Uuid,
@@ -165,6 +166,7 @@ pub async fn find_paginated_by_project(
     rows.into_iter().map(row_to_task).collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn update_tx(
     conn: &mut SqliteConnection,
     id: Uuid,
@@ -278,7 +280,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             id,
             project_id,
             "Test Task",
@@ -315,7 +317,7 @@ mod tests {
         for i in 0..3 {
             let mut tx = pool.begin().await.unwrap();
             insert_tx(
-                &mut *tx,
+                &mut tx,
                 Uuid::new_v4(),
                 project_id,
                 &format!("Task {i}"),
@@ -346,7 +348,7 @@ mod tests {
         for i in 0..5 {
             let mut tx = pool.begin().await.unwrap();
             insert_tx(
-                &mut *tx,
+                &mut tx,
                 Uuid::new_v4(),
                 project_id,
                 &format!("Task {i}"),
@@ -380,7 +382,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             id,
             project_id,
             "Original",
@@ -398,7 +400,7 @@ mod tests {
         let later = now + chrono::Duration::seconds(10);
         let mut tx = pool.begin().await.unwrap();
         update_tx(
-            &mut *tx,
+            &mut tx,
             id,
             "Updated",
             Some("new desc"),
@@ -429,7 +431,7 @@ mod tests {
 
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             id,
             project_id,
             "To Delete",
@@ -464,8 +466,8 @@ mod tests {
         let user_id = create_test_user(&pool).await;
 
         let mut tx = pool.begin().await.unwrap();
-        assert!(user_exists_tx(&mut *tx, user_id).await.expect("check"));
-        assert!(!user_exists_tx(&mut *tx, Uuid::new_v4())
+        assert!(user_exists_tx(&mut tx, user_id).await.expect("check"));
+        assert!(!user_exists_tx(&mut tx, Uuid::new_v4())
             .await
             .expect("check"));
         tx.commit().await.unwrap();
@@ -486,10 +488,10 @@ mod tests {
             .expect("add member");
 
         let mut tx = pool.begin().await.unwrap();
-        assert!(is_project_member_tx(&mut *tx, project_id, user_id)
+        assert!(is_project_member_tx(&mut tx, project_id, user_id)
             .await
             .expect("check"));
-        assert!(!is_project_member_tx(&mut *tx, project_id, Uuid::new_v4())
+        assert!(!is_project_member_tx(&mut tx, project_id, Uuid::new_v4())
             .await
             .expect("check"));
         tx.commit().await.unwrap();

--- a/backend/src/repositories/task_repository.rs
+++ b/backend/src/repositories/task_repository.rs
@@ -1,0 +1,379 @@
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::sqlite::SqliteConnection;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::task::{Task, TaskPriority, TaskStatus};
+
+#[derive(FromRow)]
+pub(crate) struct TaskRow {
+    pub id: String,
+    pub project_id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: TaskStatus,
+    pub priority: TaskPriority,
+    pub parent_id: Option<String>,
+    pub assigned_to: Option<String>,
+    pub position: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<TaskRow> for Task {
+    type Error = uuid::Error;
+
+    fn try_from(row: TaskRow) -> Result<Self, Self::Error> {
+        Ok(Task {
+            id: row.id.parse()?,
+            project_id: row.project_id.parse()?,
+            title: row.title,
+            description: row.description,
+            status: row.status,
+            priority: row.priority,
+            parent_id: row.parent_id.map(|s| s.parse()).transpose()?,
+            assigned_to: row.assigned_to.map(|s| s.parse()).transpose()?,
+            position: row.position,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+fn row_to_task(row: TaskRow) -> AppResult<Task> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+pub async fn insert_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    project_id: Uuid,
+    title: &str,
+    description: Option<&str>,
+    status: &TaskStatus,
+    priority: &TaskPriority,
+    parent_id: Option<Uuid>,
+    assigned_to: Option<Uuid>,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn find_by_id(pool: &SqlitePool, id: Uuid) -> AppResult<Task> {
+    todo!()
+}
+
+pub async fn find_by_id_tx(conn: &mut SqliteConnection, id: Uuid) -> AppResult<Task> {
+    todo!()
+}
+
+pub async fn find_all_by_project(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<Task>> {
+    todo!()
+}
+
+pub async fn count_by_project(pool: &SqlitePool, project_id: Uuid) -> AppResult<i64> {
+    todo!()
+}
+
+pub async fn find_paginated_by_project(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> AppResult<Vec<Task>> {
+    todo!()
+}
+
+pub async fn update_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    title: &str,
+    description: Option<&str>,
+    status: &TaskStatus,
+    priority: &TaskPriority,
+    parent_id: Option<Uuid>,
+    assigned_to: Option<Uuid>,
+    position: i32,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn delete(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
+    todo!()
+}
+
+pub async fn user_exists_tx(conn: &mut SqliteConnection, user_id: Uuid) -> AppResult<bool> {
+    todo!()
+}
+
+pub async fn is_project_member_tx(
+    conn: &mut SqliteConnection,
+    project_id: Uuid,
+    user_id: Uuid,
+) -> AppResult<bool> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::{AddMemberRequest, CreateProjectRequest, MemberRole};
+    use crate::models::user::RegisterRequest;
+    use crate::services::{member_service, project_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_project(pool: &SqlitePool) -> Uuid {
+        let req = CreateProjectRequest {
+            name: "Test Project".to_string(),
+            description: None,
+            repository_path: None,
+        };
+        project_service::create_project(pool, &req)
+            .await
+            .expect("create project")
+            .id
+    }
+
+    async fn create_test_user(pool: &SqlitePool) -> Uuid {
+        let req = RegisterRequest {
+            email: format!("test-{}@example.com", Uuid::new_v4()),
+            name: "Test User".to_string(),
+            password: "correct horse battery staple purple".to_string(),
+        };
+        user_service::create_user(pool, &req)
+            .await
+            .expect("create user")
+            .id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            id,
+            project_id,
+            "Test Task",
+            Some("desc"),
+            &TaskStatus::Backlog,
+            &TaskPriority::Medium,
+            None,
+            None,
+            now,
+        )
+        .await
+        .expect("insert");
+        tx.commit().await.unwrap();
+
+        let task = find_by_id(&pool, id).await.expect("find");
+        assert_eq!(task.id, id);
+        assert_eq!(task.title, "Test Task");
+        assert_eq!(task.description, Some("desc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_found() {
+        let pool = setup_test_db().await;
+        let result = find_by_id(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_project() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let now = Utc::now();
+
+        for i in 0..3 {
+            let mut tx = pool.begin().await.unwrap();
+            insert_tx(
+                &mut *tx,
+                Uuid::new_v4(),
+                project_id,
+                &format!("Task {i}"),
+                None,
+                &TaskStatus::Backlog,
+                &TaskPriority::Medium,
+                None,
+                None,
+                now,
+            )
+            .await
+            .expect("insert");
+            tx.commit().await.unwrap();
+        }
+
+        let tasks = find_all_by_project(&pool, project_id)
+            .await
+            .expect("find all");
+        assert_eq!(tasks.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_count_and_paginated() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let now = Utc::now();
+
+        for i in 0..5 {
+            let mut tx = pool.begin().await.unwrap();
+            insert_tx(
+                &mut *tx,
+                Uuid::new_v4(),
+                project_id,
+                &format!("Task {i}"),
+                None,
+                &TaskStatus::Backlog,
+                &TaskPriority::Medium,
+                None,
+                None,
+                now,
+            )
+            .await
+            .expect("insert");
+            tx.commit().await.unwrap();
+        }
+
+        let count = count_by_project(&pool, project_id).await.expect("count");
+        assert_eq!(count, 5);
+
+        let page = find_paginated_by_project(&pool, project_id, 2, 0)
+            .await
+            .expect("paginated");
+        assert_eq!(page.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_update_tx() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            id,
+            project_id,
+            "Original",
+            None,
+            &TaskStatus::Backlog,
+            &TaskPriority::Low,
+            None,
+            None,
+            now,
+        )
+        .await
+        .expect("insert");
+        tx.commit().await.unwrap();
+
+        let later = now + chrono::Duration::seconds(10);
+        let mut tx = pool.begin().await.unwrap();
+        update_tx(
+            &mut *tx,
+            id,
+            "Updated",
+            Some("new desc"),
+            &TaskStatus::InProgress,
+            &TaskPriority::High,
+            None,
+            None,
+            5,
+            later,
+        )
+        .await
+        .expect("update");
+        tx.commit().await.unwrap();
+
+        let task = find_by_id(&pool, id).await.expect("find");
+        assert_eq!(task.title, "Updated");
+        assert_eq!(task.description, Some("new desc".to_string()));
+        assert!(matches!(task.status, TaskStatus::InProgress));
+        assert_eq!(task.position, 5);
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            id,
+            project_id,
+            "To Delete",
+            None,
+            &TaskStatus::Backlog,
+            &TaskPriority::Medium,
+            None,
+            None,
+            now,
+        )
+        .await
+        .expect("insert");
+        tx.commit().await.unwrap();
+
+        delete(&pool, id).await.expect("delete");
+        assert!(matches!(
+            find_by_id(&pool, id).await,
+            Err(AppError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let pool = setup_test_db().await;
+        let result = delete(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_user_exists_tx() {
+        let pool = setup_test_db().await;
+        let user_id = create_test_user(&pool).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        assert!(user_exists_tx(&mut *tx, user_id).await.expect("check"));
+        assert!(!user_exists_tx(&mut *tx, Uuid::new_v4())
+            .await
+            .expect("check"));
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_is_project_member_tx() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool).await;
+
+        let req = AddMemberRequest {
+            user_id,
+            role: MemberRole::Member,
+        };
+        member_service::add_member(&pool, project_id, &req)
+            .await
+            .expect("add member");
+
+        let mut tx = pool.begin().await.unwrap();
+        assert!(is_project_member_tx(&mut *tx, project_id, user_id)
+            .await
+            .expect("check"));
+        assert!(!is_project_member_tx(&mut *tx, project_id, Uuid::new_v4())
+            .await
+            .expect("check"));
+        tx.commit().await.unwrap();
+    }
+}

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use crate::error::{AppError, AppResult};
 use crate::models::project::MemberRole;
 use crate::models::task::Task;
+use crate::repositories::member_repository;
 use crate::services::{project_service, task_service};
 
 /// Fetch a task and verify the user is a member of its project.
@@ -38,20 +39,11 @@ pub async fn require_project_member(
         return Ok(MemberRole::Owner);
     }
 
-    let row = sqlx::query_scalar::<_, String>(
-        r#"
-        SELECT role FROM project_members
-        WHERE project_id = $1 AND user_id = $2
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(user_id.to_string())
-    .fetch_optional(pool)
-    .await?;
+    let role_str = member_repository::find_role(pool, project_id, user_id).await?;
 
-    match row {
-        Some(role_str) => {
-            let role: MemberRole = serde_json::from_value(serde_json::Value::String(role_str))
+    match role_str {
+        Some(s) => {
+            let role: MemberRole = serde_json::from_value(serde_json::Value::String(s))
                 .map_err(|e| AppError::Internal(e.to_string()))?;
             Ok(role)
         }
@@ -103,14 +95,7 @@ pub async fn require_any_project_membership(pool: &SqlitePool, user_id: Uuid) ->
         return Ok(());
     }
 
-    let count = sqlx::query_scalar::<_, i32>(
-        "SELECT COUNT(*) FROM project_members WHERE user_id = $1 LIMIT 1",
-    )
-    .bind(user_id.to_string())
-    .fetch_one(pool)
-    .await?;
-
-    if count == 0 {
+    if !member_repository::has_any_membership(pool, user_id).await? {
         return Err(AppError::Forbidden(
             "user is not a member of any project".to_string(),
         ));
@@ -120,37 +105,12 @@ pub async fn require_any_project_membership(pool: &SqlitePool, user_id: Uuid) ->
 
 /// List project IDs the user is a member of.
 pub async fn list_user_project_ids(pool: &SqlitePool, user_id: Uuid) -> AppResult<Vec<Uuid>> {
-    let rows = sqlx::query_scalar::<_, String>(
-        r#"
-        SELECT project_id FROM project_members
-        WHERE user_id = $1
-        "#,
-    )
-    .bind(user_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|s| {
-            s.parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-        })
-        .collect()
+    member_repository::list_project_ids_by_user(pool, user_id).await
 }
 
 /// Count owners in a project.
 pub async fn count_owners(pool: &SqlitePool, project_id: Uuid) -> AppResult<i64> {
-    let count = sqlx::query_scalar::<_, i32>(
-        r#"
-        SELECT COUNT(*) FROM project_members
-        WHERE project_id = $1 AND role = 'owner'
-        "#,
-    )
-    .bind(project_id.to_string())
-    .fetch_one(pool)
-    .await?;
-
-    Ok(count as i64)
+    member_repository::count_owners(pool, project_id).await
 }
 
 #[cfg(test)]

--- a/backend/src/services/authorization_service.rs
+++ b/backend/src/services/authorization_service.rs
@@ -39,19 +39,14 @@ pub async fn require_project_member(
         return Ok(MemberRole::Owner);
     }
 
-    let role_str = member_repository::find_role(pool, project_id, user_id).await?;
-
-    match role_str {
-        Some(s) => {
-            let role: MemberRole = serde_json::from_value(serde_json::Value::String(s))
-                .map_err(|e| AppError::Internal(e.to_string()))?;
-            Ok(role)
-        }
-        None => Err(AppError::Forbidden(format!(
-            "user {} is not a member of project {}",
-            user_id, project_id
-        ))),
-    }
+    member_repository::find_role(pool, project_id, user_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::Forbidden(format!(
+                "user {} is not a member of project {}",
+                user_id, project_id
+            ))
+        })
 }
 
 /// Check if user has Owner or Admin role in the project.

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -1,35 +1,10 @@
-use chrono::{DateTime, Utc};
-use sqlx::prelude::FromRow;
+use chrono::Utc;
 use sqlx::{SqliteConnection, SqlitePool};
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
-use crate::models::project::{AddMemberRequest, MemberRole, ProjectMember, UpdateMemberRequest};
-
-#[derive(FromRow)]
-struct MemberRow {
-    project_id: String,
-    user_id: String,
-    role: MemberRole,
-    user_name: String,
-    user_email: String,
-    created_at: DateTime<Utc>,
-}
-
-impl TryFrom<MemberRow> for ProjectMember {
-    type Error = uuid::Error;
-
-    fn try_from(row: MemberRow) -> Result<Self, Self::Error> {
-        Ok(ProjectMember {
-            project_id: row.project_id.parse()?,
-            user_id: row.user_id.parse()?,
-            role: row.role,
-            user_name: row.user_name,
-            user_email: row.user_email,
-            created_at: row.created_at,
-        })
-    }
-}
+use crate::models::project::{AddMemberRequest, ProjectMember, UpdateMemberRequest};
+use crate::repositories::member_repository;
 
 #[tracing::instrument(skip(pool, req), fields(%project_id, user_id = %req.user_id))]
 #[allow(clippy::explicit_auto_deref)] // sqlx Transaction requires explicit deref
@@ -41,11 +16,7 @@ pub async fn add_member(
     let mut tx = pool.begin().await?;
 
     // Validate that the user exists within the transaction
-    let user_exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
-        .bind(req.user_id.to_string())
-        .fetch_optional(&mut *tx)
-        .await?;
-    if user_exists.is_none() {
+    if !member_repository::user_exists_tx(&mut *tx, req.user_id).await? {
         return Err(AppError::NotFound(format!(
             "user {} not found",
             req.user_id
@@ -53,19 +24,7 @@ pub async fn add_member(
     }
 
     let now = Utc::now();
-
-    sqlx::query(
-        r#"
-        INSERT INTO project_members (project_id, user_id, role, created_at)
-        VALUES ($1, $2, $3, $4)
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(req.user_id.to_string())
-    .bind(&req.role)
-    .bind(now)
-    .execute(&mut *tx)
-    .await?;
+    member_repository::insert_tx(&mut *tx, project_id, req.user_id, &req.role, now).await?;
 
     tx.commit().await?;
 
@@ -78,11 +37,7 @@ pub async fn add_member_tx(
     project_id: Uuid,
     req: &AddMemberRequest,
 ) -> AppResult<()> {
-    let user_exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
-        .bind(req.user_id.to_string())
-        .fetch_optional(&mut *conn)
-        .await?;
-    if user_exists.is_none() {
+    if !member_repository::user_exists_tx(&mut *conn, req.user_id).await? {
         return Err(AppError::NotFound(format!(
             "user {} not found",
             req.user_id
@@ -90,21 +45,7 @@ pub async fn add_member_tx(
     }
 
     let now = Utc::now();
-
-    sqlx::query(
-        r#"
-        INSERT INTO project_members (project_id, user_id, role, created_at)
-        VALUES ($1, $2, $3, $4)
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(req.user_id.to_string())
-    .bind(&req.role)
-    .bind(now)
-    .execute(&mut *conn)
-    .await?;
-
-    Ok(())
+    member_repository::insert_tx(&mut *conn, project_id, req.user_id, &req.role, now).await
 }
 
 pub async fn get_member(
@@ -112,24 +53,8 @@ pub async fn get_member(
     project_id: Uuid,
     user_id: Uuid,
 ) -> AppResult<ProjectMember> {
-    let row = sqlx::query_as::<_, MemberRow>(
-        r#"
-        SELECT pm.project_id, pm.user_id, pm.role,
-               u.name as user_name, u.email as user_email,
-               pm.created_at
-        FROM project_members pm
-        JOIN users u ON pm.user_id = u.id
-        WHERE pm.project_id = $1 AND pm.user_id = $2
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(user_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
+    member_repository::find_by_project_and_user(pool, project_id, user_id)
+        .await?
         .ok_or_else(|| {
             AppError::NotFound(format!(
                 "member {} not found in project {}",
@@ -139,25 +64,7 @@ pub async fn get_member(
 }
 
 pub async fn list_members(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<ProjectMember>> {
-    let rows = sqlx::query_as::<_, MemberRow>(
-        r#"
-        SELECT pm.project_id, pm.user_id, pm.role,
-               u.name as user_name, u.email as user_email,
-               pm.created_at
-        FROM project_members pm
-        JOIN users u ON pm.user_id = u.id
-        WHERE pm.project_id = $1
-        ORDER BY pm.created_at ASC
-        "#,
-    )
-    .bind(project_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    member_repository::find_all_by_project(pool, project_id).await
 }
 
 #[tracing::instrument(skip(pool, req), fields(%project_id, %user_id))]
@@ -170,36 +77,16 @@ pub async fn update_member_role(
     // Verify member exists
     get_member(pool, project_id, user_id).await?;
 
-    sqlx::query(
-        r#"
-        UPDATE project_members
-        SET role = $1
-        WHERE project_id = $2 AND user_id = $3
-        "#,
-    )
-    .bind(&req.role)
-    .bind(project_id.to_string())
-    .bind(user_id.to_string())
-    .execute(pool)
-    .await?;
+    member_repository::update_role(pool, project_id, user_id, &req.role).await?;
 
     get_member(pool, project_id, user_id).await
 }
 
 #[tracing::instrument(skip(pool), fields(%project_id, %user_id))]
 pub async fn remove_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) -> AppResult<()> {
-    let result = sqlx::query(
-        r#"
-        DELETE FROM project_members
-        WHERE project_id = $1 AND user_id = $2
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(user_id.to_string())
-    .execute(pool)
-    .await?;
+    let rows = member_repository::delete(pool, project_id, user_id).await?;
 
-    if result.rows_affected() == 0 {
+    if rows == 0 {
         return Err(AppError::NotFound(format!(
             "member {} not found in project {}",
             user_id, project_id
@@ -212,7 +99,7 @@ pub async fn remove_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::project::CreateProjectRequest;
+    use crate::models::project::{CreateProjectRequest, MemberRole};
     use crate::models::user::RegisterRequest;
     use crate::services::{project_service, user_service};
     use crate::test_helpers::setup_test_db;
@@ -423,7 +310,6 @@ mod tests {
         let project_id = create_test_project(&pool).await;
         let nonexistent_user = Uuid::new_v4();
 
-        // Attempt to add a nonexistent user as a member — should fail
         let result = add_member(
             &pool,
             project_id,
@@ -436,7 +322,6 @@ mod tests {
 
         assert!(result.is_err());
 
-        // Verify no member row was created (atomicity guarantee)
         let members = list_members(&pool, project_id)
             .await
             .expect("list should succeed");

--- a/backend/src/services/member_service.rs
+++ b/backend/src/services/member_service.rs
@@ -16,7 +16,7 @@ pub async fn add_member(
     let mut tx = pool.begin().await?;
 
     // Validate that the user exists within the transaction
-    if !member_repository::user_exists_tx(&mut *tx, req.user_id).await? {
+    if !member_repository::user_exists_tx(&mut tx, req.user_id).await? {
         return Err(AppError::NotFound(format!(
             "user {} not found",
             req.user_id
@@ -24,7 +24,7 @@ pub async fn add_member(
     }
 
     let now = Utc::now();
-    member_repository::insert_tx(&mut *tx, project_id, req.user_id, &req.role, now).await?;
+    member_repository::insert_tx(&mut tx, project_id, req.user_id, &req.role, now).await?;
 
     tx.commit().await?;
 

--- a/backend/src/services/session_service.rs
+++ b/backend/src/services/session_service.rs
@@ -73,13 +73,13 @@ pub async fn rotate_session(
 ) -> AppResult<Session> {
     let mut tx = pool.begin().await?;
 
-    session_repository::delete_by_user_id_tx(&mut *tx, user_id).await?;
+    session_repository::delete_by_user_id_tx(&mut tx, user_id).await?;
 
     let id = Uuid::new_v4();
     let now = Utc::now();
     let expires_at = now + Duration::hours(duration_hours as i64);
 
-    session_repository::insert_tx(&mut *tx, id, user_id, now, expires_at).await?;
+    session_repository::insert_tx(&mut tx, id, user_id, now, expires_at).await?;
 
     tx.commit().await?;
 

--- a/backend/src/services/session_service.rs
+++ b/backend/src/services/session_service.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::user::Session;
+use crate::repositories::session_repository;
 
 /// Create a new session for a user
 pub async fn create_session(
@@ -15,19 +16,7 @@ pub async fn create_session(
     let now = Utc::now();
     let expires_at = now + Duration::hours(duration_hours as i64);
 
-    sqlx::query(
-        r#"
-        INSERT INTO sessions (id, user_id, created_at, expires_at, last_active_at)
-        VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(user_id.to_string())
-    .bind(now)
-    .bind(expires_at)
-    .bind(now)
-    .execute(pool)
-    .await?;
+    session_repository::insert(pool, id, user_id, now, expires_at).await?;
 
     Ok(Session {
         id: id.to_string(),
@@ -41,20 +30,7 @@ pub async fn create_session(
 /// Get session by ID, returns None if not found or expired
 pub async fn get_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<Option<Session>> {
     let now = Utc::now();
-
-    let session = sqlx::query_as::<_, Session>(
-        r#"
-        SELECT id, user_id, created_at, expires_at, last_active_at
-        FROM sessions
-        WHERE id = $1 AND expires_at > $2
-        "#,
-    )
-    .bind(session_id.to_string())
-    .bind(now)
-    .fetch_optional(pool)
-    .await?;
-
-    Ok(session)
+    session_repository::find_by_id_not_expired(pool, session_id, now).await
 }
 
 /// Validate and update session's last_active_at timestamp
@@ -65,19 +41,8 @@ pub async fn validate_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<
 
     match session {
         Some(sess) => {
-            // Update last_active_at
             let now = Utc::now();
-            sqlx::query(
-                r#"
-                UPDATE sessions
-                SET last_active_at = $1
-                WHERE id = $2
-                "#,
-            )
-            .bind(now)
-            .bind(session_id.to_string())
-            .execute(pool)
-            .await?;
+            session_repository::update_last_active_at(pool, session_id, now).await?;
 
             Ok(Session {
                 last_active_at: now,
@@ -90,32 +55,12 @@ pub async fn validate_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<
 
 /// Delete a session (logout)
 pub async fn delete_session(pool: &SqlitePool, session_id: Uuid) -> AppResult<()> {
-    sqlx::query(
-        r#"
-        DELETE FROM sessions
-        WHERE id = $1
-        "#,
-    )
-    .bind(session_id.to_string())
-    .execute(pool)
-    .await?;
-
-    Ok(())
+    session_repository::delete_by_id(pool, session_id).await
 }
 
 /// Delete all sessions for a user
 pub async fn delete_user_sessions(pool: &SqlitePool, user_id: Uuid) -> AppResult<()> {
-    sqlx::query(
-        r#"
-        DELETE FROM sessions
-        WHERE user_id = $1
-        "#,
-    )
-    .bind(user_id.to_string())
-    .execute(pool)
-    .await?;
-
-    Ok(())
+    session_repository::delete_by_user_id(pool, user_id).await
 }
 
 /// Delete all sessions for a user and create a new one atomically.
@@ -128,28 +73,13 @@ pub async fn rotate_session(
 ) -> AppResult<Session> {
     let mut tx = pool.begin().await?;
 
-    sqlx::query("DELETE FROM sessions WHERE user_id = $1")
-        .bind(user_id.to_string())
-        .execute(&mut *tx)
-        .await?;
+    session_repository::delete_by_user_id_tx(&mut *tx, user_id).await?;
 
     let id = Uuid::new_v4();
     let now = Utc::now();
     let expires_at = now + Duration::hours(duration_hours as i64);
 
-    sqlx::query(
-        r#"
-        INSERT INTO sessions (id, user_id, created_at, expires_at, last_active_at)
-        VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(user_id.to_string())
-    .bind(now)
-    .bind(expires_at)
-    .bind(now)
-    .execute(&mut *tx)
-    .await?;
+    session_repository::insert_tx(&mut *tx, id, user_id, now, expires_at).await?;
 
     tx.commit().await?;
 
@@ -165,18 +95,7 @@ pub async fn rotate_session(
 /// Clean up expired sessions
 pub async fn cleanup_expired_sessions(pool: &SqlitePool) -> AppResult<u64> {
     let now = Utc::now();
-
-    let result = sqlx::query(
-        r#"
-        DELETE FROM sessions
-        WHERE expires_at <= $1
-        "#,
-    )
-    .bind(now)
-    .execute(pool)
-    .await?;
-
-    Ok(result.rows_affected())
+    session_repository::delete_expired(pool, now).await
 }
 
 #[cfg(test)]
@@ -190,7 +109,7 @@ mod tests {
         let req = RegisterRequest {
             email: format!("test-{}@example.com", Uuid::new_v4()),
             name: "Test User".to_string(),
-            password: "password123".to_string(),
+            password: "correct horse battery staple purple".to_string(),
         };
         let user = user_service::create_user(pool, &req)
             .await

--- a/backend/src/services/task_service/mod.rs
+++ b/backend/src/services/task_service/mod.rs
@@ -1,49 +1,13 @@
-use chrono::{DateTime, Utc};
-use sqlx::prelude::FromRow;
 use sqlx::sqlite::SqliteConnection;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::task::{CreateTaskRequest, Task, TaskPriority, TaskStatus, UpdateTaskRequest};
+use crate::repositories::task_repository;
 
 #[cfg(test)]
 mod tests;
-
-#[derive(FromRow)]
-struct TaskRow {
-    id: String,
-    project_id: String,
-    title: String,
-    description: Option<String>,
-    status: TaskStatus,
-    priority: TaskPriority,
-    parent_id: Option<String>,
-    assigned_to: Option<String>,
-    position: i32,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<TaskRow> for Task {
-    type Error = uuid::Error;
-
-    fn try_from(row: TaskRow) -> Result<Self, Self::Error> {
-        Ok(Task {
-            id: row.id.parse()?,
-            project_id: row.project_id.parse()?,
-            title: row.title,
-            description: row.description,
-            status: row.status,
-            priority: row.priority,
-            parent_id: row.parent_id.map(|s| s.parse()).transpose()?,
-            assigned_to: row.assigned_to.map(|s| s.parse()).transpose()?,
-            position: row.position,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
 
 #[tracing::instrument(skip(pool, req), fields(project_id = %req.project_id))]
 #[allow(clippy::explicit_auto_deref)] // sqlx Transaction requires explicit deref
@@ -53,29 +17,23 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
     validate_assigned_to_tx(&mut *tx, req.assigned_to, req.project_id).await?;
     validate_parent_project_tx(&mut *tx, req.parent_id, req.project_id).await?;
 
-    let id = Uuid::new_v4();
-    let now = Utc::now();
+    let id = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now();
     let status = req.status.clone().unwrap_or(TaskStatus::Backlog);
     let priority = req.priority.clone().unwrap_or(TaskPriority::Medium);
 
-    sqlx::query(
-        r#"
-        INSERT INTO tasks (id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-        "#,
+    task_repository::insert_tx(
+        &mut *tx,
+        id,
+        req.project_id,
+        &req.title,
+        req.description.as_deref(),
+        &status,
+        &priority,
+        req.parent_id,
+        req.assigned_to,
+        now,
     )
-    .bind(id.to_string())
-    .bind(req.project_id.to_string())
-    .bind(&req.title)
-    .bind(&req.description)
-    .bind(&status)
-    .bind(&priority)
-    .bind(req.parent_id.map(|u| u.to_string()))
-    .bind(req.assigned_to.map(|u| u.to_string()))
-    .bind(0i32)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *tx)
     .await?;
 
     tx.commit().await?;
@@ -96,40 +54,11 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
 }
 
 pub async fn get_task(pool: &SqlitePool, id: Uuid) -> AppResult<Task> {
-    let row = sqlx::query_as::<_, TaskRow>(
-        r#"
-        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
-        FROM tasks
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound(format!("task {} not found", id)))
+    task_repository::find_by_id(pool, id).await
 }
 
 pub async fn list_tasks(pool: &SqlitePool, project_id: Uuid) -> AppResult<Vec<Task>> {
-    let rows = sqlx::query_as::<_, TaskRow>(
-        r#"
-        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
-        FROM tasks
-        WHERE project_id = $1
-        ORDER BY position ASC, created_at ASC
-        "#,
-    )
-    .bind(project_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    task_repository::find_all_by_project(pool, project_id).await
 }
 
 pub async fn list_tasks_paginated(
@@ -138,37 +67,10 @@ pub async fn list_tasks_paginated(
     limit: i64,
     offset: i64,
 ) -> AppResult<(Vec<Task>, i64)> {
-    let total: (i64,) = sqlx::query_as(
-        r#"
-        SELECT COUNT(*) FROM tasks WHERE project_id = $1
-        "#,
-    )
-    .bind(project_id.to_string())
-    .fetch_one(pool)
-    .await?;
+    let total = task_repository::count_by_project(pool, project_id).await?;
+    let tasks = task_repository::find_paginated_by_project(pool, project_id, limit, offset).await?;
 
-    let rows = sqlx::query_as::<_, TaskRow>(
-        r#"
-        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
-        FROM tasks
-        WHERE project_id = $1
-        ORDER BY position ASC, created_at ASC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(project_id.to_string())
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
-
-    let tasks = rows
-        .into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?;
-
-    Ok((tasks, total.0))
+    Ok((tasks, total))
 }
 
 #[tracing::instrument(skip(pool, req), fields(task_id = %id))]
@@ -176,12 +78,12 @@ pub async fn list_tasks_paginated(
 pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 
-    let existing = get_task_tx(&mut *tx, id).await?;
+    let existing = task_repository::find_by_id_tx(&mut *tx, id).await?;
 
     validate_assigned_to_tx(&mut *tx, req.assigned_to, existing.project_id).await?;
     validate_parent_project_tx(&mut *tx, req.parent_id, existing.project_id).await?;
 
-    let now = Utc::now();
+    let now = chrono::Utc::now();
 
     let title = req.title.as_ref().unwrap_or(&existing.title);
     let description = req.description.as_ref().or(existing.description.as_ref());
@@ -194,23 +96,18 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     // Track status change for metrics
     let status_changed = *status != existing.status;
 
-    sqlx::query(
-        r#"
-        UPDATE tasks
-        SET title = $1, description = $2, status = $3, priority = $4, parent_id = $5, assigned_to = $6, position = $7, updated_at = $8
-        WHERE id = $9
-        "#,
+    task_repository::update_tx(
+        &mut *tx,
+        id,
+        title,
+        description.map(|s| s.as_str()),
+        status,
+        priority,
+        parent_id,
+        assigned_to,
+        position,
+        now,
     )
-    .bind(title)
-    .bind(description)
-    .bind(status)
-    .bind(priority)
-    .bind(parent_id.map(|u| u.to_string()))
-    .bind(assigned_to.map(|u| u.to_string()))
-    .bind(position)
-    .bind(now)
-    .bind(id.to_string())
-    .execute(&mut *tx)
     .await?;
 
     tx.commit().await?;
@@ -243,48 +140,20 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     })
 }
 
-async fn get_task_tx(conn: &mut SqliteConnection, id: Uuid) -> AppResult<Task> {
-    let row = sqlx::query_as::<_, TaskRow>(
-        r#"
-        SELECT id, project_id, title, description, status, priority, parent_id, assigned_to, position, created_at, updated_at
-        FROM tasks
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .fetch_optional(&mut *conn)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound(format!("task {} not found", id)))
-}
-
 async fn validate_assigned_to_tx(
     conn: &mut SqliteConnection,
     assigned_to: Option<Uuid>,
     project_id: Uuid,
 ) -> AppResult<()> {
     if let Some(user_id) = assigned_to {
-        let exists: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
-            .bind(user_id.to_string())
-            .fetch_optional(&mut *conn)
-            .await?;
-        if exists.is_none() {
+        if !task_repository::user_exists_tx(&mut *conn, user_id).await? {
             return Err(AppError::Validation(format!(
                 "assigned user {} does not exist",
                 user_id
             )));
         }
 
-        let is_member: Option<(i32,)> =
-            sqlx::query_as("SELECT 1 FROM project_members WHERE project_id = $1 AND user_id = $2")
-                .bind(project_id.to_string())
-                .bind(user_id.to_string())
-                .fetch_optional(&mut *conn)
-                .await?;
-        if is_member.is_none() {
+        if !task_repository::is_project_member_tx(&mut *conn, project_id, user_id).await? {
             return Err(AppError::Validation(format!(
                 "assigned user {} is not a member of project {}",
                 user_id, project_id
@@ -300,12 +169,14 @@ async fn validate_parent_project_tx(
     project_id: Uuid,
 ) -> AppResult<()> {
     if let Some(pid) = parent_id {
-        let parent = get_task_tx(&mut *conn, pid).await.map_err(|e| match e {
-            AppError::NotFound(_) => {
-                AppError::Validation(format!("parent task {} does not exist", pid))
-            }
-            other => other,
-        })?;
+        let parent = task_repository::find_by_id_tx(&mut *conn, pid)
+            .await
+            .map_err(|e| match e {
+                AppError::NotFound(_) => {
+                    AppError::Validation(format!("parent task {} does not exist", pid))
+                }
+                other => other,
+            })?;
         if parent.project_id != project_id {
             return Err(AppError::Validation(
                 "parent task must belong to the same project".to_string(),
@@ -317,19 +188,5 @@ async fn validate_parent_project_tx(
 
 #[tracing::instrument(skip(pool), fields(task_id = %id))]
 pub async fn delete_task(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
-    let result = sqlx::query(
-        r#"
-        DELETE FROM tasks
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .execute(pool)
-    .await?;
-
-    if result.rows_affected() == 0 {
-        return Err(AppError::NotFound(format!("task {} not found", id)));
-    }
-
-    Ok(())
+    task_repository::delete(pool, id).await
 }

--- a/backend/src/services/task_service/mod.rs
+++ b/backend/src/services/task_service/mod.rs
@@ -14,8 +14,8 @@ mod tests;
 pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 
-    validate_assigned_to_tx(&mut *tx, req.assigned_to, req.project_id).await?;
-    validate_parent_project_tx(&mut *tx, req.parent_id, req.project_id).await?;
+    validate_assigned_to_tx(&mut tx, req.assigned_to, req.project_id).await?;
+    validate_parent_project_tx(&mut tx, req.parent_id, req.project_id).await?;
 
     let id = uuid::Uuid::new_v4();
     let now = chrono::Utc::now();
@@ -23,7 +23,7 @@ pub async fn create_task(pool: &SqlitePool, req: &CreateTaskRequest) -> AppResul
     let priority = req.priority.clone().unwrap_or(TaskPriority::Medium);
 
     task_repository::insert_tx(
-        &mut *tx,
+        &mut tx,
         id,
         req.project_id,
         &req.title,
@@ -78,10 +78,10 @@ pub async fn list_tasks_paginated(
 pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -> AppResult<Task> {
     let mut tx = pool.begin().await?;
 
-    let existing = task_repository::find_by_id_tx(&mut *tx, id).await?;
+    let existing = task_repository::find_by_id_tx(&mut tx, id).await?;
 
-    validate_assigned_to_tx(&mut *tx, req.assigned_to, existing.project_id).await?;
-    validate_parent_project_tx(&mut *tx, req.parent_id, existing.project_id).await?;
+    validate_assigned_to_tx(&mut tx, req.assigned_to, existing.project_id).await?;
+    validate_parent_project_tx(&mut tx, req.parent_id, existing.project_id).await?;
 
     let now = chrono::Utc::now();
 
@@ -97,7 +97,7 @@ pub async fn update_task(pool: &SqlitePool, id: Uuid, req: &UpdateTaskRequest) -
     let status_changed = *status != existing.status;
 
     task_repository::update_tx(
-        &mut *tx,
+        &mut tx,
         id,
         title,
         description.map(|s| s.as_str()),


### PR DESCRIPTION
## Summary

Resolves part of #325 — extracts repository pattern for core domain services.

- Extract `session_repository` from `session_service` (8 DB functions)
- Extract `task_repository` from `task_service` (10 DB functions)
- Extract `member_repository` from `member_service` + `authorization_service` (10 DB functions)

Each repository follows a consistent pattern:
- `Row` struct with `#[derive(FromRow)]` + `TryFrom` for domain model conversion
- Pure DB operations only; business logic (validation, auth, transactions) remains in services
- `_tx` suffix functions accept `&mut SqliteConnection` for transaction-aware calls

## Test plan

- [x] All 511 tests pass (`cargo test --lib`)
- [x] No new clippy warnings on changed files
- [x] Repository tests cover insert, find, update, delete, and edge cases

> **Note**: This is PR 1/3 of the repository pattern extraction. PRs 2 and 3 build on this branch.