### PR TITLE
refactor: ♻️ enforce @/ alias for cross-directory imports

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -26,6 +26,19 @@
         "useExhaustiveDependencies": "warn",
         "useHookAtTopLevel": "error"
       },
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "patterns": [
+              {
+                "group": ["../**"],
+                "message": "Use @/ path alias instead of ../ relative imports."
+              }
+            ]
+          }
+        }
+      },
       "a11y": {
         "noAutofocus": "off",
         "useKeyWithClickEvents": "off"
@@ -44,6 +57,9 @@
       "includes": ["src/api/generated/**"],
       "linter": {
         "rules": {
+          "style": {
+            "noRestrictedImports": "off"
+          },
           "suspicious": {
             "noConfusingVoidType": "off"
           }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,10 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppRoutes } from './App';
-import * as authApi from './api/generated/endpoints/auth/auth';
-import * as projectsApi from './api/generated/endpoints/projects/projects';
-import { useAuthStore } from './stores/authStore';
-import { useUiStore } from './stores/uiStore';
+import * as authApi from '@/api/generated/endpoints/auth/auth';
+import * as projectsApi from '@/api/generated/endpoints/projects/projects';
+import { useAuthStore } from '@/stores/authStore';
+import { useUiStore } from '@/stores/uiStore';
 
 // Mock EventSource for SSE
 class MockEventSource {
@@ -18,7 +18,7 @@ class MockEventSource {
 }
 vi.stubGlobal('EventSource', MockEventSource);
 
-vi.mock('./api/generated/endpoints/projects/projects', () => ({
+vi.mock('@/api/generated/endpoints/projects/projects', () => ({
   useListProjects: vi.fn(),
   useCreateProject: vi.fn(),
   useGetProject: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock('./api/generated/endpoints/projects/projects', () => ({
   getGetProjectQueryKey: vi.fn(() => ['/api/projects']),
 }));
 
-vi.mock('./api/generated/endpoints/auth/auth', () => ({
+vi.mock('@/api/generated/endpoints/auth/auth', () => ({
   useLogin: vi.fn(),
   useLogout: vi.fn(),
   useRegister: vi.fn(),

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,11 +3,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AppRoutes } from './App';
 import * as authApi from '@/api/generated/endpoints/auth/auth';
 import * as projectsApi from '@/api/generated/endpoints/projects/projects';
 import { useAuthStore } from '@/stores/authStore';
 import { useUiStore } from '@/stores/uiStore';
+import { AppRoutes } from './App';
 
 // Mock EventSource for SSE
 class MockEventSource {

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateProject,
 } from '@/api/generated/endpoints/projects/projects';
 import { MemberRole } from '@/api/generated/model';
+import { GitHubLinkSettings } from '@/components/github/GitHubLinkSettings';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -17,7 +18,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
-import { GitHubLinkSettings } from '@/components/github/GitHubLinkSettings';
 
 export function ProjectSettingsModal({
   projectId,

--- a/frontend/src/components/project/ProjectSettingsModal.tsx
+++ b/frontend/src/components/project/ProjectSettingsModal.tsx
@@ -17,7 +17,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUiStore } from '@/stores/uiStore';
-import { GitHubLinkSettings } from '../github/GitHubLinkSettings';
+import { GitHubLinkSettings } from '@/components/github/GitHubLinkSettings';
 
 export function ProjectSettingsModal({
   projectId,

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -4,11 +4,11 @@ import { useTranslation } from 'react-i18next';
 import { useListMembers } from '@/api/generated/endpoints/project-members/project-members';
 import { useDeleteTask, useGetTask, useUpdateTask } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { PullRequestList } from '@/components/github/PullRequestList';
+import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
-import { PullRequestList } from '@/components/github/PullRequestList';
-import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { TaskTimeline } from './TaskTimeline';
 
 export function TaskDetailModal() {

--- a/frontend/src/components/task/TaskDetailModal.tsx
+++ b/frontend/src/components/task/TaskDetailModal.tsx
@@ -7,8 +7,8 @@ import type { TaskPriority, TaskStatus } from '@/api/generated/model';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { invalidateTasks } from '@/services/queryInvalidation';
 import { useUiStore } from '@/stores/uiStore';
-import { PullRequestList } from '../github/PullRequestList';
-import { WorktreePanel } from '../preview/WorktreePanel';
+import { PullRequestList } from '@/components/github/PullRequestList';
+import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { TaskTimeline } from './TaskTimeline';
 
 export function TaskDetailModal() {

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -15,8 +15,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { invalidateTasks } from '@/services/queryInvalidation';
-import { PullRequestList } from '../github/PullRequestList';
-import { WorktreePanel } from '../preview/WorktreePanel';
+import { PullRequestList } from '@/components/github/PullRequestList';
+import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { TaskTimeline } from './TaskTimeline';
 
 export function TaskDetailPage() {

--- a/frontend/src/components/task/TaskDetailPage.tsx
+++ b/frontend/src/components/task/TaskDetailPage.tsx
@@ -11,12 +11,12 @@ import {
   useUpdateTask,
 } from '@/api/generated/endpoints/tasks/tasks';
 import type { TaskPriority, TaskStatus } from '@/api/generated/model';
+import { PullRequestList } from '@/components/github/PullRequestList';
+import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { invalidateTasks } from '@/services/queryInvalidation';
-import { PullRequestList } from '@/components/github/PullRequestList';
-import { WorktreePanel } from '@/components/preview/WorktreePanel';
 import { TaskTimeline } from './TaskTimeline';
 
 export function TaskDetailPage() {

--- a/frontend/src/components/task/TaskTimeline.tsx
+++ b/frontend/src/components/task/TaskTimeline.tsx
@@ -14,13 +14,13 @@ import {
   useListComments,
 } from '@/api/generated/endpoints/task-comments/task-comments';
 import type { AgentSession, AgentType } from '@/api/generated/model';
+import { AgentOutputViewer } from '@/components/agent/AgentOutputViewer';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { useAgentStore } from '@/stores/agentStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
-import { AgentOutputViewer } from '@/components/agent/AgentOutputViewer';
 import { ActivityFilter, type ActivityFilterValue } from './ActivityFilter';
 import { TimelineAgentSessionItem } from './TimelineAgentSessionItem';
 import { TimelineCommentItem } from './TimelineCommentItem';

--- a/frontend/src/components/task/TaskTimeline.tsx
+++ b/frontend/src/components/task/TaskTimeline.tsx
@@ -20,7 +20,7 @@ import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { useAgentStore } from '@/stores/agentStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useToastStore } from '@/stores/toastStore';
-import { AgentOutputViewer } from '../agent/AgentOutputViewer';
+import { AgentOutputViewer } from '@/components/agent/AgentOutputViewer';
 import { ActivityFilter, type ActivityFilterValue } from './ActivityFilter';
 import { TimelineAgentSessionItem } from './TimelineAgentSessionItem';
 import { TimelineCommentItem } from './TimelineCommentItem';

--- a/frontend/src/hooks/useAgentEvents.ts
+++ b/frontend/src/hooks/useAgentEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { createRealtimeTransport, type EventSourceLike } from '../lib/realtimeTransport';
+import { createRealtimeTransport, type EventSourceLike } from '@/lib/realtimeTransport';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
 

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -6,16 +6,16 @@ import type {
   SyncResult,
   Task,
   TaskComment,
-} from '../api/generated/model';
-import { logger } from '../lib/logger';
-import { createRealtimeTransport } from '../lib/realtimeTransport';
+} from '@/api/generated/model';
+import { logger } from '@/lib/logger';
+import { createRealtimeTransport } from '@/lib/realtimeTransport';
 import {
   invalidateComments,
   invalidateMessages,
   invalidatePreviews,
   invalidateSessions,
   invalidateTasks,
-} from '../services/queryInvalidation';
+} from '@/services/queryInvalidation';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3000';
 const sseLog = logger.child({ module: 'sse' });

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { server } from '../test/mocks/server';
+import { server } from '@/test/mocks/server';
 import { useAuthStore } from './authStore';
 
 describe('authStore', () => {

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import { me } from '../api/generated/endpoints/auth/auth';
-import type { User } from '../api/generated/model';
+import { me } from '@/api/generated/endpoints/auth/auth';
+import type { User } from '@/api/generated/model';
 
 interface AuthState {
   user: User | null;

--- a/frontend/src/stores/boardStore.test.ts
+++ b/frontend/src/stores/boardStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { TaskPriority } from '../api/generated/model';
+import { TaskPriority } from '@/api/generated/model';
 import { useBoardStore } from './boardStore';
 
 describe('boardStore filters', () => {

--- a/frontend/src/stores/boardStore.ts
+++ b/frontend/src/stores/boardStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import type { TaskPriority } from '../api/generated/model';
+import type { TaskPriority } from '@/api/generated/model';
 
 interface BoardState {
   activeTaskId: string | null;

--- a/frontend/src/stores/uiStore.test.ts
+++ b/frontend/src/stores/uiStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { TaskStatus } from '../api/generated/model';
+import { TaskStatus } from '@/api/generated/model';
 import { useUiStore } from './uiStore';
 
 describe('uiStore', () => {

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import type { TaskStatus } from '../api/generated/model';
+import type { TaskStatus } from '@/api/generated/model';
 
 interface UiState {
   isTaskModalOpen: boolean;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { afterAll, afterEach, beforeAll } from 'vitest';
-import en from '../locales/en.json';
+import en from '@/locales/en.json';
 
 // Polyfills for Radix UI (Dialog, Select, etc.) in jsdom
 globalThis.ResizeObserver ??= class ResizeObserver {
@@ -21,11 +21,11 @@ i18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
-import { useAgentStore } from '../stores/agentStore';
-import { useAuthStore } from '../stores/authStore';
-import { useBoardStore } from '../stores/boardStore';
-import { useToastStore } from '../stores/toastStore';
-import { useUiStore } from '../stores/uiStore';
+import { useAgentStore } from '@/stores/agentStore';
+import { useAuthStore } from '@/stores/authStore';
+import { useBoardStore } from '@/stores/boardStore';
+import { useToastStore } from '@/stores/toastStore';
+import { useUiStore } from '@/stores/uiStore';
 import { server } from './mocks/server';
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));


### PR DESCRIPTION
## Summary
- `biome.json` に `noRestrictedImports` ルールを追加し、`../` による親ディレクトリ横断 import をエラーとして検出（自動生成コード `src/api/generated/` は除外）
- 14 ファイル・計 28 箇所の `../` / `./`（cross-directory）import パスを `@/` エイリアスに統一
  - stores（6 ファイル）、hooks（2 ファイル）、test（2 ファイル）、components（4 ファイル）

## Test plan
- [x] `task frontend:lint` — Biome lint エラーなし（265 ファイル）
- [x] `task frontend:test` — 全 385 テスト pass
- [x] `task frontend:build` — TypeScript コンパイル + Vite ビルド成功