### PR TITLE
refactor: ♻️ extract github, comment, message repositories (2/3)

### DIFF
--- a/backend/src/repositories/github_pr_repository.rs
+++ b/backend/src/repositories/github_pr_repository.rs
@@ -1,0 +1,498 @@
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::github::{GitHubPullRequest, PrState};
+
+#[derive(FromRow)]
+struct PrRow {
+    id: String,
+    github_link_id: String,
+    task_id: String,
+    pr_number: i64,
+    title: String,
+    url: String,
+    state: String,
+    is_merged: bool,
+    author: Option<String>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<PrRow> for GitHubPullRequest {
+    type Error = uuid::Error;
+
+    fn try_from(row: PrRow) -> Result<Self, Self::Error> {
+        let state = match row.state.as_str() {
+            "closed" => PrState::Closed,
+            _ => PrState::Open,
+        };
+        Ok(GitHubPullRequest {
+            id: row.id.parse()?,
+            github_link_id: row.github_link_id.parse()?,
+            task_id: row.task_id.parse()?,
+            pr_number: row.pr_number,
+            title: row.title,
+            url: row.url,
+            state,
+            is_merged: row.is_merged,
+            author: row.author,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+fn row_to_pr(row: PrRow) -> AppResult<GitHubPullRequest> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+/// Upsert a pull request linked to a task.
+/// Inserts a new record or updates an existing one (matched by github_link_id + pr_number + task_id).
+#[allow(clippy::too_many_arguments)]
+pub async fn upsert(
+    pool: &SqlitePool,
+    id: Uuid,
+    github_link_id: Uuid,
+    task_id: Uuid,
+    pr_number: i64,
+    title: &str,
+    url: &str,
+    state: &str,
+    is_merged: bool,
+    author: Option<&str>,
+) -> AppResult<GitHubPullRequest> {
+    let db_state = match state {
+        "closed" => "closed",
+        _ => "open",
+    };
+
+    sqlx::query(
+        r#"
+        INSERT INTO github_pull_requests (id, github_link_id, task_id, pr_number, title, url, state, is_merged, author)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        ON CONFLICT (github_link_id, pr_number, task_id) DO UPDATE SET
+            title = excluded.title,
+            url = excluded.url,
+            state = excluded.state,
+            is_merged = excluded.is_merged,
+            author = excluded.author,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(github_link_id.to_string())
+    .bind(task_id.to_string())
+    .bind(pr_number)
+    .bind(title)
+    .bind(url)
+    .bind(db_state)
+    .bind(is_merged)
+    .bind(author)
+    .execute(pool)
+    .await?;
+
+    let row = sqlx::query_as::<_, PrRow>(
+        r#"
+        SELECT id, github_link_id, task_id, pr_number, title, url, state, is_merged, author, created_at, updated_at
+        FROM github_pull_requests
+        WHERE github_link_id = $1 AND pr_number = $2 AND task_id = $3
+        "#,
+    )
+    .bind(github_link_id.to_string())
+    .bind(pr_number)
+    .bind(task_id.to_string())
+    .fetch_one(pool)
+    .await?;
+
+    row_to_pr(row)
+}
+
+/// Find a specific pull request by link, PR number, and task.
+pub async fn find_by_link_and_pr(
+    pool: &SqlitePool,
+    github_link_id: Uuid,
+    pr_number: i64,
+    task_id: Uuid,
+) -> AppResult<Option<GitHubPullRequest>> {
+    let row = sqlx::query_as::<_, PrRow>(
+        r#"
+        SELECT id, github_link_id, task_id, pr_number, title, url, state, is_merged, author, created_at, updated_at
+        FROM github_pull_requests
+        WHERE github_link_id = $1 AND pr_number = $2 AND task_id = $3
+        "#,
+    )
+    .bind(github_link_id.to_string())
+    .bind(pr_number)
+    .bind(task_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_pr).transpose()
+}
+
+/// List all pull requests linked to a task.
+pub async fn find_all_by_task(
+    pool: &SqlitePool,
+    task_id: Uuid,
+) -> AppResult<Vec<GitHubPullRequest>> {
+    let rows = sqlx::query_as::<_, PrRow>(
+        r#"
+        SELECT id, github_link_id, task_id, pr_number, title, url, state, is_merged, author, created_at, updated_at
+        FROM github_pull_requests
+        WHERE task_id = $1
+        ORDER BY pr_number
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_pr).collect()
+}
+
+/// Find task IDs linked to a specific PR number within a github_link.
+pub async fn find_task_ids_by_pr(
+    pool: &SqlitePool,
+    github_link_id: Uuid,
+    pr_number: i64,
+) -> AppResult<Vec<Uuid>> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT task_id FROM github_pull_requests WHERE github_link_id = $1 AND pr_number = $2",
+    )
+    .bind(github_link_id.to_string())
+    .bind(pr_number)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|(id,)| {
+            id.parse::<Uuid>()
+                .map_err(|e| AppError::Internal(e.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn setup_db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("Failed to create test database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+        pool
+    }
+
+    async fn create_project(pool: &SqlitePool) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query("INSERT INTO projects (id, name) VALUES ($1, $2)")
+            .bind(id.to_string())
+            .bind("test-project")
+            .execute(pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    async fn create_link(pool: &SqlitePool, project_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO github_links (id, project_id, repo_owner, repo_name) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(id.to_string())
+        .bind(project_id.to_string())
+        .bind("owner")
+        .bind("repo")
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    async fn create_task(pool: &SqlitePool, project_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tasks (id, project_id, title, status, priority, position) VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(id.to_string())
+        .bind(project_id.to_string())
+        .bind("Test Task")
+        .bind("todo")
+        .bind("medium")
+        .bind(0)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_upsert_creates_new_record() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let id = Uuid::new_v4();
+        let result = upsert(
+            &pool,
+            id,
+            link_id,
+            task_id,
+            42,
+            "PR #42",
+            "https://github.com/owner/repo/pull/42",
+            "open",
+            false,
+            Some("octocat"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.pr_number, 42);
+        assert_eq!(result.title, "PR #42");
+        assert_eq!(result.state, PrState::Open);
+        assert!(!result.is_merged);
+        assert_eq!(result.author.as_deref(), Some("octocat"));
+        assert_eq!(result.github_link_id, link_id);
+        assert_eq!(result.task_id, task_id);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_updates_existing_record() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let id = Uuid::new_v4();
+        let first = upsert(
+            &pool,
+            id,
+            link_id,
+            task_id,
+            42,
+            "PR #42",
+            "https://github.com/owner/repo/pull/42",
+            "open",
+            false,
+            Some("octocat"),
+        )
+        .await
+        .unwrap();
+
+        // Update with merged state
+        let second = upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_id,
+            42,
+            "PR #42 (merged)",
+            "https://github.com/owner/repo/pull/42",
+            "closed",
+            true,
+            Some("octocat"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(second.title, "PR #42 (merged)");
+        assert_eq!(second.state, PrState::Closed);
+        assert!(second.is_merged);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_link_and_pr() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_id,
+            42,
+            "PR #42",
+            "https://github.com/owner/repo/pull/42",
+            "open",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let found = find_by_link_and_pr(&pool, link_id, 42, task_id)
+            .await
+            .unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().pr_number, 42);
+
+        // Non-existent PR number
+        let not_found = find_by_link_and_pr(&pool, link_id, 999, task_id)
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_empty() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let prs = find_all_by_task(&pool, task_id).await.unwrap();
+        assert!(prs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_returns_linked_prs() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_id,
+            1,
+            "PR #1",
+            "https://github.com/owner/repo/pull/1",
+            "open",
+            false,
+            Some("octocat"),
+        )
+        .await
+        .unwrap();
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_id,
+            2,
+            "PR #2",
+            "https://github.com/owner/repo/pull/2",
+            "open",
+            false,
+            Some("octocat"),
+        )
+        .await
+        .unwrap();
+
+        let prs = find_all_by_task(&pool, task_id).await.unwrap();
+        assert_eq!(prs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_does_not_include_other_tasks() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_a = create_task(&pool, project_id).await;
+        let task_b = create_task(&pool, project_id).await;
+
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_a,
+            10,
+            "PR #10",
+            "https://github.com/owner/repo/pull/10",
+            "open",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_b,
+            20,
+            "PR #20",
+            "https://github.com/owner/repo/pull/20",
+            "open",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let prs_a = find_all_by_task(&pool, task_a).await.unwrap();
+        assert_eq!(prs_a.len(), 1);
+        assert_eq!(prs_a[0].pr_number, 10);
+
+        let prs_b = find_all_by_task(&pool, task_b).await.unwrap();
+        assert_eq!(prs_b.len(), 1);
+        assert_eq!(prs_b[0].pr_number, 20);
+    }
+
+    #[tokio::test]
+    async fn test_find_task_ids_by_pr() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_a = create_task(&pool, project_id).await;
+        let task_b = create_task(&pool, project_id).await;
+
+        // Same PR number linked to two different tasks
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_a,
+            42,
+            "PR #42",
+            "https://github.com/owner/repo/pull/42",
+            "open",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+        upsert(
+            &pool,
+            Uuid::new_v4(),
+            link_id,
+            task_b,
+            42,
+            "PR #42",
+            "https://github.com/owner/repo/pull/42",
+            "open",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let task_ids = find_task_ids_by_pr(&pool, link_id, 42).await.unwrap();
+        assert_eq!(task_ids.len(), 2);
+        assert!(task_ids.contains(&task_a));
+        assert!(task_ids.contains(&task_b));
+    }
+
+    #[tokio::test]
+    async fn test_find_task_ids_by_pr_empty() {
+        let pool = setup_db().await;
+        let task_ids = find_task_ids_by_pr(&pool, Uuid::new_v4(), 999)
+            .await
+            .unwrap();
+        assert!(task_ids.is_empty());
+    }
+}

--- a/backend/src/repositories/github_pr_repository.rs
+++ b/backend/src/repositories/github_pr_repository.rs
@@ -64,11 +64,6 @@ pub async fn upsert(
     is_merged: bool,
     author: Option<&str>,
 ) -> AppResult<GitHubPullRequest> {
-    let db_state = match state {
-        "closed" => "closed",
-        _ => "open",
-    };
-
     sqlx::query(
         r#"
         INSERT INTO github_pull_requests (id, github_link_id, task_id, pr_number, title, url, state, is_merged, author)
@@ -88,7 +83,7 @@ pub async fn upsert(
     .bind(pr_number)
     .bind(title)
     .bind(url)
-    .bind(db_state)
+    .bind(state)
     .bind(is_merged)
     .bind(author)
     .execute(pool)

--- a/backend/src/repositories/github_sync_repository.rs
+++ b/backend/src/repositories/github_sync_repository.rs
@@ -1,0 +1,375 @@
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::github::GitHubIssueMapping;
+
+#[derive(FromRow)]
+struct MappingRow {
+    id: String,
+    task_id: String,
+    github_link_id: String,
+    github_issue_number: i64,
+    github_issue_id: Option<i64>,
+    last_local_update: Option<DateTime<Utc>>,
+    last_remote_update: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+impl TryFrom<MappingRow> for GitHubIssueMapping {
+    type Error = uuid::Error;
+
+    fn try_from(row: MappingRow) -> Result<Self, Self::Error> {
+        Ok(GitHubIssueMapping {
+            id: row.id.parse()?,
+            task_id: row.task_id.parse()?,
+            github_link_id: row.github_link_id.parse()?,
+            github_issue_number: row.github_issue_number,
+            github_issue_id: row.github_issue_id,
+            last_local_update: row.last_local_update,
+            last_remote_update: row.last_remote_update,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn row_to_mapping(row: MappingRow) -> AppResult<GitHubIssueMapping> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+/// Insert a new GitHub issue mapping.
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    task_id: Uuid,
+    github_link_id: Uuid,
+    issue_number: i64,
+    issue_id: Option<i64>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO github_issue_mappings (id, task_id, github_link_id, github_issue_number, github_issue_id)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .bind(github_link_id.to_string())
+    .bind(issue_number)
+    .bind(issue_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Find a mapping by its ID.
+pub async fn find_by_id(pool: &SqlitePool, id: Uuid) -> AppResult<GitHubIssueMapping> {
+    let row = sqlx::query_as::<_, MappingRow>(
+        r#"
+        SELECT id, task_id, github_link_id, github_issue_number, github_issue_id,
+               last_local_update, last_remote_update, created_at
+        FROM github_issue_mappings
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(r) => row_to_mapping(r),
+        None => Err(AppError::NotFound(format!(
+            "github issue mapping {} not found",
+            id
+        ))),
+    }
+}
+
+/// Find a mapping by task ID (returns Option since a task may not have a mapping).
+pub async fn find_by_task_id(
+    pool: &SqlitePool,
+    task_id: Uuid,
+) -> AppResult<Option<GitHubIssueMapping>> {
+    let row = sqlx::query_as::<_, MappingRow>(
+        r#"
+        SELECT id, task_id, github_link_id, github_issue_number, github_issue_id,
+               last_local_update, last_remote_update, created_at
+        FROM github_issue_mappings
+        WHERE task_id = $1
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_mapping).transpose()
+}
+
+/// Find a mapping by GitHub link ID and issue number (returns Option).
+pub async fn find_by_issue_number(
+    pool: &SqlitePool,
+    github_link_id: Uuid,
+    issue_number: i64,
+) -> AppResult<Option<GitHubIssueMapping>> {
+    let row = sqlx::query_as::<_, MappingRow>(
+        r#"
+        SELECT id, task_id, github_link_id, github_issue_number, github_issue_id,
+               last_local_update, last_remote_update, created_at
+        FROM github_issue_mappings
+        WHERE github_link_id = $1 AND github_issue_number = $2
+        "#,
+    )
+    .bind(github_link_id.to_string())
+    .bind(issue_number)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_mapping).transpose()
+}
+
+/// Find all mappings for a given GitHub link.
+pub async fn find_all_by_link(
+    pool: &SqlitePool,
+    github_link_id: Uuid,
+) -> AppResult<Vec<GitHubIssueMapping>> {
+    let rows = sqlx::query_as::<_, MappingRow>(
+        r#"
+        SELECT id, task_id, github_link_id, github_issue_number, github_issue_id,
+               last_local_update, last_remote_update, created_at
+        FROM github_issue_mappings
+        WHERE github_link_id = $1
+        "#,
+    )
+    .bind(github_link_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_mapping).collect()
+}
+
+/// Update the local and remote timestamps on a mapping.
+pub async fn update_timestamps(
+    pool: &SqlitePool,
+    mapping_id: Uuid,
+    last_local_update: Option<DateTime<Utc>>,
+    last_remote_update: Option<DateTime<Utc>>,
+) -> AppResult<()> {
+    let result = sqlx::query(
+        r#"
+        UPDATE github_issue_mappings
+        SET last_local_update = $2, last_remote_update = $3
+        WHERE id = $1
+        "#,
+    )
+    .bind(mapping_id.to_string())
+    .bind(last_local_update)
+    .bind(last_remote_update)
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!(
+            "github issue mapping {} not found",
+            mapping_id
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn setup_db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("Failed to create test database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+        pool
+    }
+
+    /// Helper: create a project and return its ID.
+    async fn create_project(pool: &SqlitePool) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query("INSERT INTO projects (id, name) VALUES ($1, $2)")
+            .bind(id.to_string())
+            .bind("test-project")
+            .execute(pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    /// Helper: create a github_link and return its ID.
+    async fn create_link(pool: &SqlitePool, project_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO github_links (id, project_id, repo_owner, repo_name) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(id.to_string())
+        .bind(project_id.to_string())
+        .bind("owner")
+        .bind("repo")
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Helper: create a task and return its ID.
+    async fn create_task(pool: &SqlitePool, project_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO tasks (id, project_id, title, status, priority, position) VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(id.to_string())
+        .bind(project_id.to_string())
+        .bind("Test Task")
+        .bind("todo")
+        .bind("medium")
+        .bind(0)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let id = Uuid::new_v4();
+        insert(&pool, id, task_id, link_id, 42, Some(12345))
+            .await
+            .unwrap();
+
+        let mapping = find_by_id(&pool, id).await.unwrap();
+        assert_eq!(mapping.id, id);
+        assert_eq!(mapping.task_id, task_id);
+        assert_eq!(mapping.github_link_id, link_id);
+        assert_eq!(mapping.github_issue_number, 42);
+        assert_eq!(mapping.github_issue_id, Some(12345));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_found() {
+        let pool = setup_db().await;
+        let result = find_by_id(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_task_id() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let id = Uuid::new_v4();
+        insert(&pool, id, task_id, link_id, 42, Some(12345))
+            .await
+            .unwrap();
+
+        let found = find_by_task_id(&pool, task_id).await.unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.id, id);
+        assert_eq!(found.task_id, task_id);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_task_id_not_found() {
+        let pool = setup_db().await;
+        let result = find_by_task_id(&pool, Uuid::new_v4()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_issue_number() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        insert(&pool, Uuid::new_v4(), task_id, link_id, 99, None)
+            .await
+            .unwrap();
+
+        let found = find_by_issue_number(&pool, link_id, 99).await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().github_issue_number, 99);
+
+        // Different issue number -> None
+        let not_found = find_by_issue_number(&pool, link_id, 100).await.unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_link() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task1 = create_task(&pool, project_id).await;
+        let task2 = create_task(&pool, project_id).await;
+
+        insert(&pool, Uuid::new_v4(), task1, link_id, 1, None)
+            .await
+            .unwrap();
+        insert(&pool, Uuid::new_v4(), task2, link_id, 2, None)
+            .await
+            .unwrap();
+
+        let mappings = find_all_by_link(&pool, link_id).await.unwrap();
+        assert_eq!(mappings.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_link_empty() {
+        let pool = setup_db().await;
+        let mappings = find_all_by_link(&pool, Uuid::new_v4()).await.unwrap();
+        assert!(mappings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_timestamps() {
+        let pool = setup_db().await;
+        let project_id = create_project(&pool).await;
+        let link_id = create_link(&pool, project_id).await;
+        let task_id = create_task(&pool, project_id).await;
+
+        let id = Uuid::new_v4();
+        insert(&pool, id, task_id, link_id, 10, None).await.unwrap();
+
+        let mapping = find_by_id(&pool, id).await.unwrap();
+        assert!(mapping.last_local_update.is_none());
+        assert!(mapping.last_remote_update.is_none());
+
+        let now = Utc::now();
+        update_timestamps(&pool, id, Some(now), Some(now))
+            .await
+            .unwrap();
+
+        let updated = find_by_id(&pool, id).await.unwrap();
+        assert!(updated.last_local_update.is_some());
+        assert!(updated.last_remote_update.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_update_timestamps_not_found() {
+        let pool = setup_db().await;
+        let result = update_timestamps(&pool, Uuid::new_v4(), None, None).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+}

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -1,7 +1,11 @@
 pub mod audit_repository;
 pub mod github_link_repository;
+pub mod github_pr_repository;
+pub mod github_sync_repository;
 pub mod member_repository;
 pub mod preview_repository;
+pub mod project_message_repository;
 pub mod session_repository;
+pub mod task_comment_repository;
 pub mod task_repository;
 pub mod user_repository;

--- a/backend/src/repositories/project_message_repository.rs
+++ b/backend/src/repositories/project_message_repository.rs
@@ -1,0 +1,324 @@
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::project_message::ProjectMessage;
+
+#[derive(FromRow)]
+struct MessageRow {
+    id: String,
+    project_id: String,
+    user_id: String,
+    user_name: String,
+    content: String,
+    created_at: DateTime<Utc>,
+}
+
+impl TryFrom<MessageRow> for ProjectMessage {
+    type Error = uuid::Error;
+
+    fn try_from(row: MessageRow) -> Result<Self, Self::Error> {
+        Ok(ProjectMessage {
+            id: row.id.parse()?,
+            project_id: row.project_id.parse()?,
+            user_id: row.user_id.parse()?,
+            user_name: row.user_name,
+            content: row.content,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn row_to_message(row: MessageRow) -> AppResult<ProjectMessage> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+/// Insert a new project message.
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    project_id: Uuid,
+    user_id: Uuid,
+    content: &str,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO project_messages (id, project_id, user_id, content)
+        VALUES ($1, $2, $3, $4)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .bind(content)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Find a message by its ID (with user name via JOIN).
+pub async fn find_by_id(pool: &SqlitePool, message_id: Uuid) -> AppResult<ProjectMessage> {
+    let row = sqlx::query_as::<_, MessageRow>(
+        r#"
+        SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
+        FROM project_messages m
+        JOIN users u ON m.user_id = u.id
+        WHERE m.id = $1
+        "#,
+    )
+    .bind(message_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(r) => row_to_message(r),
+        None => Err(AppError::NotFound(format!(
+            "project message not found: {}",
+            message_id
+        ))),
+    }
+}
+
+/// Find messages by project with a cursor (created_at < cursor), ordered DESC, limited.
+pub async fn find_by_project_before_cursor(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    cursor: DateTime<Utc>,
+    limit: i64,
+) -> AppResult<Vec<ProjectMessage>> {
+    let rows = sqlx::query_as::<_, MessageRow>(
+        r#"
+        SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
+        FROM project_messages m
+        JOIN users u ON m.user_id = u.id
+        WHERE m.project_id = $1 AND m.created_at < $2
+        ORDER BY m.created_at DESC
+        LIMIT $3
+        "#,
+    )
+    .bind(project_id.to_string())
+    .bind(cursor)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_message).collect()
+}
+
+/// Find messages by project (no cursor), ordered DESC, limited.
+pub async fn find_by_project(
+    pool: &SqlitePool,
+    project_id: Uuid,
+    limit: i64,
+) -> AppResult<Vec<ProjectMessage>> {
+    let rows = sqlx::query_as::<_, MessageRow>(
+        r#"
+        SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
+        FROM project_messages m
+        JOIN users u ON m.user_id = u.id
+        WHERE m.project_id = $1
+        ORDER BY m.created_at DESC
+        LIMIT $2
+        "#,
+    )
+    .bind(project_id.to_string())
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_message).collect()
+}
+
+/// Delete a message. Returns the number of rows affected.
+pub async fn delete(pool: &SqlitePool, message_id: Uuid) -> AppResult<u64> {
+    let result = sqlx::query("DELETE FROM project_messages WHERE id = $1")
+        .bind(message_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::user::RegisterRequest;
+    use crate::services::{project_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn setup_project_and_user(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let user = user_service::create_user(
+            pool,
+            &RegisterRequest {
+                email: "msg_user@test.com".to_string(),
+                name: "MsgUser".to_string(),
+                password: "password123".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "MsgProject".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        (project.id, user.id)
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        insert(&pool, id, project_id, user_id, "Hello!")
+            .await
+            .unwrap();
+
+        let msg = find_by_id(&pool, id).await.unwrap();
+        assert_eq!(msg.id, id);
+        assert_eq!(msg.project_id, project_id);
+        assert_eq!(msg.user_id, user_id);
+        assert_eq!(msg.content, "Hello!");
+        assert_eq!(msg.user_name, "MsgUser");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_found() {
+        let pool = setup_test_db().await;
+        let result = find_by_id(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_project_returns_desc_order() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        insert(&pool, Uuid::new_v4(), project_id, user_id, "First")
+            .await
+            .unwrap();
+        insert(&pool, Uuid::new_v4(), project_id, user_id, "Second")
+            .await
+            .unwrap();
+
+        let msgs = find_by_project(&pool, project_id, 50).await.unwrap();
+        assert_eq!(msgs.len(), 2);
+        // DESC order: newest first
+        assert_eq!(msgs[0].content, "Second");
+        assert_eq!(msgs[1].content, "First");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_project_respects_limit() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        for i in 0..5 {
+            insert(
+                &pool,
+                Uuid::new_v4(),
+                project_id,
+                user_id,
+                &format!("Msg {i}"),
+            )
+            .await
+            .unwrap();
+        }
+
+        let msgs = find_by_project(&pool, project_id, 2).await.unwrap();
+        assert_eq!(msgs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_project_before_cursor() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        // Insert with explicit different timestamps to ensure cursor works reliably.
+        let old_id = Uuid::new_v4();
+        let new_id = Uuid::new_v4();
+        let old_time = "2025-01-01T00:00:00.000Z";
+        let new_time = "2025-06-01T00:00:00.000Z";
+
+        sqlx::query(
+            "INSERT INTO project_messages (id, project_id, user_id, content, created_at) VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(old_id.to_string())
+        .bind(project_id.to_string())
+        .bind(user_id.to_string())
+        .bind("Old")
+        .bind(old_time)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO project_messages (id, project_id, user_id, content, created_at) VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(new_id.to_string())
+        .bind(project_id.to_string())
+        .bind(user_id.to_string())
+        .bind("New")
+        .bind(new_time)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Get all messages to determine cursor
+        let all = find_by_project(&pool, project_id, 50).await.unwrap();
+        assert_eq!(all.len(), 2);
+        // DESC order: New first
+        assert_eq!(all[0].content, "New");
+
+        // Use the newest message's created_at as cursor -> should return only the older one
+        let cursor = all[0].created_at;
+        let before = find_by_project_before_cursor(&pool, project_id, cursor, 50)
+            .await
+            .unwrap();
+        assert_eq!(before.len(), 1);
+        assert_eq!(before[0].content, "Old");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_project_empty() {
+        let pool = setup_test_db().await;
+        let msgs = find_by_project(&pool, Uuid::new_v4(), 50).await.unwrap();
+        assert!(msgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let pool = setup_test_db().await;
+        let (project_id, user_id) = setup_project_and_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        insert(&pool, id, project_id, user_id, "Delete me")
+            .await
+            .unwrap();
+
+        let rows_affected = delete(&pool, id).await.unwrap();
+        assert_eq!(rows_affected, 1);
+
+        let result = find_by_id(&pool, id).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let pool = setup_test_db().await;
+        let rows_affected = delete(&pool, Uuid::new_v4()).await.unwrap();
+        assert_eq!(rows_affected, 0);
+    }
+}

--- a/backend/src/repositories/task_comment_repository.rs
+++ b/backend/src/repositories/task_comment_repository.rs
@@ -1,0 +1,311 @@
+use chrono::{DateTime, Utc};
+use sqlx::{FromRow, SqlitePool};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::task_comment::TaskComment;
+
+#[derive(FromRow)]
+struct CommentRow {
+    id: String,
+    task_id: String,
+    user_id: String,
+    user_name: String,
+    content: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<CommentRow> for TaskComment {
+    type Error = uuid::Error;
+
+    fn try_from(row: CommentRow) -> Result<Self, Self::Error> {
+        Ok(TaskComment {
+            id: row.id.parse()?,
+            task_id: row.task_id.parse()?,
+            user_id: row.user_id.parse()?,
+            user_name: row.user_name,
+            content: row.content,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+fn row_to_comment(row: CommentRow) -> AppResult<TaskComment> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+/// Insert a new task comment.
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    task_id: Uuid,
+    user_id: Uuid,
+    content: &str,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO task_comments (id, task_id, user_id, content, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .bind(user_id.to_string())
+    .bind(content)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Find a comment by its ID (with user name via JOIN).
+pub async fn find_by_id(pool: &SqlitePool, comment_id: Uuid) -> AppResult<TaskComment> {
+    let row = sqlx::query_as::<_, CommentRow>(
+        r#"
+        SELECT c.id, c.task_id, c.user_id, u.name as user_name,
+               c.content, c.created_at, c.updated_at
+        FROM task_comments c
+        JOIN users u ON c.user_id = u.id
+        WHERE c.id = $1
+        "#,
+    )
+    .bind(comment_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(r) => row_to_comment(r),
+        None => Err(AppError::NotFound(format!(
+            "comment {} not found",
+            comment_id
+        ))),
+    }
+}
+
+/// Find all comments for a task, ordered by created_at ASC.
+pub async fn find_all_by_task(pool: &SqlitePool, task_id: Uuid) -> AppResult<Vec<TaskComment>> {
+    let rows = sqlx::query_as::<_, CommentRow>(
+        r#"
+        SELECT c.id, c.task_id, c.user_id, u.name as user_name,
+               c.content, c.created_at, c.updated_at
+        FROM task_comments c
+        JOIN users u ON c.user_id = u.id
+        WHERE c.task_id = $1
+        ORDER BY c.created_at ASC
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_comment).collect()
+}
+
+/// Update a comment's content.
+pub async fn update_content(
+    pool: &SqlitePool,
+    comment_id: Uuid,
+    content: &str,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    let result = sqlx::query(
+        r#"
+        UPDATE task_comments
+        SET content = $1, updated_at = $2
+        WHERE id = $3
+        "#,
+    )
+    .bind(content)
+    .bind(now)
+    .bind(comment_id.to_string())
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!(
+            "comment {} not found",
+            comment_id
+        )));
+    }
+
+    Ok(())
+}
+
+/// Delete a comment. Returns the number of rows affected.
+pub async fn delete(pool: &SqlitePool, comment_id: Uuid) -> AppResult<u64> {
+    let result = sqlx::query("DELETE FROM task_comments WHERE id = $1")
+        .bind(comment_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::task::{CreateTaskRequest, TaskPriority, TaskStatus};
+    use crate::models::user::RegisterRequest;
+    use crate::services::{project_service, task_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn setup_task_and_user(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let user = user_service::create_user(
+            pool,
+            &RegisterRequest {
+                email: "alice@test.com".to_string(),
+                name: "Alice".to_string(),
+                password: "password123".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let task = task_service::create_task(
+            pool,
+            &CreateTaskRequest {
+                project_id: project.id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: Some(TaskStatus::Todo),
+                priority: Some(TaskPriority::Medium),
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        (task.id, user.id)
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let (task_id, user_id) = setup_task_and_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        insert(&pool, id, task_id, user_id, "Hello, world!", now)
+            .await
+            .unwrap();
+
+        let comment = find_by_id(&pool, id).await.unwrap();
+        assert_eq!(comment.id, id);
+        assert_eq!(comment.task_id, task_id);
+        assert_eq!(comment.user_id, user_id);
+        assert_eq!(comment.content, "Hello, world!");
+        assert_eq!(comment.user_name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_found() {
+        let pool = setup_test_db().await;
+        let result = find_by_id(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_returns_chronological_order() {
+        let pool = setup_test_db().await;
+        let (task_id, user_id) = setup_task_and_user(&pool).await;
+
+        let now = Utc::now();
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+
+        insert(&pool, id1, task_id, user_id, "First", now)
+            .await
+            .unwrap();
+        insert(
+            &pool,
+            id2,
+            task_id,
+            user_id,
+            "Second",
+            now + chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap();
+
+        let comments = find_all_by_task(&pool, task_id).await.unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].content, "First");
+        assert_eq!(comments[1].content, "Second");
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_empty() {
+        let pool = setup_test_db().await;
+        let comments = find_all_by_task(&pool, Uuid::new_v4()).await.unwrap();
+        assert!(comments.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_content() {
+        let pool = setup_test_db().await;
+        let (task_id, user_id) = setup_task_and_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        insert(&pool, id, task_id, user_id, "Original", now)
+            .await
+            .unwrap();
+
+        let later = now + chrono::Duration::seconds(1);
+        update_content(&pool, id, "Updated", later).await.unwrap();
+
+        let comment = find_by_id(&pool, id).await.unwrap();
+        assert_eq!(comment.content, "Updated");
+    }
+
+    #[tokio::test]
+    async fn test_update_content_not_found() {
+        let pool = setup_test_db().await;
+        let result = update_content(&pool, Uuid::new_v4(), "content", Utc::now()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let pool = setup_test_db().await;
+        let (task_id, user_id) = setup_task_and_user(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        insert(&pool, id, task_id, user_id, "To delete", now)
+            .await
+            .unwrap();
+
+        let rows_affected = delete(&pool, id).await.unwrap();
+        assert_eq!(rows_affected, 1);
+
+        let result = find_by_id(&pool, id).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let pool = setup_test_db().await;
+        let rows_affected = delete(&pool, Uuid::new_v4()).await.unwrap();
+        assert_eq!(rows_affected, 0);
+    }
+}

--- a/backend/src/services/github_pr_service.rs
+++ b/backend/src/services/github_pr_service.rs
@@ -1,53 +1,9 @@
-use chrono::{DateTime, Utc};
-use sqlx::{FromRow, SqlitePool};
+use sqlx::SqlitePool;
 use uuid::Uuid;
 
-use crate::error::{AppError, AppResult};
-use crate::models::github::{GitHubPullRequest, LinkedPr, PrState};
-
-#[derive(FromRow)]
-struct PrRow {
-    id: String,
-    github_link_id: String,
-    task_id: String,
-    pr_number: i64,
-    title: String,
-    url: String,
-    state: String,
-    is_merged: bool,
-    author: Option<String>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<PrRow> for GitHubPullRequest {
-    type Error = uuid::Error;
-
-    fn try_from(row: PrRow) -> Result<Self, Self::Error> {
-        let state = match row.state.as_str() {
-            "closed" => PrState::Closed,
-            _ => PrState::Open,
-        };
-        Ok(GitHubPullRequest {
-            id: row.id.parse()?,
-            github_link_id: row.github_link_id.parse()?,
-            task_id: row.task_id.parse()?,
-            pr_number: row.pr_number,
-            title: row.title,
-            url: row.url,
-            state,
-            is_merged: row.is_merged,
-            author: row.author,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
-
-fn row_to_pr(row: PrRow) -> AppResult<GitHubPullRequest> {
-    row.try_into()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-}
+use crate::error::AppResult;
+use crate::models::github::{GitHubPullRequest, LinkedPr};
+use crate::repositories::github_pr_repository;
 
 /// Upsert a pull request linked to a task.
 /// Inserts a new record or updates an existing one (matched by github_link_id + pr_number + task_id).
@@ -59,50 +15,19 @@ pub async fn upsert_pr(
     pr: &LinkedPr,
 ) -> AppResult<GitHubPullRequest> {
     let id = Uuid::new_v4();
-    let state = match pr.state.as_str() {
-        "closed" => "closed",
-        _ => "open",
-    };
-
-    sqlx::query(
-        r#"
-        INSERT INTO github_pull_requests (id, github_link_id, task_id, pr_number, title, url, state, is_merged, author)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        ON CONFLICT (github_link_id, pr_number, task_id) DO UPDATE SET
-            title = excluded.title,
-            url = excluded.url,
-            state = excluded.state,
-            is_merged = excluded.is_merged,
-            author = excluded.author,
-            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-        "#,
+    github_pr_repository::upsert(
+        pool,
+        id,
+        github_link_id,
+        task_id,
+        pr.pr_number as i64,
+        &pr.title,
+        &pr.url,
+        &pr.state,
+        pr.is_merged,
+        pr.author.as_deref(),
     )
-    .bind(id.to_string())
-    .bind(github_link_id.to_string())
-    .bind(task_id.to_string())
-    .bind(pr.pr_number as i64)
-    .bind(&pr.title)
-    .bind(&pr.url)
-    .bind(state)
-    .bind(pr.is_merged)
-    .bind(&pr.author)
-    .execute(pool)
-    .await?;
-
-    let row = sqlx::query_as::<_, PrRow>(
-        r#"
-        SELECT id, github_link_id, task_id, pr_number, title, url, state, is_merged, author, created_at, updated_at
-        FROM github_pull_requests
-        WHERE github_link_id = $1 AND pr_number = $2 AND task_id = $3
-        "#,
-    )
-    .bind(github_link_id.to_string())
-    .bind(pr.pr_number as i64)
-    .bind(task_id.to_string())
-    .fetch_one(pool)
-    .await?;
-
-    row_to_pr(row)
+    .await
 }
 
 /// List all pull requests linked to a task.
@@ -111,19 +36,7 @@ pub async fn list_prs_for_task(
     pool: &SqlitePool,
     task_id: Uuid,
 ) -> AppResult<Vec<GitHubPullRequest>> {
-    let rows = sqlx::query_as::<_, PrRow>(
-        r#"
-        SELECT id, github_link_id, task_id, pr_number, title, url, state, is_merged, author, created_at, updated_at
-        FROM github_pull_requests
-        WHERE task_id = $1
-        ORDER BY pr_number
-        "#,
-    )
-    .bind(task_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter().map(row_to_pr).collect()
+    github_pr_repository::find_all_by_task(pool, task_id).await
 }
 
 /// Find task IDs linked to a specific PR number within a github_link.
@@ -132,25 +45,13 @@ pub async fn find_task_ids_by_pr(
     github_link_id: Uuid,
     pr_number: i64,
 ) -> AppResult<Vec<Uuid>> {
-    let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT task_id FROM github_pull_requests WHERE github_link_id = $1 AND pr_number = $2",
-    )
-    .bind(github_link_id.to_string())
-    .bind(pr_number)
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|(id,)| {
-            id.parse::<Uuid>()
-                .map_err(|e| AppError::Internal(e.to_string()))
-        })
-        .collect()
+    github_pr_repository::find_task_ids_by_pr(pool, github_link_id, pr_number).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::github::PrState;
     use sqlx::sqlite::SqlitePoolOptions;
 
     async fn setup_db() -> SqlitePool {

--- a/backend/src/services/github_pr_service.rs
+++ b/backend/src/services/github_pr_service.rs
@@ -7,7 +7,7 @@ use crate::repositories::github_pr_repository;
 
 /// Upsert a pull request linked to a task.
 /// Inserts a new record or updates an existing one (matched by github_link_id + pr_number + task_id).
-#[tracing::instrument(skip(pool))]
+#[tracing::instrument(skip(pool, pr), fields(pr_number = pr.pr_number))]
 pub async fn upsert_pr(
     pool: &SqlitePool,
     github_link_id: Uuid,
@@ -15,6 +15,10 @@ pub async fn upsert_pr(
     pr: &LinkedPr,
 ) -> AppResult<GitHubPullRequest> {
     let id = Uuid::new_v4();
+    let state = match pr.state.as_str() {
+        "closed" => "closed",
+        _ => "open",
+    };
     github_pr_repository::upsert(
         pool,
         id,
@@ -23,7 +27,7 @@ pub async fn upsert_pr(
         pr.pr_number as i64,
         &pr.title,
         &pr.url,
-        &pr.state,
+        state,
         pr.is_merged,
         pr.author.as_deref(),
     )

--- a/backend/src/services/github_sync_service.rs
+++ b/backend/src/services/github_sync_service.rs
@@ -1,43 +1,10 @@
 use chrono::{DateTime, Utc};
-use sqlx::{FromRow, SqlitePool};
+use sqlx::SqlitePool;
 use uuid::Uuid;
 
-use crate::error::{AppError, AppResult};
+use crate::error::AppResult;
 use crate::models::github::GitHubIssueMapping;
-
-#[derive(FromRow)]
-struct MappingRow {
-    id: String,
-    task_id: String,
-    github_link_id: String,
-    github_issue_number: i64,
-    github_issue_id: Option<i64>,
-    last_local_update: Option<DateTime<Utc>>,
-    last_remote_update: Option<DateTime<Utc>>,
-    created_at: DateTime<Utc>,
-}
-
-impl TryFrom<MappingRow> for GitHubIssueMapping {
-    type Error = uuid::Error;
-
-    fn try_from(row: MappingRow) -> Result<Self, Self::Error> {
-        Ok(GitHubIssueMapping {
-            id: row.id.parse()?,
-            task_id: row.task_id.parse()?,
-            github_link_id: row.github_link_id.parse()?,
-            github_issue_number: row.github_issue_number,
-            github_issue_id: row.github_issue_id,
-            last_local_update: row.last_local_update,
-            last_remote_update: row.last_remote_update,
-            created_at: row.created_at,
-        })
-    }
-}
-
-fn row_to_mapping(row: MappingRow) -> AppResult<GitHubIssueMapping> {
-    row.try_into()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-}
+use crate::repositories::github_sync_repository;
 
 /// Create a new issue mapping.
 pub async fn create_mapping(
@@ -48,28 +15,9 @@ pub async fn create_mapping(
     issue_id: Option<i64>,
 ) -> AppResult<GitHubIssueMapping> {
     let id = Uuid::new_v4();
-    sqlx::query(
-        r#"
-        INSERT INTO github_issue_mappings (id, task_id, github_link_id, github_issue_number, github_issue_id)
-        VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .bind(github_link_id.to_string())
-    .bind(issue_number)
-    .bind(issue_id)
-    .execute(pool)
-    .await?;
-
-    let row = sqlx::query_as::<_, MappingRow>(
-        "SELECT id, task_id, github_link_id, github_issue_number, github_issue_id, last_local_update, last_remote_update, created_at FROM github_issue_mappings WHERE id = $1",
-    )
-    .bind(id.to_string())
-    .fetch_one(pool)
-    .await?;
-
-    row_to_mapping(row)
+    github_sync_repository::insert(pool, id, task_id, github_link_id, issue_number, issue_id)
+        .await?;
+    github_sync_repository::find_by_id(pool, id).await
 }
 
 /// Get a mapping by task ID.
@@ -77,14 +25,7 @@ pub async fn get_mapping_by_task_id(
     pool: &SqlitePool,
     task_id: Uuid,
 ) -> AppResult<Option<GitHubIssueMapping>> {
-    let row = sqlx::query_as::<_, MappingRow>(
-        "SELECT id, task_id, github_link_id, github_issue_number, github_issue_id, last_local_update, last_remote_update, created_at FROM github_issue_mappings WHERE task_id = $1",
-    )
-    .bind(task_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(row_to_mapping).transpose()
+    github_sync_repository::find_by_task_id(pool, task_id).await
 }
 
 /// Get a mapping by GitHub link ID and issue number.
@@ -93,15 +34,7 @@ pub async fn get_mapping_by_issue_number(
     github_link_id: Uuid,
     issue_number: i64,
 ) -> AppResult<Option<GitHubIssueMapping>> {
-    let row = sqlx::query_as::<_, MappingRow>(
-        "SELECT id, task_id, github_link_id, github_issue_number, github_issue_id, last_local_update, last_remote_update, created_at FROM github_issue_mappings WHERE github_link_id = $1 AND github_issue_number = $2",
-    )
-    .bind(github_link_id.to_string())
-    .bind(issue_number)
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(row_to_mapping).transpose()
+    github_sync_repository::find_by_issue_number(pool, github_link_id, issue_number).await
 }
 
 /// List all mappings for a given GitHub link.
@@ -109,14 +42,7 @@ pub async fn list_mappings_by_link(
     pool: &SqlitePool,
     github_link_id: Uuid,
 ) -> AppResult<Vec<GitHubIssueMapping>> {
-    let rows = sqlx::query_as::<_, MappingRow>(
-        "SELECT id, task_id, github_link_id, github_issue_number, github_issue_id, last_local_update, last_remote_update, created_at FROM github_issue_mappings WHERE github_link_id = $1",
-    )
-    .bind(github_link_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter().map(row_to_mapping).collect()
+    github_sync_repository::find_all_by_link(pool, github_link_id).await
 }
 
 /// Update the local and remote timestamps on a mapping.
@@ -126,27 +52,13 @@ pub async fn update_mapping_timestamps(
     last_local_update: Option<DateTime<Utc>>,
     last_remote_update: Option<DateTime<Utc>>,
 ) -> AppResult<()> {
-    let result = sqlx::query(
-        r#"
-        UPDATE github_issue_mappings
-        SET last_local_update = $2, last_remote_update = $3
-        WHERE id = $1
-        "#,
+    github_sync_repository::update_timestamps(
+        pool,
+        mapping_id,
+        last_local_update,
+        last_remote_update,
     )
-    .bind(mapping_id.to_string())
-    .bind(last_local_update)
-    .bind(last_remote_update)
-    .execute(pool)
-    .await?;
-
-    if result.rows_affected() == 0 {
-        return Err(AppError::NotFound(format!(
-            "github issue mapping {} not found",
-            mapping_id
-        )));
-    }
-
-    Ok(())
+    .await
 }
 
 #[cfg(test)]

--- a/backend/src/services/project_message_service.rs
+++ b/backend/src/services/project_message_service.rs
@@ -1,43 +1,10 @@
 use chrono::{DateTime, Utc};
-use sqlx::{FromRow, SqlitePool};
+use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project_message::{CreateMessageRequest, ProjectMessage};
-
-#[derive(FromRow)]
-struct MessageRow {
-    id: String,
-    project_id: String,
-    user_id: String,
-    user_name: String,
-    content: String,
-    created_at: DateTime<Utc>,
-}
-
-impl TryFrom<MessageRow> for ProjectMessage {
-    type Error = AppError;
-
-    fn try_from(row: MessageRow) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: row
-                .id
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            project_id: row
-                .project_id
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            user_id: row
-                .user_id
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            user_name: row.user_name,
-            content: row.content,
-            created_at: row.created_at,
-        })
-    }
-}
+use crate::repositories::project_message_repository;
 
 pub async fn create_message(
     pool: &SqlitePool,
@@ -46,37 +13,12 @@ pub async fn create_message(
     req: &CreateMessageRequest,
 ) -> AppResult<ProjectMessage> {
     let id = Uuid::new_v4();
-    sqlx::query(
-        r#"
-        INSERT INTO project_messages (id, project_id, user_id, content)
-        VALUES ($1, $2, $3, $4)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(project_id.to_string())
-    .bind(user_id.to_string())
-    .bind(&req.content)
-    .execute(pool)
-    .await?;
-
-    get_message(pool, id).await
+    project_message_repository::insert(pool, id, project_id, user_id, &req.content).await?;
+    project_message_repository::find_by_id(pool, id).await
 }
 
 pub async fn get_message(pool: &SqlitePool, message_id: Uuid) -> AppResult<ProjectMessage> {
-    let row = sqlx::query_as::<_, MessageRow>(
-        r#"
-        SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
-        FROM project_messages m
-        JOIN users u ON m.user_id = u.id
-        WHERE m.id = $1
-        "#,
-    )
-    .bind(message_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.ok_or_else(|| AppError::NotFound(format!("project message not found: {message_id}")))
-        .and_then(ProjectMessage::try_from)
+    project_message_repository::find_by_id(pool, message_id).await
 }
 
 pub async fn list_messages(
@@ -85,65 +27,31 @@ pub async fn list_messages(
     before: Option<DateTime<Utc>>,
     limit: i64,
 ) -> AppResult<Vec<ProjectMessage>> {
-    let rows = match before {
+    match before {
         Some(cursor) => {
-            sqlx::query_as::<_, MessageRow>(
-                r#"
-                SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
-                FROM project_messages m
-                JOIN users u ON m.user_id = u.id
-                WHERE m.project_id = $1 AND m.created_at < $2
-                ORDER BY m.created_at DESC
-                LIMIT $3
-                "#,
+            project_message_repository::find_by_project_before_cursor(
+                pool, project_id, cursor, limit,
             )
-            .bind(project_id.to_string())
-            .bind(cursor)
-            .bind(limit)
-            .fetch_all(pool)
-            .await?
+            .await
         }
-        None => {
-            sqlx::query_as::<_, MessageRow>(
-                r#"
-                SELECT m.id, m.project_id, m.user_id, u.name AS user_name, m.content, m.created_at
-                FROM project_messages m
-                JOIN users u ON m.user_id = u.id
-                WHERE m.project_id = $1
-                ORDER BY m.created_at DESC
-                LIMIT $2
-                "#,
-            )
-            .bind(project_id.to_string())
-            .bind(limit)
-            .fetch_all(pool)
-            .await?
-        }
-    };
-
-    rows.into_iter().map(ProjectMessage::try_from).collect()
+        None => project_message_repository::find_by_project(pool, project_id, limit).await,
+    }
 }
 
 pub async fn delete_message(pool: &SqlitePool, message_id: Uuid, user_id: Uuid) -> AppResult<()> {
-    let existing = get_message(pool, message_id).await?;
+    let existing = project_message_repository::find_by_id(pool, message_id).await?;
     if existing.user_id != user_id {
         return Err(AppError::Forbidden(
             "only the message author can delete this message".to_string(),
         ));
     }
-    sqlx::query("DELETE FROM project_messages WHERE id = $1")
-        .bind(message_id.to_string())
-        .execute(pool)
-        .await?;
+    project_message_repository::delete(pool, message_id).await?;
     Ok(())
 }
 
 pub async fn delete_message_admin(pool: &SqlitePool, message_id: Uuid) -> AppResult<()> {
-    let result = sqlx::query("DELETE FROM project_messages WHERE id = $1")
-        .bind(message_id.to_string())
-        .execute(pool)
-        .await?;
-    if result.rows_affected() == 0 {
+    let rows_affected = project_message_repository::delete(pool, message_id).await?;
+    if rows_affected == 0 {
         return Err(AppError::NotFound(format!(
             "project message not found: {message_id}"
         )));

--- a/backend/src/services/task_comment_service.rs
+++ b/backend/src/services/task_comment_service.rs
@@ -1,37 +1,10 @@
-use chrono::{DateTime, Utc};
-use sqlx::prelude::FromRow;
+use chrono::Utc;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::task_comment::{CreateCommentRequest, TaskComment, UpdateCommentRequest};
-
-#[derive(FromRow)]
-struct CommentRow {
-    id: String,
-    task_id: String,
-    user_id: String,
-    user_name: String,
-    content: String,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<CommentRow> for TaskComment {
-    type Error = uuid::Error;
-
-    fn try_from(row: CommentRow) -> Result<Self, Self::Error> {
-        Ok(TaskComment {
-            id: row.id.parse()?,
-            task_id: row.task_id.parse()?,
-            user_id: row.user_id.parse()?,
-            user_name: row.user_name,
-            content: row.content,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
+use crate::repositories::task_comment_repository;
 
 pub async fn create_comment(
     pool: &SqlitePool,
@@ -41,64 +14,16 @@ pub async fn create_comment(
 ) -> AppResult<TaskComment> {
     let id = Uuid::new_v4();
     let now = Utc::now();
-
-    sqlx::query(
-        r#"
-        INSERT INTO task_comments (id, task_id, user_id, content, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .bind(user_id.to_string())
-    .bind(&req.content)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
-    .await?;
-
-    get_comment(pool, id).await
+    task_comment_repository::insert(pool, id, task_id, user_id, &req.content, now).await?;
+    task_comment_repository::find_by_id(pool, id).await
 }
 
 pub async fn get_comment(pool: &SqlitePool, comment_id: Uuid) -> AppResult<TaskComment> {
-    let row = sqlx::query_as::<_, CommentRow>(
-        r#"
-        SELECT c.id, c.task_id, c.user_id, u.name as user_name,
-               c.content, c.created_at, c.updated_at
-        FROM task_comments c
-        JOIN users u ON c.user_id = u.id
-        WHERE c.id = $1
-        "#,
-    )
-    .bind(comment_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound(format!("comment {} not found", comment_id)))
+    task_comment_repository::find_by_id(pool, comment_id).await
 }
 
 pub async fn list_comments(pool: &SqlitePool, task_id: Uuid) -> AppResult<Vec<TaskComment>> {
-    let rows = sqlx::query_as::<_, CommentRow>(
-        r#"
-        SELECT c.id, c.task_id, c.user_id, u.name as user_name,
-               c.content, c.created_at, c.updated_at
-        FROM task_comments c
-        JOIN users u ON c.user_id = u.id
-        WHERE c.task_id = $1
-        ORDER BY c.created_at ASC
-        "#,
-    )
-    .bind(task_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    task_comment_repository::find_all_by_task(pool, task_id).await
 }
 
 pub async fn update_comment(
@@ -107,7 +32,7 @@ pub async fn update_comment(
     user_id: Uuid,
     req: &UpdateCommentRequest,
 ) -> AppResult<TaskComment> {
-    let existing = get_comment(pool, comment_id).await?;
+    let existing = task_comment_repository::find_by_id(pool, comment_id).await?;
 
     if existing.user_id != user_id {
         return Err(AppError::Forbidden(
@@ -116,24 +41,12 @@ pub async fn update_comment(
     }
 
     let now = Utc::now();
-    sqlx::query(
-        r#"
-        UPDATE task_comments
-        SET content = $1, updated_at = $2
-        WHERE id = $3
-        "#,
-    )
-    .bind(&req.content)
-    .bind(now)
-    .bind(comment_id.to_string())
-    .execute(pool)
-    .await?;
-
-    get_comment(pool, comment_id).await
+    task_comment_repository::update_content(pool, comment_id, &req.content, now).await?;
+    task_comment_repository::find_by_id(pool, comment_id).await
 }
 
 pub async fn delete_comment(pool: &SqlitePool, comment_id: Uuid, user_id: Uuid) -> AppResult<()> {
-    let existing = get_comment(pool, comment_id).await?;
+    let existing = task_comment_repository::find_by_id(pool, comment_id).await?;
 
     if existing.user_id != user_id {
         return Err(AppError::Forbidden(
@@ -141,22 +54,15 @@ pub async fn delete_comment(pool: &SqlitePool, comment_id: Uuid, user_id: Uuid) 
         ));
     }
 
-    sqlx::query("DELETE FROM task_comments WHERE id = $1")
-        .bind(comment_id.to_string())
-        .execute(pool)
-        .await?;
-
+    task_comment_repository::delete(pool, comment_id).await?;
     Ok(())
 }
 
 /// Delete a comment regardless of author (for admin use).
 pub async fn delete_comment_admin(pool: &SqlitePool, comment_id: Uuid) -> AppResult<()> {
-    let result = sqlx::query("DELETE FROM task_comments WHERE id = $1")
-        .bind(comment_id.to_string())
-        .execute(pool)
-        .await?;
+    let rows_affected = task_comment_repository::delete(pool, comment_id).await?;
 
-    if result.rows_affected() == 0 {
+    if rows_affected == 0 {
         return Err(AppError::NotFound(format!(
             "comment {} not found",
             comment_id


### PR DESCRIPTION
## Summary

Continues #325 — extracts repository pattern for GitHub and communication services.

- Extract `github_sync_repository` from `github_sync_service` (6 DB functions)
- Extract `github_pr_repository` from `github_pr_service` (4 DB functions)
- Extract `task_comment_repository` from `task_comment_service` (5 DB functions)
- Extract `project_message_repository` from `project_message_service` (5 DB functions)

Services now delegate all SQL queries to repositories while retaining business logic (author permission checks, state normalization, tracing instrumentation).

## Test plan

- [x] All 511 tests pass (`cargo test --lib`)
- [x] No new clippy warnings on changed files
- [x] Each repository has comprehensive unit tests

> **Note**: Stacked on #381. Merge that first.