### PR TITLE
fix: 🐛 add platform detection to frontend entrypoint

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -15,6 +15,7 @@ if [ ! -d node_modules ] \
    || [ "$(cat "$MARKER")" != "$PLATFORM" ]; then
   echo "Installing dependencies (platform: $PLATFORM)..."
   npm ci
+  touch -r package-lock.json node_modules/.package-lock.json
   echo "$PLATFORM" > "$MARKER"
 fi
 

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,10 +1,21 @@
 #!/bin/sh
 set -e
 
-# Install dependencies if node_modules is missing or package manifest/lockfile has changed
-if [ ! -d node_modules ] || [ package.json -nt node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
-  echo "Installing dependencies..."
+PLATFORM="$(uname -s)-$(uname -m)"
+MARKER="node_modules/.platform"
+
+# Install dependencies if:
+#   - node_modules is missing
+#   - package manifest/lockfile has changed
+#   - platform marker mismatches (e.g. host macOS modules mounted into Linux container)
+if [ ! -d node_modules ] \
+   || [ package.json -nt node_modules/.package-lock.json ] \
+   || [ package-lock.json -nt node_modules/.package-lock.json ] \
+   || [ ! -f "$MARKER" ] \
+   || [ "$(cat "$MARKER")" != "$PLATFORM" ]; then
+  echo "Installing dependencies (platform: $PLATFORM)..."
   npm ci
+  echo "$PLATFORM" > "$MARKER"
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary
- Fix frontend container crash caused by host (macOS) `node_modules` being mounted into the Linux ARM64 container, where platform-specific rollup native binaries are missing (e.g. `@rollup/rollup-linux-arm64-gnu`)
- Add platform detection to `docker-entrypoint.sh` using a `.platform` marker file that triggers `npm ci` when the OS/architecture changes

## Test plan
- [x] Verify frontend container starts successfully with `docker compose up` on macOS host
- [ ] Verify `npm ci` runs on first startup after deleting `node_modules`
- [ ] Verify `npm ci` is skipped on subsequent startups when platform matches