### PR TITLE
refactor: ♻️ extract invitation, project, agent repos (3/3)

### DIFF
--- a/backend/src/models/agent_session_output.rs
+++ b/backend/src/models/agent_session_output.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::prelude::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -11,27 +10,4 @@ pub struct AgentSessionOutput {
     pub sequence: i64,
     pub content: String,
     pub created_at: DateTime<Utc>,
-}
-
-#[derive(FromRow)]
-pub(crate) struct AgentSessionOutputRow {
-    pub id: i64,
-    pub session_id: String,
-    pub sequence: i64,
-    pub content: String,
-    pub created_at: DateTime<Utc>,
-}
-
-impl TryFrom<AgentSessionOutputRow> for AgentSessionOutput {
-    type Error = uuid::Error;
-
-    fn try_from(row: AgentSessionOutputRow) -> Result<Self, Self::Error> {
-        Ok(AgentSessionOutput {
-            id: row.id,
-            session_id: row.session_id.parse()?,
-            sequence: row.sequence,
-            content: row.content,
-            created_at: row.created_at,
-        })
-    }
 }

--- a/backend/src/repositories/agent_session_output_repository.rs
+++ b/backend/src/repositories/agent_session_output_repository.rs
@@ -1,0 +1,445 @@
+//! Repository for agent_session_outputs table.
+
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::agent_session_output::AgentSessionOutput;
+
+#[derive(FromRow)]
+struct AgentSessionOutputRow {
+    pub id: i64,
+    pub session_id: String,
+    pub sequence: i64,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TryFrom<AgentSessionOutputRow> for AgentSessionOutput {
+    type Error = uuid::Error;
+
+    fn try_from(row: AgentSessionOutputRow) -> Result<Self, Self::Error> {
+        Ok(AgentSessionOutput {
+            id: row.id,
+            session_id: row.session_id.parse()?,
+            sequence: row.sequence,
+            content: row.content,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn row_to_output(row: AgentSessionOutputRow) -> AppResult<AgentSessionOutput> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+fn rows_to_outputs(rows: Vec<AgentSessionOutputRow>) -> AppResult<Vec<AgentSessionOutput>> {
+    rows.into_iter().map(row_to_output).collect()
+}
+
+pub async fn insert_returning(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    sequence: i64,
+    content: &str,
+) -> AppResult<AgentSessionOutput> {
+    let row = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        INSERT INTO agent_session_outputs (session_id, sequence, content)
+        VALUES ($1, $2, $3)
+        RETURNING id, session_id, sequence, content, created_at
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(sequence)
+    .bind(content)
+    .fetch_one(pool)
+    .await?;
+
+    row_to_output(row)
+}
+
+pub async fn find_all_by_session(
+    pool: &SqlitePool,
+    session_id: Uuid,
+) -> AppResult<Vec<AgentSessionOutput>> {
+    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        SELECT id, session_id, sequence, content, created_at
+        FROM agent_session_outputs
+        WHERE session_id = $1
+        ORDER BY sequence ASC
+        "#,
+    )
+    .bind(session_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_outputs(rows)
+}
+
+pub async fn find_by_session_paginated(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> AppResult<Vec<AgentSessionOutput>> {
+    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        SELECT id, session_id, sequence, content, created_at
+        FROM agent_session_outputs
+        WHERE session_id = $1
+        ORDER BY sequence ASC
+        LIMIT $2 OFFSET $3
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_outputs(rows)
+}
+
+pub async fn find_by_session_after_sequence(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    after_sequence: i64,
+) -> AppResult<Vec<AgentSessionOutput>> {
+    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
+        r#"
+        SELECT id, session_id, sequence, content, created_at
+        FROM agent_session_outputs
+        WHERE session_id = $1 AND sequence > $2
+        ORDER BY sequence ASC
+        "#,
+    )
+    .bind(session_id.to_string())
+    .bind(after_sequence)
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_outputs(rows)
+}
+
+/// Delete outputs older than the given cutoff date for completed/failed/cancelled sessions.
+pub async fn delete_old_for_terminal_sessions(
+    pool: &SqlitePool,
+    cutoff: DateTime<Utc>,
+) -> AppResult<u64> {
+    let result = sqlx::query(
+        r#"
+        DELETE FROM agent_session_outputs
+        WHERE created_at <= $1
+          AND session_id IN (
+            SELECT id FROM agent_sessions
+            WHERE status IN ('completed', 'failed', 'cancelled')
+          )
+        "#,
+    )
+    .bind(cutoff.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::agent_session::{AgentSessionStatus, AgentType, CreateAgentSessionRequest};
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::task::CreateTaskRequest;
+    use crate::services::{agent_session_service, project_service, task_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_session(pool: &SqlitePool) -> Uuid {
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .expect("Failed to create project");
+
+        let task = task_service::create_task(
+            pool,
+            &CreateTaskRequest {
+                project_id: project.id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("Failed to create task");
+
+        let session = agent_session_service::create_agent_session(
+            pool,
+            task.id,
+            &CreateAgentSessionRequest {
+                agent_type: AgentType::ClaudeCode,
+            },
+        )
+        .await
+        .expect("Failed to create session");
+
+        session.id
+    }
+
+    #[tokio::test]
+    async fn test_insert_returning_and_find_all() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        let out1 = insert_returning(&pool, session_id, 0, "Hello ")
+            .await
+            .expect("insert 1");
+        let out2 = insert_returning(&pool, session_id, 1, "World")
+            .await
+            .expect("insert 2");
+
+        assert_eq!(out1.sequence, 0);
+        assert_eq!(out1.content, "Hello ");
+        assert_eq!(out1.session_id, session_id);
+        assert_eq!(out2.sequence, 1);
+        assert_eq!(out2.content, "World");
+
+        let outputs = find_all_by_session(&pool, session_id)
+            .await
+            .expect("find_all");
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].sequence, 0);
+        assert_eq!(outputs[1].sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_session_empty() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        let outputs = find_all_by_session(&pool, session_id)
+            .await
+            .expect("find_all");
+        assert!(outputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_session_ordered_by_sequence() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        insert_returning(&pool, session_id, 2, "Third")
+            .await
+            .expect("insert");
+        insert_returning(&pool, session_id, 0, "First")
+            .await
+            .expect("insert");
+        insert_returning(&pool, session_id, 1, "Second")
+            .await
+            .expect("insert");
+
+        let outputs = find_all_by_session(&pool, session_id)
+            .await
+            .expect("find_all");
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(outputs[0].content, "First");
+        assert_eq!(outputs[1].content, "Second");
+        assert_eq!(outputs[2].content, "Third");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_session_after_sequence() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        for i in 0..5 {
+            insert_returning(&pool, session_id, i, &format!("chunk-{i}"))
+                .await
+                .expect("insert");
+        }
+
+        let outputs = find_by_session_after_sequence(&pool, session_id, 2)
+            .await
+            .expect("find_after");
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].sequence, 3);
+        assert_eq!(outputs[1].sequence, 4);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_session_paginated() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        for i in 0..10 {
+            insert_returning(&pool, session_id, i, &format!("chunk-{i}"))
+                .await
+                .expect("insert");
+        }
+
+        let page1 = find_by_session_paginated(&pool, session_id, 5, 0)
+            .await
+            .expect("page 1");
+        assert_eq!(page1.len(), 5);
+        assert_eq!(page1[0].sequence, 0);
+        assert_eq!(page1[4].sequence, 4);
+
+        let page2 = find_by_session_paginated(&pool, session_id, 5, 5)
+            .await
+            .expect("page 2");
+        assert_eq!(page2.len(), 5);
+        assert_eq!(page2[0].sequence, 5);
+        assert_eq!(page2[4].sequence, 9);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_session_paginated_offset_beyond_total() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        for i in 0..3 {
+            insert_returning(&pool, session_id, i, &format!("chunk-{i}"))
+                .await
+                .expect("insert");
+        }
+
+        let outputs = find_by_session_paginated(&pool, session_id, 100, 100)
+            .await
+            .expect("paginated");
+        assert!(outputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_sequence_returns_error() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        insert_returning(&pool, session_id, 0, "first")
+            .await
+            .expect("insert first");
+
+        let result = insert_returning(&pool, session_id, 0, "duplicate").await;
+        assert!(
+            result.is_err(),
+            "duplicate sequence should fail, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_old_for_terminal_sessions() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        insert_returning(&pool, session_id, 0, "old output")
+            .await
+            .expect("insert");
+
+        // Mark session as completed
+        let task_id = get_task_id_for_session(&pool, session_id).await;
+        agent_session_service::update_agent_session(
+            &pool,
+            task_id,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("to running");
+        agent_session_service::update_agent_session(
+            &pool,
+            task_id,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("to completed");
+
+        // Backdate the output
+        sqlx::query(
+            "UPDATE agent_session_outputs SET created_at = '2020-01-01T00:00:00.000Z' WHERE session_id = $1",
+        )
+        .bind(session_id.to_string())
+        .execute(&pool)
+        .await
+        .expect("backdate");
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        let count = delete_old_for_terminal_sessions(&pool, cutoff)
+            .await
+            .expect("delete_old");
+        assert_eq!(count, 1);
+
+        let outputs = find_all_by_session(&pool, session_id)
+            .await
+            .expect("find_all");
+        assert!(outputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete_old_preserves_recent() {
+        let pool = setup_test_db().await;
+        let session_id = create_test_session(&pool).await;
+
+        insert_returning(&pool, session_id, 0, "recent output")
+            .await
+            .expect("insert");
+
+        // Mark session as completed
+        let task_id = get_task_id_for_session(&pool, session_id).await;
+        agent_session_service::update_agent_session(
+            &pool,
+            task_id,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Running,
+            },
+        )
+        .await
+        .expect("to running");
+        agent_session_service::update_agent_session(
+            &pool,
+            task_id,
+            session_id,
+            &crate::models::agent_session::UpdateAgentSessionRequest {
+                status: AgentSessionStatus::Completed,
+            },
+        )
+        .await
+        .expect("to completed");
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        let count = delete_old_for_terminal_sessions(&pool, cutoff)
+            .await
+            .expect("delete_old");
+        assert_eq!(count, 0);
+
+        let outputs = find_all_by_session(&pool, session_id)
+            .await
+            .expect("find_all");
+        assert_eq!(outputs.len(), 1);
+    }
+
+    /// Helper to get task_id from a session_id (for tests only)
+    async fn get_task_id_for_session(pool: &SqlitePool, session_id: Uuid) -> Uuid {
+        let row: (String,) = sqlx::query_as("SELECT task_id FROM agent_sessions WHERE id = $1")
+            .bind(session_id.to_string())
+            .fetch_one(pool)
+            .await
+            .expect("Failed to get task_id");
+        row.0.parse().expect("Failed to parse task_id")
+    }
+}

--- a/backend/src/repositories/agent_session_repository.rs
+++ b/backend/src/repositories/agent_session_repository.rs
@@ -1,0 +1,750 @@
+//! Repository for agent_sessions table.
+
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::sqlite::SqliteConnection;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::agent_session::{AgentSession, AgentSessionStatus, AgentType};
+
+#[derive(FromRow)]
+struct AgentSessionRow {
+    pub id: String,
+    pub task_id: String,
+    pub agent_type: AgentType,
+    pub status: AgentSessionStatus,
+    pub prompt: Option<String>,
+    pub worktree_name: Option<String>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<AgentSessionRow> for AgentSession {
+    type Error = uuid::Error;
+
+    fn try_from(row: AgentSessionRow) -> Result<Self, Self::Error> {
+        Ok(AgentSession {
+            id: row.id.parse()?,
+            task_id: row.task_id.parse()?,
+            agent_type: row.agent_type,
+            status: row.status,
+            prompt: row.prompt,
+            worktree_name: row.worktree_name,
+            started_at: row.started_at,
+            finished_at: row.finished_at,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+fn row_to_agent_session(row: AgentSessionRow) -> AppResult<AgentSession> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+fn rows_to_agent_sessions(rows: Vec<AgentSessionRow>) -> AppResult<Vec<AgentSession>> {
+    rows.into_iter().map(row_to_agent_session).collect()
+}
+
+pub async fn find_by_id(
+    pool: &SqlitePool,
+    task_id: Uuid,
+    id: Uuid,
+) -> AppResult<Option<AgentSession>> {
+    let row = sqlx::query_as::<_, AgentSessionRow>(
+        r#"
+        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
+        FROM agent_sessions
+        WHERE id = $1 AND task_id = $2
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_agent_session).transpose()
+}
+
+pub async fn find_all_by_task(pool: &SqlitePool, task_id: Uuid) -> AppResult<Vec<AgentSession>> {
+    let rows = sqlx::query_as::<_, AgentSessionRow>(
+        r#"
+        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
+        FROM agent_sessions
+        WHERE task_id = $1
+        ORDER BY created_at ASC
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_agent_sessions(rows)
+}
+
+/// Find sessions for a task that have a worktree and are in a terminal state.
+pub async fn find_with_worktrees_terminal(
+    pool: &SqlitePool,
+    task_id: Uuid,
+) -> AppResult<Vec<AgentSession>> {
+    let rows = sqlx::query_as::<_, AgentSessionRow>(
+        r#"
+        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
+        FROM agent_sessions
+        WHERE task_id = $1
+          AND worktree_name IS NOT NULL
+          AND status IN ('completed', 'failed', 'cancelled')
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_agent_sessions(rows)
+}
+
+/// Check that no active (pending/running/paused) session exists for a task, using a connection (for transactions).
+pub async fn find_active_by_task_tx(
+    conn: &mut SqliteConnection,
+    task_id: Uuid,
+) -> AppResult<Option<AgentSession>> {
+    let row = sqlx::query_as::<_, AgentSessionRow>(
+        r#"
+        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
+        FROM agent_sessions
+        WHERE task_id = $1 AND status IN ('pending', 'running', 'paused')
+        LIMIT 1
+        "#,
+    )
+    .bind(task_id.to_string())
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    row.map(row_to_agent_session).transpose()
+}
+
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    task_id: Uuid,
+    agent_type: &AgentType,
+    status: &AgentSessionStatus,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO agent_sessions (id, task_id, agent_type, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .bind(agent_type)
+    .bind(status)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn insert_tx(
+    conn: &mut SqliteConnection,
+    id: Uuid,
+    task_id: Uuid,
+    agent_type: &AgentType,
+    status: &AgentSessionStatus,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO agent_sessions (id, task_id, agent_type, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .bind(agent_type)
+    .bind(status)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn update_prompt(pool: &SqlitePool, session_id: Uuid, prompt: &str) -> AppResult<u64> {
+    let result = sqlx::query(
+        "UPDATE agent_sessions SET prompt = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+    )
+    .bind(prompt)
+    .bind(session_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn update_prompt_tx(
+    conn: &mut SqliteConnection,
+    session_id: Uuid,
+    prompt: &str,
+) -> AppResult<u64> {
+    let result = sqlx::query(
+        "UPDATE agent_sessions SET prompt = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+    )
+    .bind(prompt)
+    .bind(session_id.to_string())
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn update_worktree_name(
+    pool: &SqlitePool,
+    session_id: Uuid,
+    worktree_name: &str,
+) -> AppResult<u64> {
+    let result = sqlx::query(
+        "UPDATE agent_sessions SET worktree_name = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+    )
+    .bind(worktree_name)
+    .bind(session_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn clear_worktree_name(pool: &SqlitePool, session_id: Uuid) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE agent_sessions SET worktree_name = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = $1",
+    )
+    .bind(session_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Recovered session info for logging and worktree cleanup.
+#[derive(Debug)]
+pub struct RecoveredSession {
+    pub id: String,
+    pub task_id: String,
+    pub worktree_name: Option<String>,
+}
+
+/// Mark all active sessions (running, paused, pending) as failed.
+/// Returns info about the recovered sessions.
+pub async fn recover_orphaned(pool: &SqlitePool) -> AppResult<Vec<RecoveredSession>> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>)>(
+        r#"
+        UPDATE agent_sessions
+        SET status = 'failed', finished_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+        WHERE status IN ('running', 'paused', 'pending')
+        RETURNING id, task_id, worktree_name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(id, task_id, worktree_name)| RecoveredSession {
+            id,
+            task_id,
+            worktree_name,
+        })
+        .collect())
+}
+
+pub async fn update_status(
+    pool: &SqlitePool,
+    id: Uuid,
+    task_id: Uuid,
+    status: &AgentSessionStatus,
+    started_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        UPDATE agent_sessions
+        SET status = $1, started_at = $2, finished_at = $3, updated_at = $4
+        WHERE id = $5 AND task_id = $6
+        "#,
+    )
+    .bind(status)
+    .bind(started_at)
+    .bind(finished_at)
+    .bind(now)
+    .bind(id.to_string())
+    .bind(task_id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::task::CreateTaskRequest;
+    use crate::services::{project_service, task_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_task(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let project = project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .expect("Failed to create project");
+
+        let task = task_service::create_task(
+            pool,
+            &CreateTaskRequest {
+                project_id: project.id,
+                title: "Test Task".to_string(),
+                description: None,
+                status: None,
+                priority: None,
+                parent_id: None,
+                assigned_to: None,
+            },
+        )
+        .await
+        .expect("Failed to create task");
+
+        (project.id, task.id)
+    }
+
+    async fn insert_test_session(pool: &SqlitePool, task_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        insert(
+            pool,
+            id,
+            task_id,
+            &AgentType::ClaudeCode,
+            &AgentSessionStatus::Pending,
+            now,
+        )
+        .await
+        .expect("insert session");
+        id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+
+        assert_eq!(session.id, id);
+        assert_eq!(session.task_id, task_id);
+        assert!(matches!(session.agent_type, AgentType::ClaudeCode));
+        assert_eq!(session.status, AgentSessionStatus::Pending);
+        assert!(session.prompt.is_none());
+        assert!(session.worktree_name.is_none());
+        assert!(session.started_at.is_none());
+        assert!(session.finished_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_returns_none_for_nonexistent() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let result = find_by_id(&pool, task_id, Uuid::new_v4())
+            .await
+            .expect("find_by_id");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_empty() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let sessions = find_all_by_task(&pool, task_id)
+            .await
+            .expect("find_all_by_task");
+
+        assert!(sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_task_returns_sessions() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        // Insert first session, then mark it as completed so a second can be created
+        let id1 = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+        update_status(
+            &pool,
+            id1,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("to running");
+        update_status(
+            &pool,
+            id1,
+            task_id,
+            &AgentSessionStatus::Completed,
+            Some(now),
+            Some(now),
+            now,
+        )
+        .await
+        .expect("to completed");
+
+        let id2 = insert_test_session(&pool, task_id).await;
+
+        let sessions = find_all_by_task(&pool, task_id)
+            .await
+            .expect("find_all_by_task");
+
+        assert_eq!(sessions.len(), 2);
+        let ids: Vec<Uuid> = sessions.iter().map(|s| s.id).collect();
+        assert!(ids.contains(&id1));
+        assert!(ids.contains(&id2));
+    }
+
+    #[tokio::test]
+    async fn test_insert_tx_and_find() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let mut tx = pool.begin().await.unwrap();
+        insert_tx(
+            &mut *tx,
+            id,
+            task_id,
+            &AgentType::GeminiCli,
+            &AgentSessionStatus::Pending,
+            now,
+        )
+        .await
+        .expect("insert_tx");
+        tx.commit().await.unwrap();
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+
+        assert_eq!(session.id, id);
+        assert!(matches!(session.agent_type, AgentType::GeminiCli));
+    }
+
+    #[tokio::test]
+    async fn test_update_prompt() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+
+        let affected = update_prompt(&pool, id, "test prompt")
+            .await
+            .expect("update_prompt");
+        assert_eq!(affected, 1);
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(session.prompt.as_deref(), Some("test prompt"));
+    }
+
+    #[tokio::test]
+    async fn test_update_prompt_nonexistent_returns_zero() {
+        let pool = setup_test_db().await;
+
+        let affected = update_prompt(&pool, Uuid::new_v4(), "test")
+            .await
+            .expect("update_prompt");
+        assert_eq!(affected, 0);
+    }
+
+    #[tokio::test]
+    async fn test_update_prompt_tx() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        let affected = update_prompt_tx(&mut *tx, id, "tx prompt")
+            .await
+            .expect("update_prompt_tx");
+        assert_eq!(affected, 1);
+        tx.commit().await.unwrap();
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(session.prompt.as_deref(), Some("tx prompt"));
+    }
+
+    #[tokio::test]
+    async fn test_update_worktree_name() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+
+        let affected = update_worktree_name(&pool, id, "my-worktree")
+            .await
+            .expect("update_worktree_name");
+        assert_eq!(affected, 1);
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(session.worktree_name.as_deref(), Some("my-worktree"));
+    }
+
+    #[tokio::test]
+    async fn test_update_worktree_name_nonexistent_returns_zero() {
+        let pool = setup_test_db().await;
+
+        let affected = update_worktree_name(&pool, Uuid::new_v4(), "wt")
+            .await
+            .expect("update_worktree_name");
+        assert_eq!(affected, 0);
+    }
+
+    #[tokio::test]
+    async fn test_clear_worktree_name() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        update_worktree_name(&pool, id, "my-worktree")
+            .await
+            .expect("set worktree");
+
+        clear_worktree_name(&pool, id)
+            .await
+            .expect("clear_worktree_name");
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert!(session.worktree_name.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_status() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("update_status");
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(session.status, AgentSessionStatus::Running);
+        assert!(session.started_at.is_some());
+        assert!(session.finished_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_active_by_task_tx() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        // No active session initially
+        let mut tx = pool.begin().await.unwrap();
+        let active = find_active_by_task_tx(&mut *tx, task_id)
+            .await
+            .expect("find_active");
+        assert!(active.is_none());
+        tx.commit().await.unwrap();
+
+        // Insert a pending session
+        insert_test_session(&pool, task_id).await;
+
+        let mut tx = pool.begin().await.unwrap();
+        let active = find_active_by_task_tx(&mut *tx, task_id)
+            .await
+            .expect("find_active");
+        assert!(active.is_some());
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_find_with_worktrees_terminal() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+
+        // Set worktree name and move to completed
+        update_worktree_name(&pool, id, "wt-1")
+            .await
+            .expect("set worktree");
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("to running");
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Completed,
+            Some(now),
+            Some(now),
+            now,
+        )
+        .await
+        .expect("to completed");
+
+        let sessions = find_with_worktrees_terminal(&pool, task_id)
+            .await
+            .expect("find_with_worktrees_terminal");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, id);
+    }
+
+    #[tokio::test]
+    async fn test_find_with_worktrees_terminal_excludes_running() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+
+        // Set worktree name but keep running (non-terminal)
+        update_worktree_name(&pool, id, "wt-1")
+            .await
+            .expect("set worktree");
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("to running");
+
+        let sessions = find_with_worktrees_terminal(&pool, task_id)
+            .await
+            .expect("find_with_worktrees_terminal");
+        assert!(sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recover_orphaned() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("to running");
+
+        let recovered = recover_orphaned(&pool).await.expect("recover");
+        assert_eq!(recovered.len(), 1);
+
+        let session = find_by_id(&pool, task_id, id)
+            .await
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(session.status, AgentSessionStatus::Failed);
+        assert!(session.finished_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_recover_orphaned_idempotent() {
+        let pool = setup_test_db().await;
+        let (_project_id, task_id) = create_test_task(&pool).await;
+
+        let id = insert_test_session(&pool, task_id).await;
+        let now = Utc::now();
+        update_status(
+            &pool,
+            id,
+            task_id,
+            &AgentSessionStatus::Running,
+            Some(now),
+            None,
+            now,
+        )
+        .await
+        .expect("to running");
+
+        let recovered1 = recover_orphaned(&pool).await.expect("first recover");
+        assert_eq!(recovered1.len(), 1);
+
+        let recovered2 = recover_orphaned(&pool).await.expect("second recover");
+        assert_eq!(recovered2.len(), 0, "second call should be no-op");
+    }
+}

--- a/backend/src/repositories/agent_session_repository.rs
+++ b/backend/src/repositories/agent_session_repository.rs
@@ -447,7 +447,7 @@ mod tests {
         let now = Utc::now();
         let mut tx = pool.begin().await.unwrap();
         insert_tx(
-            &mut *tx,
+            &mut tx,
             id,
             task_id,
             &AgentType::GeminiCli,
@@ -504,7 +504,7 @@ mod tests {
         let id = insert_test_session(&pool, task_id).await;
 
         let mut tx = pool.begin().await.unwrap();
-        let affected = update_prompt_tx(&mut *tx, id, "tx prompt")
+        let affected = update_prompt_tx(&mut tx, id, "tx prompt")
             .await
             .expect("update_prompt_tx");
         assert_eq!(affected, 1);
@@ -603,7 +603,7 @@ mod tests {
 
         // No active session initially
         let mut tx = pool.begin().await.unwrap();
-        let active = find_active_by_task_tx(&mut *tx, task_id)
+        let active = find_active_by_task_tx(&mut tx, task_id)
             .await
             .expect("find_active");
         assert!(active.is_none());
@@ -613,7 +613,7 @@ mod tests {
         insert_test_session(&pool, task_id).await;
 
         let mut tx = pool.begin().await.unwrap();
-        let active = find_active_by_task_tx(&mut *tx, task_id)
+        let active = find_active_by_task_tx(&mut tx, task_id)
             .await
             .expect("find_active");
         assert!(active.is_some());

--- a/backend/src/repositories/invitation_repository.rs
+++ b/backend/src/repositories/invitation_repository.rs
@@ -1,0 +1,436 @@
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::sqlite::SqliteConnection;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::project_invitation::ProjectInvitation;
+
+#[derive(FromRow)]
+struct InvitationRow {
+    id: String,
+    project_id: String,
+    invited_by: String,
+    invited_by_name: String,
+    project_name: String,
+    role: String,
+    expires_at: DateTime<Utc>,
+    accepted_at: Option<DateTime<Utc>>,
+    accepted_by: Option<String>,
+    created_at: DateTime<Utc>,
+}
+
+impl TryFrom<InvitationRow> for ProjectInvitation {
+    type Error = AppError;
+
+    fn try_from(row: InvitationRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: row
+                .id
+                .parse()
+                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
+            project_id: row
+                .project_id
+                .parse()
+                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
+            invited_by: row
+                .invited_by
+                .parse()
+                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
+            invited_by_name: row.invited_by_name,
+            project_name: row.project_name,
+            role: serde_json::from_value(serde_json::Value::String(row.role))
+                .map_err(|e| AppError::Internal(e.to_string()))?,
+            expires_at: row.expires_at,
+            accepted_at: row.accepted_at,
+            accepted_by: row
+                .accepted_by
+                .map(|s| {
+                    s.parse()
+                        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+                })
+                .transpose()?,
+            created_at: row.created_at,
+        })
+    }
+}
+
+fn row_to_invitation(row: InvitationRow) -> AppResult<ProjectInvitation> {
+    row.try_into()
+}
+
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    project_id: Uuid,
+    invited_by: Uuid,
+    token_hash: &str,
+    role: &str,
+    expires_at: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO project_invitations (id, project_id, invited_by, token_hash, role, expires_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(project_id.to_string())
+    .bind(invited_by.to_string())
+    .bind(token_hash)
+    .bind(role)
+    .bind(expires_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn find_by_id(pool: &SqlitePool, invitation_id: Uuid) -> AppResult<ProjectInvitation> {
+    let row = sqlx::query_as::<_, InvitationRow>(
+        r#"
+        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
+               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
+               i.accepted_by, i.created_at
+        FROM project_invitations i
+        JOIN users u ON i.invited_by = u.id
+        JOIN projects p ON i.project_id = p.id
+        WHERE i.id = $1
+        "#,
+    )
+    .bind(invitation_id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.ok_or_else(|| AppError::NotFound(format!("invitation not found: {invitation_id}")))
+        .and_then(row_to_invitation)
+}
+
+pub async fn find_all_by_project(
+    pool: &SqlitePool,
+    project_id: Uuid,
+) -> AppResult<Vec<ProjectInvitation>> {
+    let rows = sqlx::query_as::<_, InvitationRow>(
+        r#"
+        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
+               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
+               i.accepted_by, i.created_at
+        FROM project_invitations i
+        JOIN users u ON i.invited_by = u.id
+        JOIN projects p ON i.project_id = p.id
+        WHERE i.project_id = $1
+        ORDER BY i.created_at DESC
+        "#,
+    )
+    .bind(project_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(row_to_invitation).collect()
+}
+
+pub async fn delete(pool: &SqlitePool, invitation_id: Uuid, project_id: Uuid) -> AppResult<u64> {
+    let result = sqlx::query("DELETE FROM project_invitations WHERE id = $1 AND project_id = $2")
+        .bind(invitation_id.to_string())
+        .bind(project_id.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn find_by_token_hash(
+    pool: &SqlitePool,
+    token_hash: &str,
+) -> AppResult<Option<ProjectInvitation>> {
+    let row = sqlx::query_as::<_, InvitationRow>(
+        r#"
+        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
+               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
+               i.accepted_by, i.created_at
+        FROM project_invitations i
+        JOIN users u ON i.invited_by = u.id
+        JOIN projects p ON i.project_id = p.id
+        WHERE i.token_hash = $1
+        "#,
+    )
+    .bind(token_hash)
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_invitation).transpose()
+}
+
+pub async fn mark_accepted_tx(
+    conn: &mut SqliteConnection,
+    invitation_id: Uuid,
+    user_id: Uuid,
+    now: DateTime<Utc>,
+) -> AppResult<u64> {
+    let result = sqlx::query(
+        "UPDATE project_invitations SET accepted_at = $1, accepted_by = $2 WHERE id = $3 AND accepted_at IS NULL",
+    )
+    .bind(now)
+    .bind(user_id.to_string())
+    .bind(invitation_id.to_string())
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn is_project_member_tx(
+    conn: &mut SqliteConnection,
+    project_id: Uuid,
+    user_id: Uuid,
+) -> AppResult<bool> {
+    let count = sqlx::query_scalar::<_, i32>(
+        "SELECT COUNT(*) FROM project_members WHERE project_id = $1 AND user_id = $2",
+    )
+    .bind(project_id.to_string())
+    .bind(user_id.to_string())
+    .fetch_one(&mut *conn)
+    .await?;
+
+    Ok(count > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::project::CreateProjectRequest;
+    use crate::models::user::RegisterRequest;
+    use crate::services::{project_service, user_service};
+    use crate::test_helpers::setup_test_db;
+
+    async fn create_test_project(pool: &SqlitePool) -> Uuid {
+        project_service::create_project(
+            pool,
+            &CreateProjectRequest {
+                name: "Test Project".to_string(),
+                description: None,
+                repository_path: None,
+            },
+        )
+        .await
+        .expect("create project")
+        .id
+    }
+
+    async fn create_test_user(pool: &SqlitePool, email: &str, name: &str) -> Uuid {
+        let req = RegisterRequest {
+            email: email.to_string(),
+            name: name.to_string(),
+            password: "correct horse battery staple purple".to_string(),
+        };
+        user_service::create_user(pool, &req)
+            .await
+            .expect("create user")
+            .id
+    }
+
+    async fn create_test_invitation(
+        pool: &SqlitePool,
+        project_id: Uuid,
+        invited_by: Uuid,
+        token_hash: &str,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        let expires_at = Utc::now() + chrono::Duration::hours(72);
+        insert(
+            pool, id, project_id, invited_by, token_hash, "member", expires_at,
+        )
+        .await
+        .expect("insert invitation");
+        id
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+
+        let id = create_test_invitation(&pool, project_id, user_id, "hash_abc").await;
+
+        let invitation = find_by_id(&pool, id).await.expect("find_by_id");
+        assert_eq!(invitation.id, id);
+        assert_eq!(invitation.project_id, project_id);
+        assert_eq!(invitation.invited_by, user_id);
+        assert_eq!(invitation.invited_by_name, "Inviter");
+        assert_eq!(invitation.project_name, "Test Project");
+        assert!(invitation.accepted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_found() {
+        let pool = setup_test_db().await;
+        let result = find_by_id(&pool, Uuid::new_v4()).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_project() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+
+        create_test_invitation(&pool, project_id, user_id, "hash_1").await;
+        create_test_invitation(&pool, project_id, user_id, "hash_2").await;
+
+        let invitations = find_all_by_project(&pool, project_id)
+            .await
+            .expect("find_all_by_project");
+        assert_eq!(invitations.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_by_project_empty() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let invitations = find_all_by_project(&pool, project_id)
+            .await
+            .expect("find_all_by_project");
+        assert!(invitations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+
+        let id = create_test_invitation(&pool, project_id, user_id, "hash_del").await;
+
+        let rows = delete(&pool, id, project_id).await.expect("delete");
+        assert_eq!(rows, 1);
+
+        let result = find_by_id(&pool, id).await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+
+        let rows = delete(&pool, Uuid::new_v4(), project_id)
+            .await
+            .expect("delete");
+        assert_eq!(rows, 0);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_token_hash_found() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+
+        let id = create_test_invitation(&pool, project_id, user_id, "unique_hash").await;
+
+        let result = find_by_token_hash(&pool, "unique_hash")
+            .await
+            .expect("find_by_token_hash");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().id, id);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_token_hash_not_found() {
+        let pool = setup_test_db().await;
+
+        let result = find_by_token_hash(&pool, "nonexistent_hash")
+            .await
+            .expect("find_by_token_hash");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mark_accepted_tx() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let inviter_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+        let acceptor_id = create_test_user(&pool, "acceptor@test.com", "Acceptor").await;
+
+        let id = create_test_invitation(&pool, project_id, inviter_id, "hash_accept").await;
+
+        let now = Utc::now();
+        let mut tx = pool.begin().await.unwrap();
+        let rows = mark_accepted_tx(&mut *tx, id, acceptor_id, now)
+            .await
+            .expect("mark_accepted_tx");
+        tx.commit().await.unwrap();
+
+        assert_eq!(rows, 1);
+
+        let invitation = find_by_id(&pool, id).await.expect("find_by_id");
+        assert!(invitation.accepted_at.is_some());
+        assert_eq!(invitation.accepted_by, Some(acceptor_id));
+    }
+
+    #[tokio::test]
+    async fn test_mark_accepted_tx_already_accepted() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let inviter_id = create_test_user(&pool, "inviter@test.com", "Inviter").await;
+        let acceptor_id = create_test_user(&pool, "acceptor@test.com", "Acceptor").await;
+
+        let id = create_test_invitation(&pool, project_id, inviter_id, "hash_double").await;
+
+        let now = Utc::now();
+        let mut tx = pool.begin().await.unwrap();
+        mark_accepted_tx(&mut *tx, id, acceptor_id, now)
+            .await
+            .expect("first accept");
+        tx.commit().await.unwrap();
+
+        // Second accept should return 0 rows
+        let mut tx2 = pool.begin().await.unwrap();
+        let rows = mark_accepted_tx(&mut *tx2, id, acceptor_id, now)
+            .await
+            .expect("second accept");
+        tx2.commit().await.unwrap();
+
+        assert_eq!(rows, 0);
+    }
+
+    #[tokio::test]
+    async fn test_is_project_member_tx() {
+        let pool = setup_test_db().await;
+        let project_id = create_test_project(&pool).await;
+        let user_id = create_test_user(&pool, "member@test.com", "Member").await;
+
+        // Not a member yet
+        let mut tx = pool.begin().await.unwrap();
+        let is_member = is_project_member_tx(&mut *tx, project_id, user_id)
+            .await
+            .expect("is_project_member_tx");
+        tx.commit().await.unwrap();
+        assert!(!is_member);
+
+        // Add as member
+        use crate::models::project::AddMemberRequest;
+        use crate::models::project::MemberRole;
+        use crate::services::member_service;
+        member_service::add_member(
+            &pool,
+            project_id,
+            &AddMemberRequest {
+                user_id,
+                role: MemberRole::Member,
+            },
+        )
+        .await
+        .expect("add member");
+
+        // Now is a member
+        let mut tx2 = pool.begin().await.unwrap();
+        let is_member = is_project_member_tx(&mut *tx2, project_id, user_id)
+            .await
+            .expect("is_project_member_tx");
+        tx2.commit().await.unwrap();
+        assert!(is_member);
+    }
+}

--- a/backend/src/repositories/invitation_repository.rs
+++ b/backend/src/repositories/invitation_repository.rs
@@ -358,7 +358,7 @@ mod tests {
 
         let now = Utc::now();
         let mut tx = pool.begin().await.unwrap();
-        let rows = mark_accepted_tx(&mut *tx, id, acceptor_id, now)
+        let rows = mark_accepted_tx(&mut tx, id, acceptor_id, now)
             .await
             .expect("mark_accepted_tx");
         tx.commit().await.unwrap();
@@ -381,14 +381,14 @@ mod tests {
 
         let now = Utc::now();
         let mut tx = pool.begin().await.unwrap();
-        mark_accepted_tx(&mut *tx, id, acceptor_id, now)
+        mark_accepted_tx(&mut tx, id, acceptor_id, now)
             .await
             .expect("first accept");
         tx.commit().await.unwrap();
 
         // Second accept should return 0 rows
         let mut tx2 = pool.begin().await.unwrap();
-        let rows = mark_accepted_tx(&mut *tx2, id, acceptor_id, now)
+        let rows = mark_accepted_tx(&mut tx2, id, acceptor_id, now)
             .await
             .expect("second accept");
         tx2.commit().await.unwrap();
@@ -404,7 +404,7 @@ mod tests {
 
         // Not a member yet
         let mut tx = pool.begin().await.unwrap();
-        let is_member = is_project_member_tx(&mut *tx, project_id, user_id)
+        let is_member = is_project_member_tx(&mut tx, project_id, user_id)
             .await
             .expect("is_project_member_tx");
         tx.commit().await.unwrap();
@@ -427,7 +427,7 @@ mod tests {
 
         // Now is a member
         let mut tx2 = pool.begin().await.unwrap();
-        let is_member = is_project_member_tx(&mut *tx2, project_id, user_id)
+        let is_member = is_project_member_tx(&mut tx2, project_id, user_id)
             .await
             .expect("is_project_member_tx");
         tx2.commit().await.unwrap();

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -1,10 +1,14 @@
+pub mod agent_session_output_repository;
+pub mod agent_session_repository;
 pub mod audit_repository;
 pub mod github_link_repository;
 pub mod github_pr_repository;
 pub mod github_sync_repository;
+pub mod invitation_repository;
 pub mod member_repository;
 pub mod preview_repository;
 pub mod project_message_repository;
+pub mod project_repository;
 pub mod session_repository;
 pub mod task_comment_repository;
 pub mod task_repository;

--- a/backend/src/repositories/project_repository.rs
+++ b/backend/src/repositories/project_repository.rs
@@ -1,0 +1,465 @@
+use chrono::{DateTime, Utc};
+use sqlx::prelude::FromRow;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::models::project::Project;
+
+#[derive(FromRow)]
+struct ProjectRow {
+    id: String,
+    name: String,
+    description: Option<String>,
+    #[sqlx(default)]
+    repository_path: Option<String>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl TryFrom<ProjectRow> for Project {
+    type Error = uuid::Error;
+
+    fn try_from(row: ProjectRow) -> Result<Self, Self::Error> {
+        Ok(Project {
+            id: row.id.parse()?,
+            name: row.name,
+            description: row.description,
+            repository_path: row.repository_path,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+        })
+    }
+}
+
+fn row_to_project(row: ProjectRow) -> AppResult<Project> {
+    row.try_into()
+        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+}
+
+fn rows_to_projects(rows: Vec<ProjectRow>) -> AppResult<Vec<Project>> {
+    rows.into_iter().map(row_to_project).collect()
+}
+
+pub async fn insert(
+    pool: &SqlitePool,
+    id: Uuid,
+    name: &str,
+    description: Option<&str>,
+    repository_path: Option<&str>,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO projects (id, name, description, repository_path, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(id.to_string())
+    .bind(name)
+    .bind(description)
+    .bind(repository_path)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn find_by_id(pool: &SqlitePool, id: Uuid) -> AppResult<Option<Project>> {
+    let row = sqlx::query_as::<_, ProjectRow>(
+        r#"
+        SELECT id, name, description, repository_path, created_at, updated_at
+        FROM projects
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(row_to_project).transpose()
+}
+
+pub async fn find_all(pool: &SqlitePool) -> AppResult<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        r#"
+        SELECT id, name, description, repository_path, created_at, updated_at
+        FROM projects
+        ORDER BY created_at DESC
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_projects(rows)
+}
+
+pub async fn find_all_paginated(
+    pool: &SqlitePool,
+    limit: i64,
+    offset: i64,
+) -> AppResult<(Vec<Project>, i64)> {
+    let total: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*) FROM projects
+        "#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        r#"
+        SELECT id, name, description, repository_path, created_at, updated_at
+        FROM projects
+        ORDER BY created_at DESC
+        LIMIT $1 OFFSET $2
+        "#,
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    let projects = rows_to_projects(rows)?;
+    Ok((projects, total.0))
+}
+
+pub async fn find_all_for_user(pool: &SqlitePool, user_id: Uuid) -> AppResult<Vec<Project>> {
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        r#"
+        SELECT p.id, p.name, p.description, p.repository_path, p.created_at, p.updated_at
+        FROM projects p
+        INNER JOIN project_members pm ON p.id = pm.project_id
+        WHERE pm.user_id = $1
+        ORDER BY p.created_at DESC
+        "#,
+    )
+    .bind(user_id.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    rows_to_projects(rows)
+}
+
+pub async fn find_all_for_user_paginated(
+    pool: &SqlitePool,
+    user_id: Uuid,
+    limit: i64,
+    offset: i64,
+) -> AppResult<(Vec<Project>, i64)> {
+    let total: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)
+        FROM projects p
+        INNER JOIN project_members pm ON p.id = pm.project_id
+        WHERE pm.user_id = $1
+        "#,
+    )
+    .bind(user_id.to_string())
+    .fetch_one(pool)
+    .await?;
+
+    let rows = sqlx::query_as::<_, ProjectRow>(
+        r#"
+        SELECT p.id, p.name, p.description, p.repository_path, p.created_at, p.updated_at
+        FROM projects p
+        INNER JOIN project_members pm ON p.id = pm.project_id
+        WHERE pm.user_id = $1
+        ORDER BY p.created_at DESC
+        LIMIT $2 OFFSET $3
+        "#,
+    )
+    .bind(user_id.to_string())
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+
+    let projects = rows_to_projects(rows)?;
+    Ok((projects, total.0))
+}
+
+pub async fn update(
+    pool: &SqlitePool,
+    id: Uuid,
+    name: &str,
+    description: Option<&str>,
+    repository_path: Option<&str>,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    sqlx::query(
+        r#"
+        UPDATE projects
+        SET name = $1, description = $2, repository_path = $3, updated_at = $4
+        WHERE id = $5
+        "#,
+    )
+    .bind(name)
+    .bind(description)
+    .bind(repository_path)
+    .bind(now)
+    .bind(id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn delete(pool: &SqlitePool, id: Uuid) -> AppResult<u64> {
+    let result = sqlx::query(
+        r#"
+        DELETE FROM projects
+        WHERE id = $1
+        "#,
+    )
+    .bind(id.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::setup_test_db;
+
+    async fn insert_test_project(pool: &SqlitePool, name: &str) -> Uuid {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        insert(pool, id, name, None, None, now)
+            .await
+            .expect("insert project");
+        id
+    }
+
+    async fn insert_test_user(pool: &SqlitePool) -> Uuid {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let password_hash = "hashed_password";
+        sqlx::query(
+            r#"
+            INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            "#,
+        )
+        .bind(id.to_string())
+        .bind(format!("test-{}@example.com", id))
+        .bind("Test User")
+        .bind(password_hash)
+        .bind(now)
+        .bind(now)
+        .execute(pool)
+        .await
+        .expect("insert user");
+        id
+    }
+
+    async fn insert_project_member(pool: &SqlitePool, project_id: Uuid, user_id: Uuid) {
+        let now = Utc::now();
+        sqlx::query(
+            r#"
+            INSERT INTO project_members (project_id, user_id, role, created_at)
+            VALUES ($1, $2, $3, $4)
+            "#,
+        )
+        .bind(project_id.to_string())
+        .bind(user_id.to_string())
+        .bind("member")
+        .bind(now)
+        .execute(pool)
+        .await
+        .expect("insert project member");
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_find_by_id() {
+        let pool = setup_test_db().await;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        insert(
+            &pool,
+            id,
+            "Test Project",
+            Some("A description"),
+            Some("/repo/path"),
+            now,
+        )
+        .await
+        .expect("insert");
+
+        let project = find_by_id(&pool, id)
+            .await
+            .expect("find")
+            .expect("should exist");
+
+        assert_eq!(project.id, id);
+        assert_eq!(project.name, "Test Project");
+        assert_eq!(project.description, Some("A description".to_string()));
+        assert_eq!(project.repository_path, Some("/repo/path".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_returns_none_for_nonexistent() {
+        let pool = setup_test_db().await;
+
+        let result = find_by_id(&pool, Uuid::new_v4()).await.expect("find");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_insert_without_optional_fields() {
+        let pool = setup_test_db().await;
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        insert(&pool, id, "Minimal Project", None, None, now)
+            .await
+            .expect("insert");
+
+        let project = find_by_id(&pool, id)
+            .await
+            .expect("find")
+            .expect("should exist");
+
+        assert_eq!(project.name, "Minimal Project");
+        assert!(project.description.is_none());
+        assert!(project.repository_path.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_empty() {
+        let pool = setup_test_db().await;
+
+        let projects = find_all(&pool).await.expect("find_all");
+
+        assert!(projects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_returns_multiple() {
+        let pool = setup_test_db().await;
+        insert_test_project(&pool, "Project A").await;
+        insert_test_project(&pool, "Project B").await;
+
+        let projects = find_all(&pool).await.expect("find_all");
+
+        assert_eq!(projects.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_paginated() {
+        let pool = setup_test_db().await;
+        for i in 0..5 {
+            insert_test_project(&pool, &format!("Project {i}")).await;
+        }
+
+        let (projects, total) = find_all_paginated(&pool, 2, 0)
+            .await
+            .expect("find_all_paginated");
+
+        assert_eq!(projects.len(), 2);
+        assert_eq!(total, 5);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_paginated_with_offset() {
+        let pool = setup_test_db().await;
+        for i in 0..5 {
+            insert_test_project(&pool, &format!("Project {i}")).await;
+        }
+
+        let (projects, total) = find_all_paginated(&pool, 2, 3)
+            .await
+            .expect("find_all_paginated");
+
+        assert_eq!(projects.len(), 2);
+        assert_eq!(total, 5);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_for_user() {
+        let pool = setup_test_db().await;
+        let user_id = insert_test_user(&pool).await;
+        let p1 = insert_test_project(&pool, "Project 1").await;
+        let _p2 = insert_test_project(&pool, "Project 2").await;
+
+        insert_project_member(&pool, p1, user_id).await;
+
+        let projects = find_all_for_user(&pool, user_id)
+            .await
+            .expect("find_all_for_user");
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, p1);
+    }
+
+    #[tokio::test]
+    async fn test_find_all_for_user_paginated() {
+        let pool = setup_test_db().await;
+        let user_id = insert_test_user(&pool).await;
+
+        for i in 0..5 {
+            let pid = insert_test_project(&pool, &format!("Project {i}")).await;
+            insert_project_member(&pool, pid, user_id).await;
+        }
+
+        let (projects, total) = find_all_for_user_paginated(&pool, user_id, 2, 0)
+            .await
+            .expect("find_all_for_user_paginated");
+
+        assert_eq!(projects.len(), 2);
+        assert_eq!(total, 5);
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let pool = setup_test_db().await;
+        let id = insert_test_project(&pool, "Original").await;
+
+        let now = Utc::now();
+        update(
+            &pool,
+            id,
+            "Updated",
+            Some("New desc"),
+            Some("/new/path"),
+            now,
+        )
+        .await
+        .expect("update");
+
+        let project = find_by_id(&pool, id)
+            .await
+            .expect("find")
+            .expect("should exist");
+
+        assert_eq!(project.name, "Updated");
+        assert_eq!(project.description, Some("New desc".to_string()));
+        assert_eq!(project.repository_path, Some("/new/path".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_delete_existing() {
+        let pool = setup_test_db().await;
+        let id = insert_test_project(&pool, "To Delete").await;
+
+        let rows = delete(&pool, id).await.expect("delete");
+
+        assert_eq!(rows, 1);
+        assert!(find_by_id(&pool, id).await.expect("find").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent() {
+        let pool = setup_test_db().await;
+
+        let rows = delete(&pool, Uuid::new_v4()).await.expect("delete");
+
+        assert_eq!(rows, 0);
+    }
+}

--- a/backend/src/services/agent_session_output_service/query.rs
+++ b/backend/src/services/agent_session_output_service/query.rs
@@ -1,9 +1,9 @@
-use chrono::Utc;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
-use crate::models::agent_session_output::{AgentSessionOutput, AgentSessionOutputRow};
+use crate::models::agent_session_output::AgentSessionOutput;
+use crate::repositories::agent_session_output_repository;
 
 use super::{MAX_CONTENT_SIZE, MAX_OUTPUTS_PER_SESSION};
 
@@ -25,43 +25,14 @@ pub async fn append_output(
         )));
     }
 
-    let row = sqlx::query_as::<_, AgentSessionOutputRow>(
-        r#"
-        INSERT INTO agent_session_outputs (session_id, sequence, content)
-        VALUES ($1, $2, $3)
-        RETURNING id, session_id, sequence, content, created_at
-        "#,
-    )
-    .bind(session_id.to_string())
-    .bind(sequence)
-    .bind(content)
-    .fetch_one(pool)
-    .await?;
-
-    row.try_into()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    agent_session_output_repository::insert_returning(pool, session_id, sequence, content).await
 }
 
 pub async fn get_outputs(
     pool: &SqlitePool,
     session_id: Uuid,
 ) -> AppResult<Vec<AgentSessionOutput>> {
-    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
-        r#"
-        SELECT id, session_id, sequence, content, created_at
-        FROM agent_session_outputs
-        WHERE session_id = $1
-        ORDER BY sequence ASC
-        "#,
-    )
-    .bind(session_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    agent_session_output_repository::find_all_by_session(pool, session_id).await
 }
 
 pub async fn get_outputs_paginated(
@@ -70,25 +41,8 @@ pub async fn get_outputs_paginated(
     limit: i64,
     offset: i64,
 ) -> AppResult<Vec<AgentSessionOutput>> {
-    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
-        r#"
-        SELECT id, session_id, sequence, content, created_at
-        FROM agent_session_outputs
-        WHERE session_id = $1
-        ORDER BY sequence ASC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(session_id.to_string())
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    agent_session_output_repository::find_by_session_paginated(pool, session_id, limit, offset)
+        .await
 }
 
 pub async fn get_outputs_after(
@@ -96,23 +50,12 @@ pub async fn get_outputs_after(
     session_id: Uuid,
     after_sequence: i64,
 ) -> AppResult<Vec<AgentSessionOutput>> {
-    let rows = sqlx::query_as::<_, AgentSessionOutputRow>(
-        r#"
-        SELECT id, session_id, sequence, content, created_at
-        FROM agent_session_outputs
-        WHERE session_id = $1 AND sequence > $2
-        ORDER BY sequence ASC
-        "#,
+    agent_session_output_repository::find_by_session_after_sequence(
+        pool,
+        session_id,
+        after_sequence,
     )
-    .bind(session_id.to_string())
-    .bind(after_sequence)
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    .await
 }
 
 /// Delete agent session outputs older than the given number of days.
@@ -120,21 +63,8 @@ pub async fn get_outputs_after(
 pub async fn cleanup_old_outputs(pool: &SqlitePool, retention_days: u64) -> AppResult<u64> {
     let retention_days_i64 = i64::try_from(retention_days)
         .map_err(|_| AppError::Internal("retention_days too large".to_string()))?;
-    let cutoff = Utc::now() - chrono::Duration::days(retention_days_i64);
-    let result = sqlx::query(
-        r#"
-        DELETE FROM agent_session_outputs
-        WHERE created_at <= $1
-          AND session_id IN (
-            SELECT id FROM agent_sessions
-            WHERE status IN ('completed', 'failed', 'cancelled')
-          )
-        "#,
-    )
-    .bind(cutoff.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
-    .execute(pool)
-    .await?;
-    Ok(result.rows_affected())
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days_i64);
+    agent_session_output_repository::delete_old_for_terminal_sessions(pool, cutoff).await
 }
 
 #[cfg(test)]

--- a/backend/src/services/agent_session_service/command.rs
+++ b/backend/src/services/agent_session_service/command.rs
@@ -8,6 +8,7 @@ use crate::error::{AppError, AppResult};
 use crate::models::agent_session::{
     AgentSession, AgentSessionStatus, CreateAgentSessionRequest, UpdateAgentSessionRequest,
 };
+use crate::repositories::agent_session_repository;
 
 use super::query::get_agent_session;
 
@@ -19,19 +20,14 @@ pub async fn create_agent_session(
     let id = Uuid::new_v4();
     let now = Utc::now();
 
-    sqlx::query(
-        r#"
-        INSERT INTO agent_sessions (id, task_id, agent_type, status, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+    agent_session_repository::insert(
+        pool,
+        id,
+        task_id,
+        &req.agent_type,
+        &AgentSessionStatus::Pending,
+        now,
     )
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .bind(&req.agent_type)
-    .bind(&AgentSessionStatus::Pending)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
     .await?;
 
     Ok(AgentSession {
@@ -57,19 +53,14 @@ pub async fn create_agent_session_tx(
     let id = Uuid::new_v4();
     let now = Utc::now();
 
-    sqlx::query(
-        r#"
-        INSERT INTO agent_sessions (id, task_id, agent_type, status, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+    agent_session_repository::insert_tx(
+        conn,
+        id,
+        task_id,
+        &req.agent_type,
+        &AgentSessionStatus::Pending,
+        now,
     )
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .bind(&req.agent_type)
-    .bind(&AgentSessionStatus::Pending)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *conn)
     .await?;
 
     Ok(AgentSession {
@@ -87,14 +78,8 @@ pub async fn create_agent_session_tx(
 }
 
 pub async fn save_prompt(pool: &SqlitePool, session_id: Uuid, prompt: &str) -> AppResult<()> {
-    let result = sqlx::query(
-        "UPDATE agent_sessions SET prompt = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
-    )
-    .bind(prompt)
-    .bind(session_id.to_string())
-    .execute(pool)
-    .await?;
-    if result.rows_affected() == 0 {
+    let affected = agent_session_repository::update_prompt(pool, session_id, prompt).await?;
+    if affected == 0 {
         return Err(AppError::NotFound(format!(
             "Agent session {session_id} not found"
         )));
@@ -108,14 +93,8 @@ pub async fn save_prompt_tx(
     session_id: Uuid,
     prompt: &str,
 ) -> AppResult<()> {
-    let result = sqlx::query(
-        "UPDATE agent_sessions SET prompt = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
-    )
-    .bind(prompt)
-    .bind(session_id.to_string())
-    .execute(&mut *conn)
-    .await?;
-    if result.rows_affected() == 0 {
+    let affected = agent_session_repository::update_prompt_tx(conn, session_id, prompt).await?;
+    if affected == 0 {
         return Err(AppError::NotFound(format!(
             "Agent session {session_id} not found"
         )));
@@ -129,14 +108,9 @@ pub async fn save_worktree_name(
     session_id: Uuid,
     worktree_name: &str,
 ) -> AppResult<()> {
-    let result = sqlx::query(
-        "UPDATE agent_sessions SET worktree_name = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
-    )
-    .bind(worktree_name)
-    .bind(session_id.to_string())
-    .execute(pool)
-    .await?;
-    if result.rows_affected() == 0 {
+    let affected =
+        agent_session_repository::update_worktree_name(pool, session_id, worktree_name).await?;
+    if affected == 0 {
         return Err(AppError::NotFound(format!(
             "Agent session {session_id} not found"
         )));
@@ -146,22 +120,11 @@ pub async fn save_worktree_name(
 
 /// Clear the worktree_name for a session after cleanup.
 pub async fn clear_worktree_name(pool: &SqlitePool, session_id: Uuid) -> AppResult<()> {
-    sqlx::query(
-        "UPDATE agent_sessions SET worktree_name = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = $1",
-    )
-    .bind(session_id.to_string())
-    .execute(pool)
-    .await?;
-    Ok(())
+    agent_session_repository::clear_worktree_name(pool, session_id).await
 }
 
-/// Recovered session info for logging and worktree cleanup.
-#[derive(Debug)]
-pub struct RecoveredSession {
-    pub id: String,
-    pub task_id: String,
-    pub worktree_name: Option<String>,
-}
+/// Re-export RecoveredSession from the repository.
+pub use agent_session_repository::RecoveredSession;
 
 /// Recover orphaned agent sessions by marking all active sessions as failed.
 ///
@@ -170,25 +133,7 @@ pub struct RecoveredSession {
 ///
 /// This function is idempotent -- calling it multiple times is safe.
 pub async fn recover_orphaned_sessions(pool: &SqlitePool) -> AppResult<Vec<RecoveredSession>> {
-    let rows = sqlx::query_as::<_, (String, String, Option<String>)>(
-        r#"
-        UPDATE agent_sessions
-        SET status = 'failed', finished_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-        WHERE status IN ('running', 'paused', 'pending')
-        RETURNING id, task_id, worktree_name
-        "#,
-    )
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(|(id, task_id, worktree_name)| RecoveredSession {
-            id,
-            task_id,
-            worktree_name,
-        })
-        .collect())
+    agent_session_repository::recover_orphaned(pool).await
 }
 
 fn validate_status_transition(from: &AgentSessionStatus, to: &AgentSessionStatus) -> AppResult<()> {
@@ -245,20 +190,15 @@ pub async fn update_agent_session(
         _ => None,
     };
 
-    sqlx::query(
-        r#"
-        UPDATE agent_sessions
-        SET status = $1, started_at = $2, finished_at = $3, updated_at = $4
-        WHERE id = $5 AND task_id = $6
-        "#,
+    agent_session_repository::update_status(
+        pool,
+        id,
+        task_id,
+        &req.status,
+        started_at,
+        finished_at,
+        now,
     )
-    .bind(&req.status)
-    .bind(started_at)
-    .bind(finished_at)
-    .bind(now)
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .execute(pool)
     .await?;
 
     Ok(AgentSession {

--- a/backend/src/services/agent_session_service/mod.rs
+++ b/backend/src/services/agent_session_service/mod.rs
@@ -7,45 +7,6 @@ pub mod query;
 pub use command::*;
 pub use query::*;
 
-use chrono::{DateTime, Utc};
-use sqlx::prelude::FromRow;
-
-use crate::models::agent_session::{AgentSession, AgentSessionStatus, AgentType};
-
-/// Internal row type shared between query and command submodules.
-#[derive(FromRow)]
-pub(crate) struct AgentSessionRow {
-    pub id: String,
-    pub task_id: String,
-    pub agent_type: AgentType,
-    pub status: AgentSessionStatus,
-    pub prompt: Option<String>,
-    pub worktree_name: Option<String>,
-    pub started_at: Option<DateTime<Utc>>,
-    pub finished_at: Option<DateTime<Utc>>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<AgentSessionRow> for AgentSession {
-    type Error = uuid::Error;
-
-    fn try_from(row: AgentSessionRow) -> Result<Self, Self::Error> {
-        Ok(AgentSession {
-            id: row.id.parse()?,
-            task_id: row.task_id.parse()?,
-            agent_type: row.agent_type,
-            status: row.status,
-            prompt: row.prompt,
-            worktree_name: row.worktree_name,
-            started_at: row.started_at,
-            finished_at: row.finished_at,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/services/agent_session_service/query.rs
+++ b/backend/src/services/agent_session_service/query.rs
@@ -3,50 +3,22 @@
 use sqlx::{SqliteConnection, SqlitePool};
 use uuid::Uuid;
 
-use super::AgentSessionRow;
 use crate::error::{AppError, AppResult};
 use crate::models::agent_session::AgentSession;
+use crate::repositories::agent_session_repository;
 
 pub async fn get_agent_session(
     pool: &SqlitePool,
     task_id: Uuid,
     id: Uuid,
 ) -> AppResult<AgentSession> {
-    let row = sqlx::query_as::<_, AgentSessionRow>(
-        r#"
-        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
-        FROM agent_sessions
-        WHERE id = $1 AND task_id = $2
-        "#,
-    )
-    .bind(id.to_string())
-    .bind(task_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
+    agent_session_repository::find_by_id(pool, task_id, id)
+        .await?
         .ok_or_else(|| AppError::NotFound(format!("agent session {} not found", id)))
 }
 
 pub async fn list_agent_sessions(pool: &SqlitePool, task_id: Uuid) -> AppResult<Vec<AgentSession>> {
-    let rows = sqlx::query_as::<_, AgentSessionRow>(
-        r#"
-        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
-        FROM agent_sessions
-        WHERE task_id = $1
-        ORDER BY created_at ASC
-        "#,
-    )
-    .bind(task_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    agent_session_repository::find_all_by_task(pool, task_id).await
 }
 
 /// List sessions for a task that have a worktree and are in a terminal state.
@@ -55,23 +27,7 @@ pub async fn list_sessions_with_worktrees(
     pool: &SqlitePool,
     task_id: Uuid,
 ) -> AppResult<Vec<AgentSession>> {
-    let rows = sqlx::query_as::<_, AgentSessionRow>(
-        r#"
-        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
-        FROM agent_sessions
-        WHERE task_id = $1
-          AND worktree_name IS NOT NULL
-          AND status IN ('completed', 'failed', 'cancelled')
-        "#,
-    )
-    .bind(task_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    agent_session_repository::find_with_worktrees_terminal(pool, task_id).await
 }
 
 /// Check that no active (pending/running) session exists for a task, using a connection (for transactions).
@@ -79,19 +35,9 @@ pub async fn check_no_active_session_tx(
     conn: &mut SqliteConnection,
     task_id: Uuid,
 ) -> AppResult<()> {
-    let row = sqlx::query_as::<_, AgentSessionRow>(
-        r#"
-        SELECT id, task_id, agent_type, status, prompt, worktree_name, started_at, finished_at, created_at, updated_at
-        FROM agent_sessions
-        WHERE task_id = $1 AND status IN ('pending', 'running', 'paused')
-        LIMIT 1
-        "#,
-    )
-    .bind(task_id.to_string())
-    .fetch_optional(&mut *conn)
-    .await?;
+    let active = agent_session_repository::find_active_by_task_tx(conn, task_id).await?;
 
-    if row.is_some() {
+    if active.is_some() {
         return Err(AppError::Conflict(format!(
             "task {task_id} already has an active agent session"
         )));

--- a/backend/src/services/invitation_service.rs
+++ b/backend/src/services/invitation_service.rs
@@ -1,12 +1,13 @@
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use rand::Rng;
 use sha2::{Digest, Sha256};
-use sqlx::{FromRow, SqlitePool};
+use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project::MemberRole;
 use crate::models::project_invitation::{InvitationInfo, ProjectInvitation};
+use crate::repositories::invitation_repository;
 
 const TOKEN_BYTES: usize = 32; // 256-bit
 const EXPIRY_HOURS: i64 = 72;
@@ -34,55 +35,6 @@ pub fn hash_token(token: &str) -> String {
     result.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-#[derive(FromRow)]
-struct InvitationRow {
-    id: String,
-    project_id: String,
-    invited_by: String,
-    invited_by_name: String,
-    project_name: String,
-    role: String,
-    expires_at: DateTime<Utc>,
-    accepted_at: Option<DateTime<Utc>>,
-    accepted_by: Option<String>,
-    created_at: DateTime<Utc>,
-}
-
-impl TryFrom<InvitationRow> for ProjectInvitation {
-    type Error = AppError;
-
-    fn try_from(row: InvitationRow) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: row
-                .id
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            project_id: row
-                .project_id
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            invited_by: row
-                .invited_by
-                .parse()
-                .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?,
-            invited_by_name: row.invited_by_name,
-            project_name: row.project_name,
-            role: serde_json::from_value(serde_json::Value::String(row.role))
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-            expires_at: row.expires_at,
-            accepted_at: row.accepted_at,
-            accepted_by: row
-                .accepted_by
-                .map(|s| {
-                    s.parse()
-                        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
-                })
-                .transpose()?,
-            created_at: row.created_at,
-        })
-    }
-}
-
 pub async fn create_invitation(
     pool: &SqlitePool,
     project_id: Uuid,
@@ -100,19 +52,15 @@ pub async fn create_invitation(
         .unwrap_or("member")
         .to_string();
 
-    sqlx::query(
-        r#"
-        INSERT INTO project_invitations (id, project_id, invited_by, token_hash, role, expires_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+    invitation_repository::insert(
+        pool,
+        id,
+        project_id,
+        invited_by,
+        &token_hash,
+        &role_str,
+        expires_at,
     )
-    .bind(id.to_string())
-    .bind(project_id.to_string())
-    .bind(invited_by.to_string())
-    .bind(&token_hash)
-    .bind(&role_str)
-    .bind(expires_at)
-    .execute(pool)
     .await?;
 
     let invitation = get_invitation(pool, id).await?;
@@ -123,46 +71,14 @@ pub async fn get_invitation(
     pool: &SqlitePool,
     invitation_id: Uuid,
 ) -> AppResult<ProjectInvitation> {
-    let row = sqlx::query_as::<_, InvitationRow>(
-        r#"
-        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
-               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
-               i.accepted_by, i.created_at
-        FROM project_invitations i
-        JOIN users u ON i.invited_by = u.id
-        JOIN projects p ON i.project_id = p.id
-        WHERE i.id = $1
-        "#,
-    )
-    .bind(invitation_id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.ok_or_else(|| AppError::NotFound(format!("invitation not found: {invitation_id}")))
-        .and_then(ProjectInvitation::try_from)
+    invitation_repository::find_by_id(pool, invitation_id).await
 }
 
 pub async fn list_invitations(
     pool: &SqlitePool,
     project_id: Uuid,
 ) -> AppResult<Vec<ProjectInvitation>> {
-    let rows = sqlx::query_as::<_, InvitationRow>(
-        r#"
-        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
-               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
-               i.accepted_by, i.created_at
-        FROM project_invitations i
-        JOIN users u ON i.invited_by = u.id
-        JOIN projects p ON i.project_id = p.id
-        WHERE i.project_id = $1
-        ORDER BY i.created_at DESC
-        "#,
-    )
-    .bind(project_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter().map(ProjectInvitation::try_from).collect()
+    invitation_repository::find_all_by_project(pool, project_id).await
 }
 
 pub async fn delete_invitation(
@@ -170,12 +86,8 @@ pub async fn delete_invitation(
     project_id: Uuid,
     invitation_id: Uuid,
 ) -> AppResult<()> {
-    let result = sqlx::query("DELETE FROM project_invitations WHERE id = $1 AND project_id = $2")
-        .bind(invitation_id.to_string())
-        .bind(project_id.to_string())
-        .execute(pool)
-        .await?;
-    if result.rows_affected() == 0 {
+    let rows = invitation_repository::delete(pool, invitation_id, project_id).await?;
+    if rows == 0 {
         return Err(AppError::NotFound(format!(
             "invitation not found: {invitation_id}"
         )));
@@ -186,24 +98,9 @@ pub async fn delete_invitation(
 pub async fn get_invitation_by_token(pool: &SqlitePool, token: &str) -> AppResult<InvitationInfo> {
     let token_hash = hash_token(token);
 
-    let row = sqlx::query_as::<_, InvitationRow>(
-        r#"
-        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
-               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
-               i.accepted_by, i.created_at
-        FROM project_invitations i
-        JOIN users u ON i.invited_by = u.id
-        JOIN projects p ON i.project_id = p.id
-        WHERE i.token_hash = $1
-        "#,
-    )
-    .bind(&token_hash)
-    .fetch_optional(pool)
-    .await?;
-
-    let invitation = row
-        .ok_or_else(|| AppError::NotFound("invalid invitation token".to_string()))
-        .and_then(ProjectInvitation::try_from)?;
+    let invitation = invitation_repository::find_by_token_hash(pool, &token_hash)
+        .await?
+        .ok_or_else(|| AppError::NotFound("invalid invitation token".to_string()))?;
 
     Ok(InvitationInfo {
         id: invitation.id,
@@ -223,24 +120,9 @@ pub async fn accept_invitation(
 ) -> AppResult<ProjectInvitation> {
     let token_hash = hash_token(token);
 
-    let row = sqlx::query_as::<_, InvitationRow>(
-        r#"
-        SELECT i.id, i.project_id, i.invited_by, u.name AS invited_by_name,
-               p.name AS project_name, i.role, i.expires_at, i.accepted_at,
-               i.accepted_by, i.created_at
-        FROM project_invitations i
-        JOIN users u ON i.invited_by = u.id
-        JOIN projects p ON i.project_id = p.id
-        WHERE i.token_hash = $1
-        "#,
-    )
-    .bind(&token_hash)
-    .fetch_optional(pool)
-    .await?;
-
-    let invitation = row
-        .ok_or_else(|| AppError::NotFound("invalid invitation token".to_string()))
-        .and_then(ProjectInvitation::try_from)?;
+    let invitation = invitation_repository::find_by_token_hash(pool, &token_hash)
+        .await?
+        .ok_or_else(|| AppError::NotFound("invalid invitation token".to_string()))?;
 
     if invitation.accepted_at.is_some() {
         return Err(AppError::Conflict(
@@ -256,16 +138,11 @@ pub async fn accept_invitation(
 
     // Mark invitation as accepted (conditional on accepted_at still being NULL
     // to prevent double-accept race condition)
-    let result = sqlx::query(
-        "UPDATE project_invitations SET accepted_at = $1, accepted_by = $2 WHERE id = $3 AND accepted_at IS NULL",
-    )
-    .bind(Utc::now())
-    .bind(user_id.to_string())
-    .bind(invitation.id.to_string())
-    .execute(&mut *tx)
-    .await?;
+    let rows =
+        invitation_repository::mark_accepted_tx(&mut *tx, invitation.id, user_id, Utc::now())
+            .await?;
 
-    if result.rows_affected() == 0 {
+    if rows == 0 {
         return Err(AppError::Conflict(
             "invitation has already been accepted".to_string(),
         ));
@@ -276,15 +153,11 @@ pub async fn accept_invitation(
     use crate::services::member_service;
 
     // Check if already a member
-    let existing = sqlx::query_scalar::<_, i32>(
-        "SELECT COUNT(*) FROM project_members WHERE project_id = $1 AND user_id = $2",
-    )
-    .bind(invitation.project_id.to_string())
-    .bind(user_id.to_string())
-    .fetch_one(&mut *tx)
-    .await?;
+    let is_member =
+        invitation_repository::is_project_member_tx(&mut *tx, invitation.project_id, user_id)
+            .await?;
 
-    if existing == 0 {
+    if !is_member {
         member_service::add_member_tx(
             &mut tx,
             invitation.project_id,

--- a/backend/src/services/invitation_service.rs
+++ b/backend/src/services/invitation_service.rs
@@ -138,9 +138,8 @@ pub async fn accept_invitation(
 
     // Mark invitation as accepted (conditional on accepted_at still being NULL
     // to prevent double-accept race condition)
-    let rows =
-        invitation_repository::mark_accepted_tx(&mut *tx, invitation.id, user_id, Utc::now())
-            .await?;
+    let rows = invitation_repository::mark_accepted_tx(&mut tx, invitation.id, user_id, Utc::now())
+        .await?;
 
     if rows == 0 {
         return Err(AppError::Conflict(
@@ -154,7 +153,7 @@ pub async fn accept_invitation(
 
     // Check if already a member
     let is_member =
-        invitation_repository::is_project_member_tx(&mut *tx, invitation.project_id, user_id)
+        invitation_repository::is_project_member_tx(&mut tx, invitation.project_id, user_id)
             .await?;
 
     if !is_member {

--- a/backend/src/services/project_service/commands.rs
+++ b/backend/src/services/project_service/commands.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project::{CreateProjectRequest, Project, UpdateProjectRequest};
+use crate::repositories::project_repository;
 
 use super::queries::get_project;
 
@@ -12,19 +13,14 @@ pub async fn create_project(pool: &SqlitePool, req: &CreateProjectRequest) -> Ap
     let id = Uuid::new_v4();
     let now = Utc::now();
 
-    sqlx::query(
-        r#"
-        INSERT INTO projects (id, name, description, repository_path, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6)
-        "#,
+    project_repository::insert(
+        pool,
+        id,
+        &req.name,
+        req.description.as_deref(),
+        req.repository_path.as_deref(),
+        now,
     )
-    .bind(id.to_string())
-    .bind(&req.name)
-    .bind(&req.description)
-    .bind(&req.repository_path)
-    .bind(now)
-    .bind(now)
-    .execute(pool)
     .await?;
 
     Ok(Project {
@@ -56,19 +52,14 @@ pub async fn update_project(
         .as_ref()
         .or(existing.repository_path.as_ref());
 
-    sqlx::query(
-        r#"
-        UPDATE projects
-        SET name = $1, description = $2, repository_path = $3, updated_at = $4
-        WHERE id = $5
-        "#,
+    project_repository::update(
+        pool,
+        id,
+        name,
+        description.map(|s| s.as_str()),
+        repository_path.map(|s| s.as_str()),
+        now,
     )
-    .bind(name)
-    .bind(description)
-    .bind(repository_path)
-    .bind(now)
-    .bind(id.to_string())
-    .execute(pool)
     .await?;
 
     Ok(Project {
@@ -106,17 +97,9 @@ pub fn validate_repository_path(path: &str) -> AppResult<()> {
 
 #[tracing::instrument(skip(pool), fields(project_id = %id))]
 pub async fn delete_project(pool: &SqlitePool, id: Uuid) -> AppResult<()> {
-    let result = sqlx::query(
-        r#"
-        DELETE FROM projects
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .execute(pool)
-    .await?;
+    let rows = project_repository::delete(pool, id).await?;
 
-    if result.rows_affected() == 0 {
+    if rows == 0 {
         return Err(AppError::NotFound(format!("project {} not found", id)));
     }
 

--- a/backend/src/services/project_service/mod.rs
+++ b/backend/src/services/project_service/mod.rs
@@ -6,35 +6,3 @@ pub mod queries;
 // Re-export all public items for backward compatibility.
 pub use commands::*;
 pub use queries::*;
-
-use chrono::{DateTime, Utc};
-use sqlx::prelude::FromRow;
-
-use crate::models::project::Project;
-
-/// Internal row type shared between query and command submodules.
-#[derive(FromRow)]
-pub(crate) struct ProjectRow {
-    pub id: String,
-    pub name: String,
-    pub description: Option<String>,
-    #[sqlx(default)]
-    pub repository_path: Option<String>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
-impl TryFrom<ProjectRow> for Project {
-    type Error = uuid::Error;
-
-    fn try_from(row: ProjectRow) -> Result<Self, Self::Error> {
-        Ok(Project {
-            id: row.id.parse()?,
-            name: row.name,
-            description: row.description,
-            repository_path: row.repository_path,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-        })
-    }
-}

--- a/backend/src/services/project_service/queries.rs
+++ b/backend/src/services/project_service/queries.rs
@@ -3,42 +3,16 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::models::project::Project;
-
-use super::ProjectRow;
+use crate::repositories::project_repository;
 
 pub async fn get_project(pool: &SqlitePool, id: Uuid) -> AppResult<Project> {
-    let row = sqlx::query_as::<_, ProjectRow>(
-        r#"
-        SELECT id, name, description, repository_path, created_at, updated_at
-        FROM projects
-        WHERE id = $1
-        "#,
-    )
-    .bind(id.to_string())
-    .fetch_optional(pool)
-    .await?;
-
-    row.map(|r| r.try_into())
-        .transpose()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?
+    project_repository::find_by_id(pool, id)
+        .await?
         .ok_or_else(|| AppError::NotFound(format!("project {} not found", id)))
 }
 
 pub async fn list_projects(pool: &SqlitePool) -> AppResult<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
-        r#"
-        SELECT id, name, description, repository_path, created_at, updated_at
-        FROM projects
-        ORDER BY created_at DESC
-        "#,
-    )
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    project_repository::find_all(pool).await
 }
 
 pub async fn list_projects_paginated(
@@ -46,54 +20,11 @@ pub async fn list_projects_paginated(
     limit: i64,
     offset: i64,
 ) -> AppResult<(Vec<Project>, i64)> {
-    let total: (i64,) = sqlx::query_as(
-        r#"
-        SELECT COUNT(*) FROM projects
-        "#,
-    )
-    .fetch_one(pool)
-    .await?;
-
-    let rows = sqlx::query_as::<_, ProjectRow>(
-        r#"
-        SELECT id, name, description, repository_path, created_at, updated_at
-        FROM projects
-        ORDER BY created_at DESC
-        LIMIT $1 OFFSET $2
-        "#,
-    )
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
-
-    let projects = rows
-        .into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?;
-
-    Ok((projects, total.0))
+    project_repository::find_all_paginated(pool, limit, offset).await
 }
 
 pub async fn list_projects_for_user(pool: &SqlitePool, user_id: Uuid) -> AppResult<Vec<Project>> {
-    let rows = sqlx::query_as::<_, ProjectRow>(
-        r#"
-        SELECT p.id, p.name, p.description, p.repository_path, p.created_at, p.updated_at
-        FROM projects p
-        INNER JOIN project_members pm ON p.id = pm.project_id
-        WHERE pm.user_id = $1
-        ORDER BY p.created_at DESC
-        "#,
-    )
-    .bind(user_id.to_string())
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))
+    project_repository::find_all_for_user(pool, user_id).await
 }
 
 pub async fn list_projects_for_user_paginated(
@@ -102,41 +33,7 @@ pub async fn list_projects_for_user_paginated(
     limit: i64,
     offset: i64,
 ) -> AppResult<(Vec<Project>, i64)> {
-    let total: (i64,) = sqlx::query_as(
-        r#"
-        SELECT COUNT(*)
-        FROM projects p
-        INNER JOIN project_members pm ON p.id = pm.project_id
-        WHERE pm.user_id = $1
-        "#,
-    )
-    .bind(user_id.to_string())
-    .fetch_one(pool)
-    .await?;
-
-    let rows = sqlx::query_as::<_, ProjectRow>(
-        r#"
-        SELECT p.id, p.name, p.description, p.repository_path, p.created_at, p.updated_at
-        FROM projects p
-        INNER JOIN project_members pm ON p.id = pm.project_id
-        WHERE pm.user_id = $1
-        ORDER BY p.created_at DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(user_id.to_string())
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
-
-    let projects = rows
-        .into_iter()
-        .map(|r| r.try_into())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e: uuid::Error| AppError::Internal(e.to_string()))?;
-
-    Ok((projects, total.0))
+    project_repository::find_all_for_user_paginated(pool, user_id, limit, offset).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Completes #325 — extracts repository pattern for remaining services.

- Extract `invitation_repository` from `invitation_service` (7 DB functions incl. `_tx` variants)
- Extract `project_repository` from `project_service` (8 DB functions)
- Extract `agent_session_repository` from `agent_session_service` (12 DB functions incl. `_tx` variants)
- Extract `agent_session_output_repository` from `agent_session_output_service` (5 DB functions)

All 15 backend services now follow a consistent repository pattern:
- `repositories/` — pure DB operations (Row structs, SQL queries)
- `services/` — business logic (validation, auth, transactions, domain rules)

Closes #325

## Test plan

- [x] All 511 tests pass (`cargo test --lib`)
- [x] No new clippy warnings on changed files
- [x] Each repository has comprehensive unit tests
- [x] All existing service tests pass unchanged

> **Note**: Stacked on #382. Merge #381 → #382 → this PR in order.